### PR TITLE
Hand MapLibre its worker instead of letting it guess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "jiff",
+ "libc",
  "mime_guess",
  "num-complex",
  "rmcp",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -51,6 +51,10 @@ rust-embed.workspace = true
 mime_guess.workspace = true
 tracing.workspace = true
 
+# `--doctor`'s USB-permission check asks for the effective uid, which only the Linux arm needs.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"

--- a/web/src/components/MapPanel.tsx
+++ b/web/src/components/MapPanel.tsx
@@ -9,7 +9,9 @@ import {
   Map as MapLibreMap,
   type MapOptions,
   NavigationControl,
+  setWorkerUrl,
 } from "maplibre-gl";
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
 import { useEffect, useRef, useState } from "react";
 import { useDecodedStore } from "../lib/decoded";
 import {
@@ -28,6 +30,12 @@ import {
   targetDetail,
 } from "../lib/map/layers";
 import { formatMhz } from "./format";
+
+// MapLibre v6 ships its worker as a separate file and derives its URL from `import.meta.url`,
+// which under a bundler points at the bundle rather than the package — so every bundler consumer
+// has to hand it the worker itself. `?worker&url` and not `?url`: the dist worker imports a
+// sibling chunk that a verbatim asset copy would leave behind.
+setWorkerUrl(workerUrl);
 
 /** PLAN §10: OpenFreeMap vector tiles — free, no API key, no usage cap. A self-hosted PMTiles
  * basemap replaces this URL when the server grows one; nothing else here changes. */


### PR DESCRIPTION
`vite` dev died on the map with:

> The file does not exist at ".../web/node_modules/.vite/deps/maplibre-gl-worker.mjs" which is in the optimize deps directory.

## Cause

MapLibre v6 no longer inlines its worker: it ships `dist/maplibre-gl-worker.mjs` and derives the
URL at runtime from `import.meta.url` ([`web_worker.ts`](https://github.com/maplibre/maplibre-gl-js/blob/v6.2.0/src/util/web_worker.ts)).
Under a bundler that module identity is the bundle, not the package, so the guess lands in
`node_modules/.vite/deps/` in dev — hence the error — and in `assets/` in a production build,
where nothing was emitted either. Upstream says as much and asks every bundler consumer to call
`setWorkerUrl()` once ([installation guide](https://maplibre.org/maplibre-gl-js/docs/),
[v5→v6 migration](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/)).

## Fix

`MapPanel` hands MapLibre the worker itself, with the specifier upstream prescribes for Vite:

```ts
import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
setWorkerUrl(workerUrl);
```

`?worker&url` and not `?url`: the dist worker imports a sibling chunk, which a verbatim asset copy
would leave behind. No `optimizeDeps.exclude` — pre-bundling maplibre stays on; the guessed URL is
simply never used.

Second commit is unrelated but blocks the gate on Linux: `crates/server`'s `--doctor` calls
`libc::geteuid` behind `cfg(target_os = "linux")` without depending on `libc`, so `main` does not
compile on a Linux host at all. The dep is now declared, target-gated.

## Verification

- `cargo xtask check` — green (was failing to compile on Linux before the `libc` commit).
- `cargo xtask test` — 171 web tests, full Rust suite, green.
- `vite build` now emits `assets/maplibre-gl-worker-*.js` (470 kB, sibling chunk included); before
  this change no worker asset was emitted at all.
- `vite` dev: `maplibre-gl-worker.mjs?worker&url` resolves to a served `?worker_file&type=module`
  URL that returns 200 with its imports rewritten, instead of the `.vite/deps` 404.

No unit test: the wiring is a Vite transform concern — a wrong specifier fails the build itself,
and the worker only actually spawns in a browser, which CI has no ability to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)