### PR TITLE
The map's credits open as a badge, not a banner

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -203,4 +203,49 @@ test.describe("the workspace", () => {
     // layers, which is where a rejected paint colour would have said so.
     expect(styleErrors).toEqual([]);
   });
+
+  test("opens the map's basemap credits collapsed", async ({ page }) => {
+    // A basemap with credits, which the offline fallback has none of — MapLibre only expands the
+    // attribution once a *used* source hands it a line to show, so a source without a layer
+    // referencing it would leave the control empty and this test asserting nothing. The tiles
+    // themselves stay off the wire; the credit line is the whole subject here.
+    await page.route("https://tiles.openfreemap.org/styles/liberty", (route) =>
+      route.fulfill({
+        json: {
+          version: 8,
+          sources: {
+            basemap: {
+              type: "raster",
+              tiles: ["https://tiles.openfreemap.org/tiles/{z}/{x}/{y}.png"],
+              tileSize: 256,
+              attribution: "Stub basemap credits",
+            },
+          },
+          layers: [{ id: "basemap", type: "raster", source: "basemap" }],
+        },
+      }),
+    );
+    await page.route("https://tiles.openfreemap.org/tiles/**", (route) => route.abort());
+    await page.goto("/");
+    await expect(page.locator('.react-flow__node[data-id="device"]')).toBeVisible();
+
+    // The arrangement is server state and the run shares one database, so the map the flow above
+    // wired is still on the canvas — and a map is a placeholder until a decoder's events reach it
+    // (CANVAS §1), which is what the aircraft legend names.
+    const map = page.locator('.react-flow__node[data-id^="map:"]', { hasText: "Aircraft" });
+    await fitPatch(page);
+    const attribution = map.locator(".maplibregl-ctrl-attrib");
+
+    // Waiting on the control to *appear* is waiting on the credits: MapLibre hides an attribution
+    // with nothing in it, and the moment it fills is the moment the old default expanded, since
+    // every attribution change re-runs the compact check.
+    await expect(attribution).toBeVisible();
+    await expect(attribution.locator(".maplibregl-ctrl-attrib-inner")).toBeHidden();
+
+    // Collapsed is a default, not a verdict — the ⓘ still owes the operator the credits. The face
+    // only answers a pointer once its node is selected (NodeShell), hence the header click first.
+    await map.locator("header").click();
+    await attribution.locator("summary.maplibregl-ctrl-attrib-button").click();
+    await expect(attribution.getByText("Stub basemap credits")).toBeVisible();
+  });
 });

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,9 +1,10 @@
 // The workspace, end to end: open the app, bind the virtual radio to the receiver node, add a
 // channel, hear the graph become a running workspace, pin a face and find it on the rack.
 //
-// This is the one test that exercises the composition — canvas, faces, WebSocket, apply — that
+// This is the one suite that exercises the composition — canvas, faces, WebSocket, apply — that
 // the unit suite cannot reach (PLAN §14). It asserts behaviour, not markup: what an operator
-// would check after each gesture.
+// would check after each gesture. The flow above runs first and the legs below build on the
+// workspace it leaves, which the single worker and the throwaway database below make sound.
 import { expect, type Locator, type Page, test } from "@playwright/test";
 // The state shape is generated from the server's OpenAPI, like everywhere else (CLAUDE.md #1).
 import type { StateSnapshot } from "../src/lib/types";

--- a/web/src/components/MapPanel.tsx
+++ b/web/src/components/MapPanel.tsx
@@ -10,6 +10,7 @@
 // is not something a wire change may take away.
 import "maplibre-gl/dist/maplibre-gl.css";
 import {
+  AttributionControl,
   type GeoJSONSource,
   Map as MapLibreMap,
   type MapMouseEvent,
@@ -55,6 +56,21 @@ const BASEMAP_TIMEOUT_MS = 6_000;
 
 /** Half-size of the click/tap hit box in pixels — a 4 px dot is not a touch target. */
 const HIT_SLOP_PX = 9;
+
+/** MapLibre's compact attribution opens *expanded* and re-expands itself whenever the credits
+ * change (`_updateAttributions` calls `_updateCompact`), so a map node spends its bottom edge on a
+ * credit line the operator never asked for. `maplibregl-compact` present without
+ * `maplibregl-compact-show` is the collapsed ⓘ badge — the same state MapLibre's own toggle lands
+ * in — and holding the class from the start is what makes it stick: `_updateCompact` expands only
+ * when that class is *absent*. */
+class CollapsedAttributionControl extends AttributionControl {
+  override onAdd(map: MapLibreMap): HTMLElement {
+    const container = super.onAdd(map);
+    container.classList.add("maplibregl-compact");
+    container.classList.remove("maplibregl-compact-show");
+    return container;
+  }
+}
 
 type MapStyle = Exclude<NonNullable<MapOptions["style"]>, string>;
 type Counts = Record<MapKind, number>;
@@ -135,9 +151,10 @@ export function MapPanel({
         style: style ?? offlineStyle(edge),
         center: [0, 25],
         zoom: 1,
-        attributionControl: { compact: true },
+        attributionControl: false,
       });
       mapRef.current = map;
+      map.addControl(new CollapsedAttributionControl({ compact: true }));
       map.addControl(new NavigationControl({ showCompass: false }), "top-right");
 
       map.on("style.load", () => {


### PR DESCRIPTION
The basemap attribution on a map node opened **expanded**, spending the face's bottom edge on a credit line nobody asked for:

> OpenFreeMap © OpenMapTiles Data from OpenStreetMap ⓘ

Now it opens as the collapsed ⓘ badge. Clicking it still shows the credits — this is a default, not a removal.

## Why the one-liner wasn't one

`attributionControl: { compact: true }` is *already* what we passed. MapLibre's compact mode is expanded-by-default (`onAdd` sets `open` and adds `maplibregl-compact-show`), and — the part that bites — `_updateAttributions` calls `_updateCompact` again on **every** change to the credits. So stripping the class once at map creation gets undone the moment the tile source registers its attribution.

The guard in `_updateCompact` is `!container.classList.contains("maplibregl-compact")`. Holding that class from the start is therefore what makes collapsed stick, permanently and without a re-entrancy fight. The resulting state — `maplibregl-compact` present, `maplibregl-compact-show` absent — is exactly where MapLibre's own toggle lands when a user closes the panel, so nothing here is an invented state.

Passing `{ compact: true }` to our own control keeps the credit text byte-identical to today (MapLibre's default `customAttribution` link stays off, as it already was).

## Tests

New Playwright leg in `web/e2e/smoke.spec.ts`. The existing map leg aborts the tile CDN and lands on the offline fallback, which has *no* credits — and MapLibre hides an empty attribution outright, so any assertion there would have passed vacuously on the old code too.

So this test stubs the style URL with a raster source carrying an `attribution` string **and a layer using it** (attribution only registers once a source is `used`), aborts the tiles themselves, then waits for the control to become visible — that is the moment the credits arrive and the moment the old default expanded — and asserts the inner panel is hidden, then clicks the ⓘ and asserts the credits appear.

Verified as a discriminator: it fails on `main` at `expect(inner).toBeHidden()` and passes with the fix.

`pnpm format` / `lint` / `typecheck` / `test` (315) clean, `cargo xtask smoke` green (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)