### PR TITLE
Gate RustSec advisories in CI, with glib RUSTSEC-2024-0429 as a bounded exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
-# CI mirrors the local gate 1:1 (CLAUDE.md): `cargo xtask check` + `cargo xtask test`. It lands
-# at M0 and grows each milestone (PLAN §15). No hardware — everything runs on `device-virtual`.
+# CI mirrors the local gate 1:1 (CLAUDE.md): every job here is an `xtask` subcommand a developer
+# can run unchanged — `check`, `test`, `smoke`, `audit`. It lands at M0 and grows each milestone
+# (PLAN §15). No hardware — everything runs on `device-virtual`.
 name: CI
 
 on:
@@ -33,6 +34,8 @@ jobs:
       # Installs the pinned nightly + rustfmt/clippy from rust-toolchain.toml.
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu
       - name: cargo xtask check
         run: cargo xtask check
       - name: cargo xtask test
@@ -43,6 +46,28 @@ jobs:
         run: pnpm --dir web exec playwright install --with-deps chromium
       - name: cargo xtask smoke
         run: cargo xtask smoke
+
+  advisories:
+    name: Dependency advisories (ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # `cargo xtask` links libSoapySDR through sdrmm-server's default features, same as above.
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libsoapysdr-dev
+      - run: rustup show
+      # Restore-only on the gate's cache: this job builds the same xtask binary and has nothing
+      # of its own worth storing.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu
+          save-if: false
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      # Its own job, not a step in the gate: a new advisory lands on RustSec's schedule, not on
+      # ours, and that must not read as "this pull request broke the build".
+      - name: cargo xtask audit
+        run: cargo xtask audit
 
   rust-macos:
     name: Rust tests (macos-arm64)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,6 +16,7 @@ is a deliberate no. Within each section, shipped comes first.
 - **[shipped]** Release artifacts just run — `xtask dist` produces a ~25 MB binary linking only IOKit/CoreFoundation/libiconv/libSystem: no libusb, no libSoapySDR, no libopus, no libsqlite
 - **[shipped]** `sdrmm --doctor` and `GET /api/doctor` — compiled backends, devices found, Linux udev/USB permissions with the fix, database and recordings-path writability, one shared report so CLI and UI cannot disagree
 - **[shipped]** mdBook docs site + Pages deploy
+- **[shipped]** RustSec advisories are a CI gate (`xtask audit`, policy in `deny.toml`) covering the whole graph, Tauri shell included. It runs as its own job because a new advisory lands on RustSec's schedule, not on a pull request's. Standing exception: `RUSTSEC-2024-0429` (`glib` `VariantStrIter` unsoundness), unreachable here and unfixable below gtk4 — see `deny.toml`
 - **[planned]** Desktop app connecting to a *remote* server, and saved remote connections — the shell only ever spawns its own local one
 - **[planned]** Signed/notarised macOS bundles — the workflow ships them unsigned until Apple secrets exist
 - **[planned]** A verified Raspberry Pi run — the Pi 4 is the stated performance floor and no field session has been on one; the Docker image is likewise built only by the tag workflow, never here

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ on <http://localhost:5173>, proxying `/api` and the WebSocket to the server.
 | `cargo xtask codegen` | Regenerate `openapi.json` + `web/src/generated` (run after changing `crates/wire`) |
 | `cargo xtask check` | The full gate: fmt, clippy `-D warnings`, Soapy-free build, the release-shaped native build, `biome ci`, type-aware `oxlint`, `tsgo`, web build, codegen-drift |
 | `cargo xtask test` | Rust + web test suites (uses `device-virtual`, no hardware) |
+| `cargo xtask audit` | Check the dependency graph against RustSec (`deny.toml`; needs `cargo install --locked cargo-deny`) |
 | `cargo xtask fixtures` | Regenerate the synthesized SigMF decoder fixtures in `fixtures/` |
 | `cargo xtask dist [--target <triple>]` | Build the self-contained release binary (web build, then `--no-default-features --features rtl-native,hackrf-native`) into `dist/` |
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+# Supply-chain gate for `cargo xtask audit` (CI mirrors it verbatim).
+#
+# Advisories only. License and duplicate-version policing are separate problems, and every
+# answer they would produce here is about somebody else's dependency tree.
+
+[advisories]
+# Unsound advisories default to workspace-direct crates, which hides RUSTSEC-2024-0429 —
+# the one advisory in this tree that is a soundness bug rather than a "no longer maintained"
+# notice. A transitive dependency can dereference a null pointer just as well as a direct one.
+unsound = "all"
+# Unmaintained is the opposite case: it is only actionable for crates we chose ourselves.
+# Nothing unmaintained here today is one — the ten gtk3-rs crates, five `unic-*` and
+# `proc-macro-error` arrive through `tauri`, `audiopus_sys` through `opus`, `paste` through
+# `utoipa-axum` — and pinning them as ignores would bury the advisories we can actually reason
+# about under a wall of upstream noise.
+unmaintained = "workspace"
+# An exception that no longer applies is a lie about the tree, so make it fail rather than warn:
+# when tauri finally moves off gtk3, this gate is what tells us to delete the ignore below.
+unused-ignored-advisory = "deny"
+
+ignore = [
+    # `glib` 0.18.5 is the newest version that can exist in this graph: the fix landed in
+    # 0.20.0, gtk3-rs is end-of-life at 0.18.2 (its 0.18 branch has had no commit since
+    # Dec 2023), and tauri v2 pins that whole stack through tao/wry/gtk/webkit2gtk. The
+    # affected functions — `VariantStrIter::{next,nth,last,next_back,nth_back}` — are called
+    # by nothing in the graph: glib is the only crate here that so much as names the type, and
+    # it reaches us only through the Linux desktop shell. Drop this the day tauri ships gtk4.
+    { id = "RUSTSEC-2024-0429", reason = "glib::VariantStrIter is unreachable here, and no fixed version exists below glib 0.20 / gtk4" },
+]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,6 +30,9 @@ enum Cmd {
     Check,
     /// Full test suite (uses `device-virtual`; no hardware).
     Test,
+    /// Dependency advisories (`deny.toml`). Separate from `check`: it needs `cargo-deny` and
+    /// fetches the RustSec database, so it can go red on a day the tree did not change.
+    Audit,
     /// The Playwright smoke flow against the real server on `device-virtual` (PLAN §14).
     /// Separate from `test` because it needs a browser binary; CI installs one.
     Smoke,
@@ -49,6 +52,7 @@ fn main() -> Result<()> {
         Cmd::Dev => dev(&root()),
         Cmd::Check => check(&root()),
         Cmd::Test => test(&root()),
+        Cmd::Audit => audit(&root()),
         Cmd::Smoke => smoke(&root()),
         Cmd::Fixtures => fixtures(&root()),
         Cmd::Dist { target } => dist(&root(), target.as_deref()),
@@ -281,6 +285,22 @@ fn test(root: &Path) -> Result<()> {
     ensure_web_deps(root)?;
     run("pnpm", &["--dir", "web", "test"], root)?;
     Ok(())
+}
+
+/// Check the whole dependency graph — including the Tauri shell, which the default gate skips —
+/// against the RustSec database. The policy and every standing exception live in `deny.toml`.
+fn audit(root: &Path) -> Result<()> {
+    let installed = Command::new("cargo")
+        .args(["deny", "--version"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
+    ensure!(
+        installed,
+        "cargo-deny is missing: `cargo install --locked cargo-deny`"
+    );
+    run("cargo", &["deny", "check", "advisories"], root)
 }
 
 /// The browser smoke flow. It drives the built UI served by the real binary, which is how a


### PR DESCRIPTION
## What the alert actually asks for

Dependabot cannot update `glib` to a non-vulnerable version, and neither can we. The fix for
RUSTSEC-2024-0429 landed in `glib` 0.20.0; gtk3-rs is end-of-life at 0.18.2 (no commit on its
0.18 branch since Dec 2023), and tauri v2 pins that whole stack through tao/wry/gtk/webkit2gtk.
`glib` 0.18.5 is the newest version that can exist in this graph:

```
glib v0.18.5 → atk/gdk/gtk v0.18.x → tao/wry/muda → tauri v2.11.5 → sdrmm-desktop
```

There is no version bump to make. So this PR adds the thing that was actually missing — a
supply-chain gate that records the judgement and re-checks it — instead of a bump that cannot
happen.

## Changes

- **`deny.toml`** — advisories-only cargo-deny policy. `unsound = "all"`, `unmaintained = "workspace"`,
  `unused-ignored-advisory = "deny"`, and one ignore for RUSTSEC-2024-0429 with its reasoning.
- **`xtask audit`** — runs `cargo deny check advisories` over the whole graph, Tauri shell
  included (the default gate skips it). Fails with an install hint if cargo-deny is missing.
- **CI** — a separate `advisories` job. Not a step in the gate: a new advisory lands on RustSec's
  schedule, not on a pull request's, and that must not read as "this PR broke the build". It
  restores the gate's rust-cache (`shared-key: ubuntu`, `save-if: false`).
- **`FEATURES.md` / `README.md`** — the gate and the standing exception recorded where the
  project records its gates.

## Why the exception is safe

`VariantStrIter` is reachable only through `Variant::array_iter_str`. Neither symbol is named by
any crate in the graph except `glib` itself, in its own doctests and unit tests:

```
$ grep -rl "VariantStrIter\|array_iter_str" ~/.cargo/registry/src/index.crates.io-*/
glib-0.18.5
```

Every crates.io package in `Cargo.lock` is extracted under that path (checked: 0 missing), so
that grep covers the whole graph rather than a sample. The affected iterator methods are called
by nothing we ship, and `glib` reaches us only through the Linux desktop shell.

`unsound = "all"` is load-bearing. cargo-deny scopes unsound advisories to workspace-direct
crates by default, which hides this one completely — and a transitive dependency can dereference
a null pointer just as well as a direct one.

## Verification

| Check | Result |
|---|---|
| `cargo xtask audit` | `advisories ok` |
| Ignore removed, `unsound = "all"` kept | `advisories FAILED` on RUSTSEC-2024-0429 — the ignore is live, not decorative |
| Ignore removed, `unsound = "all"` removed | `advisories ok` — confirms the default scope hides it |
| `cargo xtask check` | all gates green |
| `cargo fmt --check`, `clippy -D warnings` (xtask) | clean |

The `deny.toml` comment's inventory of unmaintained crates was verified against the lockfile
rather than asserted: ten gtk3-rs crates, five `unic-*` and `proc-macro-error` via `tauri`,
`audiopus_sys` via `opus`, `paste` via `utoipa-axum`.

## What this does not do

**It does not close the Dependabot alert.** No installable fixed version exists below gtk4, so
the alert stays open until it is dismissed in GitHub as "no bandwidth to fix" / tolerable risk.
I'd recommend dismissing it with a link to this PR rather than leaving it to age. The gate here
is what makes that dismissal honest: `unused-ignored-advisory = "deny"` fails the build the day
tauri ships gtk4, so the exception cannot quietly outlive its reason.

## Notes

- Rebased onto current `main`, which renamed `PLAN.md` → `FEATURES.md` and removed the mdBook
  site; the doc edits landed accordingly.
- 382 `PLAN §N` cross-references remain repo-wide after that rename, several pointing at section
  numbers that no longer mean what they did. Out of scope here, but worth a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)