### PR TITLE
Keep the scope's waterfall across a patch/rack switch

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -128,6 +128,10 @@ test.describe("the workspace", () => {
     await expect(channel).toHaveCount(1);
     await expect(channel.getByText(/nothing feeds this channel|not been created/i)).toHaveCount(0);
 
+    // The scope is running before the view switch below, which is what gives that switch
+    // something to preserve.
+    await expect(node("scope").getByText(/waiting for the first frame/i)).toHaveCount(0);
+
     // Pinning adds the face to the rack and leaves the canvas node where it was (CANVAS §5).
     for (const id of ["scope", "speaker"]) {
       await node(id)
@@ -140,6 +144,12 @@ test.describe("the workspace", () => {
     const rack = page.getByRole("group", { name: "View" }).getByRole("button", { name: "Rack" });
     await rack.click();
     await expect(page.getByText(/nothing pinned/i)).toHaveCount(0);
+
+    // A view switch remounts every face, and a plot's history is its own (gl/waterfall.ts), so the
+    // scope used to come back empty. It opens on the lane's kept rows and its last readout instead.
+    // Read once rather than polled: waiting for the readout would be waiting for the very frame
+    // that used to hide the gap.
+    expect(await page.getByText(/\d\.\d{4} MHz/).count()).toBeGreaterThan(0);
 
     // Dragging the boundary between two faces makes one larger and the other smaller (CANVAS §5).
     // The whole point of the gesture is that it re-balances a full rack without a hole, so both

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -21,6 +21,12 @@ async function dragWire(page: Page, from: Locator, to: Locator): Promise<void> {
   await page.mouse.up();
 }
 
+/** One face in the rack. The rack has no wires and no pane, so its faces are addressed by the
+ * node they render rather than through React Flow. */
+function rackNode(page: Page, id: string): Locator {
+  return page.locator(`.grid > [data-id="${id}"]`);
+}
+
 /** The rack as the server has it — the arrangement is server state, not what the DOM happens to
  * be showing mid-gesture. */
 async function slots(page: Page): Promise<{ node: string; x: number; w: number }[]> {
@@ -146,10 +152,15 @@ test.describe("the workspace", () => {
     await expect(page.getByText(/nothing pinned/i)).toHaveCount(0);
 
     // A view switch remounts every face, and a plot's history is its own (gl/waterfall.ts), so the
-    // scope used to come back empty. It opens on the lane's kept rows and its last readout instead.
-    // Read once rather than polled: waiting for the readout would be waiting for the very frame
-    // that used to hide the gap.
-    expect(await page.getByText(/\d\.\d{4} MHz/).count()).toBeGreaterThan(0);
+    // scope used to come back empty. It opens on the lane's kept rows and its last readout
+    // instead. Read once rather than polled: the readout is seeded during the rack's first render
+    // (ScopeFace), so polling would wait for the very frame that used to hide the gap.
+    expect(
+      await rackNode(page, "scope")
+        .getByText(/\d\.\d{4} MHz/)
+        .count(),
+    ).toBeGreaterThan(0);
+    await expect(rackNode(page, "scope").getByText(/waiting for the first frame/i)).toHaveCount(0);
 
     // Dragging the boundary between two faces makes one larger and the other smaller (CANVAS §5).
     // The whole point of the gesture is that it re-balances a full rack without a hole, so both

--- a/web/src/canvas/Rack.tsx
+++ b/web/src/canvas/Rack.tsx
@@ -126,6 +126,9 @@ export function Rack() {
         return (
           <div
             key={slot.node}
+            // The same handle React Flow puts on a patch node, so a face is addressable by node
+            // in either view.
+            data-id={slot.node}
             className="relative min-h-0 min-w-0"
             style={{
               gridColumn: `${slot.x + 1} / span ${slot.w}`,

--- a/web/src/canvas/nodes/ScopeFace.tsx
+++ b/web/src/canvas/nodes/ScopeFace.tsx
@@ -120,11 +120,17 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
   const waterfallRef = useRef<HTMLCanvasElement>(null);
   const traceRef = useRef<HTMLCanvasElement>(null);
   const rendererRef = useRef<WaterfallView | null>(null);
-  const frameRef = useRef<SpectrumFrame | null>(null);
+  // The hub kept the last frame that arrived while this face did not exist (lib/spectrum.ts).
+  // Read at first render rather than in an effect: the trace and the readout have to be there in
+  // the rack's first paint, or the switch still shows the blank the history exists to remove.
+  // `Spectrum` is keyed by lane, so a different lane is a different mount reading its own.
+  const frameRef = useRef<SpectrumFrame | null>(spectrumHub.latest(set.id, stream));
   const holdRef = useRef<Uint8Array | null>(null);
   const gestureRef = useRef<Gesture | null>(null);
 
-  const [meta, setMeta] = useState<FrameMeta | null>(null);
+  const [meta, setMeta] = useState<FrameMeta | null>(() =>
+    frameRef.current === null ? null : metaOf(frameRef.current),
+  );
   const [glError, setGlError] = useState<string | null>(null);
   const [view, setView] = useState<SpectrumView>(FULL_VIEW);
   const [hold, setHold] = useState(false);
@@ -216,14 +222,11 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
   //
   // It also kept the lane's recent rows while this face did not exist, and switching between the
   // patch and the rack remounts every face: the plot opens on the waterfall the operator was
-  // already reading, rather than blanking and filling in again from the next frame.
+  // already reading, rather than blanking and filling in again from the next frame. Seeded here
+  // and not at render, unlike the frame above, because the renderer is the previous effect's.
   useEffect(() => {
     const past = spectrumHub.history(set.id, stream);
     rendererRef.current?.seed(past.rows, past.count, past.bins);
-    if (past.latest !== null) {
-      frameRef.current = past.latest;
-      setMeta(metaOf(past.latest));
-    }
     let count = 0;
     return spectrumHub.subscribe(set.id, stream, (frame) => {
       frameRef.current = frame;

--- a/web/src/canvas/nodes/ScopeFace.tsx
+++ b/web/src/canvas/nodes/ScopeFace.tsx
@@ -213,7 +213,17 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
   // The hub refcounts the subscription and re-sends it after a reconnect, so two scopes on one
   // radio cost one stream and neither can stop the other's. The lane is the one this scope's
   // own IQ wire names, not always the radio's first.
+  //
+  // It also kept the lane's recent rows while this face did not exist, and switching between the
+  // patch and the rack remounts every face: the plot opens on the waterfall the operator was
+  // already reading, rather than blanking and filling in again from the next frame.
   useEffect(() => {
+    const past = spectrumHub.history(set.id, stream);
+    rendererRef.current?.seed(past.rows, past.count, past.bins);
+    if (past.latest !== null) {
+      frameRef.current = past.latest;
+      setMeta(metaOf(past.latest));
+    }
     let count = 0;
     return spectrumHub.subscribe(set.id, stream, (frame) => {
       frameRef.current = frame;
@@ -223,12 +233,7 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
       // frame regardless, so this only paces the text.
       count += 1;
       if (count === 1 || count % 8 === 0) {
-        setMeta({
-          centerHz: frame.centerHz,
-          spanHz: frame.spanHz,
-          dbMin: frame.dbMin,
-          dbMax: frame.dbMax,
-        });
+        setMeta(metaOf(frame));
       }
     });
   }, [set.id, stream]);
@@ -614,6 +619,15 @@ function markerAt(
     }
   }
   return best;
+}
+
+function metaOf(frame: SpectrumFrame): FrameMeta {
+  return {
+    centerHz: frame.centerHz,
+    spanHz: frame.spanHz,
+    dbMin: frame.dbMin,
+    dbMax: frame.dbMax,
+  };
 }
 
 function accumulateHold(

--- a/web/src/gl/raster.test.ts
+++ b/web/src/gl/raster.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { backingPx, fitExtent, nextRingRow, pixelRatio, rowsForHeight, zoomOf } from "./raster";
+import {
+  backingPx,
+  fitExtent,
+  nextRingRow,
+  pixelRatio,
+  rowsForHeight,
+  seedPlacement,
+  zoomOf,
+} from "./raster";
 
 describe("zoomOf", () => {
   it("is the ratio between drawn and laid-out size", () => {
@@ -110,5 +118,23 @@ describe("fitExtent", () => {
 
   it("stays allocatable when nothing is visible", () => {
     expect(fitExtent(900, 0)).toBe(1);
+  });
+});
+
+describe("seedPlacement", () => {
+  it("lays a short history at the bottom of the ring and leaves the cursor above it", () => {
+    expect(seedPlacement(3, 8)).toEqual({ skip: 0, rows: 3, write: 3 });
+  });
+
+  it("keeps the newest rows when the history outgrew the ring", () => {
+    expect(seedPlacement(10, 8)).toEqual({ skip: 2, rows: 8, write: 0 });
+  });
+
+  it("fills the ring exactly and wraps the cursor back to the start", () => {
+    expect(seedPlacement(8, 8)).toEqual({ skip: 0, rows: 8, write: 0 });
+  });
+
+  it("has nothing to place for a lane with no past", () => {
+    expect(seedPlacement(0, 8)).toEqual({ skip: 0, rows: 0, write: 0 });
   });
 });

--- a/web/src/gl/raster.ts
+++ b/web/src/gl/raster.ts
@@ -46,6 +46,17 @@ export function nextRingRow(row: number, rings: number): number {
   return rings > 0 ? (row + 1) % rings : 0;
 }
 
+/** Where a history handed to a fresh ring lands: how many of its `count` rows to skip, how many
+ * fit, and the write cursor they leave behind. More rows than the ring holds keeps the newest —
+ * the oldest are the ones already scrolled past the bottom of the plot. */
+export function seedPlacement(
+  count: number,
+  rings: number,
+): { skip: number; rows: number; write: number } {
+  const rows = Math.max(0, Math.min(count, rings));
+  return { skip: Math.max(0, count - rows), rows, write: rings > 0 ? rows % rings : 0 };
+}
+
 /** One axis of the shared drawing buffer: grow to whatever the largest visible plot needs, and
  * shrink only once it needs less than half. A buffer that tracked the requirement exactly would
  * be reallocated on every frame of a resize. */

--- a/web/src/gl/waterfall.ts
+++ b/web/src/gl/waterfall.ts
@@ -13,7 +13,15 @@
 // Every colormap here is perceptually uniform and monotone in luminance (DESIGN.md §2): jet and
 // its relatives invent bands in smooth data, so they are not offered.
 
-import { backingPx, fitExtent, nextRingRow, pixelRatio, rowsForHeight, zoomOf } from "./raster";
+import {
+  backingPx,
+  fitExtent,
+  nextRingRow,
+  pixelRatio,
+  rowsForHeight,
+  seedPlacement,
+  zoomOf,
+} from "./raster";
 
 const HISTORY_ROWS = 1024;
 
@@ -117,6 +125,10 @@ export interface WaterfallView {
    * the plot is off screen; only the drawing is skipped. They are dropped only while the context
    * is gone, when there is no history left for them to extend. */
   pushRow(bins: Uint8Array): void;
+  /** Fill the history with rows kept while this plot did not exist — `count` rows of `bins` bytes
+   * packed oldest-first, as one upload. Replaces whatever the plot held, so it belongs at the
+   * start of a plot's life and nowhere else. */
+  seed(rows: Uint8Array, count: number, bins: number): void;
   /** The visible window over the device span, `start` and `width` as fractions of it. Applied
    * to the whole history at once, so zooming re-frames what has already been received rather
    * than only what arrives next. */
@@ -280,6 +292,34 @@ class Plot implements WaterfallView {
       bins,
     );
     this.writeRow = nextRingRow(this.writeRow, HISTORY_ROWS);
+  }
+
+  seed(rows: Uint8Array, count: number, bins: number): void {
+    const live = this.live;
+    if (live === null || bins === 0) {
+      return;
+    }
+    const place = seedPlacement(count, HISTORY_ROWS);
+    if (place.rows === 0) {
+      return;
+    }
+    // `allocate` clears the ring and returns the cursor to row zero, which is where the seed's
+    // oldest row goes; the cursor then continues from the newest, as if the rows had arrived here.
+    this.allocate(bins);
+    const gl = live.context.gl;
+    gl.bindTexture(gl.TEXTURE_2D, live.texture);
+    gl.texSubImage2D(
+      gl.TEXTURE_2D,
+      0,
+      0,
+      0,
+      bins,
+      place.rows,
+      gl.RED,
+      gl.UNSIGNED_BYTE,
+      rows.subarray(place.skip * bins, (place.skip + place.rows) * bins),
+    );
+    this.writeRow = place.write;
   }
 
   setWindow(start: number, width: number): void {

--- a/web/src/lib/spectrum.test.ts
+++ b/web/src/lib/spectrum.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpectrumFrame } from "./frame";
-import { SpectrumHub, type SpectrumSocket } from "./spectrum";
+import { SPECTRUM_HISTORY_ROWS, SpectrumHub, type SpectrumSocket } from "./spectrum";
 import type { ClientCommand, ServerEvent } from "./types";
 
 function fakeSocket() {
@@ -44,7 +44,17 @@ function fakeSocket() {
         type: "StreamStopped",
         data: { stream_id: streamId, kind: "spectrum" },
       }),
-    push: (streamId: number) => frames?.({ streamId } as SpectrumFrame),
+    push: (streamId: number, bins: readonly number[] = [1, 2]) =>
+      frames?.({
+        streamId,
+        seq: 0,
+        timestamp: 0n,
+        centerHz: 100e6,
+        spanHz: 2e6,
+        dbMin: -110,
+        dbMax: -20,
+        bins: Uint8Array.from(bins),
+      }),
     reconnect: () => status?.(true),
     attached: () => frames !== null,
   };
@@ -54,7 +64,18 @@ const subscribes = (sent: ClientCommand[]) => sent.filter((c) => c.type === "Sub
 const unsubscribes = (sent: ClientCommand[]) =>
   sent.filter((c) => c.type === "UnsubscribeSpectrum");
 
+/** Past the release grace, whatever it is set to. */
+const waitOutGrace = () => vi.advanceTimersByTime(60_000);
+
 describe("SpectrumHub", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("subscribes once for many watchers of one lane and stops on the last one", () => {
     const fake = fakeSocket();
     const hub = new SpectrumHub();
@@ -75,8 +96,33 @@ describe("SpectrumHub", () => {
     expect(seen).toEqual([1, 2, 2]);
 
     second();
+    waitOutGrace();
     expect(unsubscribes(fake.sent)).toHaveLength(1);
     expect(hub.watched()).toEqual([]);
+  });
+
+  // A face is remounted by things that have nothing to do with its radio — the patch/rack switch
+  // is the everyday one — and stopping the stream on the way through costs a restart the operator
+  // sees as a stalled plot.
+  it("keeps the stream through a face that lets go and comes straight back", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+
+    hub.subscribe(1, 0, () => {})();
+    expect(hub.watched()).toEqual([{ deviceSet: 1, stream: 0 }]);
+    expect(unsubscribes(fake.sent)).toHaveLength(0);
+
+    const seen: number[] = [];
+    hub.subscribe(1, 0, (frame) => seen.push(frame.streamId));
+    waitOutGrace();
+    // Neither a stop nor a second subscribe: the server is answering the first one still.
+    expect(unsubscribes(fake.sent)).toHaveLength(0);
+    expect(subscribes(fake.sent)).toHaveLength(1);
+
+    fake.started(9, 1);
+    fake.push(9);
+    expect(seen).toEqual([9]);
   });
 
   // The id the server allocates is neither the device-set id nor the lane index, so a hub that
@@ -122,6 +168,7 @@ describe("SpectrumHub", () => {
     expect(lane2).toEqual([11]);
 
     drop0();
+    waitOutGrace();
     expect(unsubscribes(fake.sent)).toEqual([
       { type: "UnsubscribeSpectrum", data: { device_set: 1, stream: 0 } },
     ]);
@@ -188,5 +235,114 @@ describe("SpectrumHub", () => {
 
     hub.detach();
     expect(second.attached()).toBe(false);
+  });
+});
+
+/** The rows of a history, one array per row, so an expectation reads as what the plot draws. */
+function rowsOf(history: { rows: Uint8Array; count: number; bins: number }): number[][] {
+  return Array.from({ length: history.count }, (_, row) => [
+    ...history.rows.subarray(row * history.bins, (row + 1) * history.bins),
+  ]);
+}
+
+// A plot's history lives in its own GL texture, so a face that remounts starts blank. These rows
+// are what it opens on instead.
+describe("SpectrumHub history", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is empty for a lane nobody has watched", () => {
+    const hub = new SpectrumHub();
+    expect(hub.history(1, 0)).toEqual({
+      rows: new Uint8Array(0),
+      count: 0,
+      bins: 0,
+      latest: null,
+    });
+  });
+
+  it("keeps the rows of a lane whose face has gone, oldest first", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+    const drop = hub.subscribe(1, 0, () => {});
+    fake.started(9, 1);
+    fake.push(9, [1, 2]);
+    fake.push(9, [3, 4]);
+
+    drop();
+    // Frames still arrive while no face is watching, and they are the rows that make the switch
+    // look like one continuous waterfall.
+    fake.push(9, [5, 6]);
+
+    const history = hub.history(1, 0);
+    expect(rowsOf(history)).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+    expect(history.latest?.centerHz).toBe(100e6);
+  });
+
+  it("keeps the newest rows once the ring has wrapped", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+    hub.subscribe(1, 0, () => {});
+    fake.started(9, 1);
+    for (let row = 0; row < SPECTRUM_HISTORY_ROWS + 2; row++) {
+      fake.push(9, [row & 0xff, 0]);
+    }
+
+    const history = hub.history(1, 0);
+    expect(history.count).toBe(SPECTRUM_HISTORY_ROWS);
+    const rows = rowsOf(history);
+    expect(rows[0]).toEqual([2, 0]);
+    expect(rows[rows.length - 1]).toEqual([(SPECTRUM_HISTORY_ROWS + 1) & 0xff, 0]);
+  });
+
+  // A different bin count is a different x axis: the old rows cannot be drawn above the new ones.
+  it("drops what it held when the bin count changes", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+    hub.subscribe(1, 0, () => {});
+    fake.started(9, 1);
+    fake.push(9, [1, 2]);
+    fake.push(9, [7, 8, 9]);
+
+    expect(rowsOf(hub.history(1, 0))).toEqual([[7, 8, 9]]);
+  });
+
+  it("forgets a lane nobody came back for", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+    const drop = hub.subscribe(1, 0, () => {});
+    fake.started(9, 1);
+    fake.push(9, [1, 2]);
+
+    drop();
+    waitOutGrace();
+    expect(hub.history(1, 0).count).toBe(0);
+    expect(unsubscribes(fake.sent)).toHaveLength(1);
+  });
+
+  // The grace outlives a reconnect, so a lane inside one is a lane the new connection must be
+  // told about — its face is on its way back and the history has to keep filling.
+  it("re-subscribes a lane still inside its grace when the socket comes back", () => {
+    const fake = fakeSocket();
+    const hub = new SpectrumHub();
+    hub.attach(fake.socket);
+    hub.subscribe(1, 0, () => {})();
+    fake.sent.length = 0;
+
+    fake.reconnect();
+    expect(subscribes(fake.sent)).toHaveLength(1);
   });
 });

--- a/web/src/lib/spectrum.test.ts
+++ b/web/src/lib/spectrum.test.ts
@@ -258,12 +258,8 @@ describe("SpectrumHub history", () => {
 
   it("is empty for a lane nobody has watched", () => {
     const hub = new SpectrumHub();
-    expect(hub.history(1, 0)).toEqual({
-      rows: new Uint8Array(0),
-      count: 0,
-      bins: 0,
-      latest: null,
-    });
+    expect(hub.history(1, 0)).toEqual({ rows: new Uint8Array(0), count: 0, bins: 0 });
+    expect(hub.latest(1, 0)).toBeNull();
   });
 
   it("keeps the rows of a lane whose face has gone, oldest first", () => {
@@ -280,13 +276,12 @@ describe("SpectrumHub history", () => {
     // look like one continuous waterfall.
     fake.push(9, [5, 6]);
 
-    const history = hub.history(1, 0);
-    expect(rowsOf(history)).toEqual([
+    expect(rowsOf(hub.history(1, 0))).toEqual([
       [1, 2],
       [3, 4],
       [5, 6],
     ]);
-    expect(history.latest?.centerHz).toBe(100e6);
+    expect(hub.latest(1, 0)?.centerHz).toBe(100e6);
   });
 
   it("keeps the newest rows once the ring has wrapped", () => {
@@ -330,6 +325,7 @@ describe("SpectrumHub history", () => {
     drop();
     waitOutGrace();
     expect(hub.history(1, 0).count).toBe(0);
+    expect(hub.latest(1, 0)).toBeNull();
     expect(unsubscribes(fake.sent)).toHaveLength(1);
   });
 

--- a/web/src/lib/spectrum.ts
+++ b/web/src/lib/spectrum.ts
@@ -14,6 +14,12 @@
 //
 // Reconnects are the other reason this is not per-component state: subscriptions are
 // per-connection, so everything wanted must be re-sent when the socket comes back.
+//
+// Faces are the third. A scope face is remounted by things that have nothing to do with its radio
+// — switching between the patch and the rack is the everyday one — and a plot's history lives in
+// its own GL texture, so that round trip used to leave the operator watching an empty waterfall
+// fill in again. So the lane's recent rows are kept here, where they outlive any one face, and the
+// stream is stopped a few seconds after the last watcher rather than the instant it lets go.
 
 import type { SpectrumFrame } from "./frame";
 import type { ClientCommand, ServerEvent } from "./types";
@@ -35,10 +41,28 @@ export interface SpectrumSocket {
 export const SPECTRUM_FPS = 30;
 export const SPECTRUM_BINS = 1024;
 
+/** Rows of past spectrum kept per lane. Sized to the deepest history a plot can draw, so a face
+ * that comes back finds the whole waterfall it left and not a band of it. */
+export const SPECTRUM_HISTORY_ROWS = 1024;
+
+/** How long a lane's stream and history outlive their last watcher. A view switch unmounts every
+ * face and mounts it again in the same commit: stopping the server's stream on the way through
+ * would cost a restart, which the operator reads as a plot that stalled. */
+const RELEASE_GRACE_MS = 5_000;
+
 /** One watched lane. */
 export interface Lane {
   deviceSet: number;
   stream: number;
+}
+
+/** A lane's recent past, for a face that has just mounted: `count` rows of `bins` bytes packed
+ * oldest-first, and the frame the trace and the readout were last drawn from. */
+export interface SpectrumHistory {
+  rows: Uint8Array;
+  count: number;
+  bins: number;
+  latest: SpectrumFrame | null;
 }
 
 /** Map key for a lane. The pair is the identity; the id the server allocates is not, because it
@@ -47,22 +71,71 @@ function laneKey(deviceSet: number, stream: number): string {
   return `${deviceSet}:${stream}`;
 }
 
+/** One lane's rows in a ring: retention costs one buffer per lane and no allocation per frame. */
+class History {
+  private ring = new Uint8Array(0);
+  private bins = 0;
+  private write = 0;
+  private filled = 0;
+  private last: SpectrumFrame | null = null;
+
+  record(frame: SpectrumFrame): void {
+    this.last = frame;
+    if (frame.bins.length === 0) {
+      return;
+    }
+    // A different bin count is a different x axis, so the rows already held cannot be drawn above
+    // the ones arriving now — the plot reallocates its texture at this same seam.
+    if (frame.bins.length !== this.bins) {
+      this.bins = frame.bins.length;
+      this.ring = new Uint8Array(this.bins * SPECTRUM_HISTORY_ROWS);
+      this.write = 0;
+      this.filled = 0;
+    }
+    // Copied, not referenced: `bins` is a view into the socket's message buffer, and holding a
+    // thousand of those would pin a thousand messages.
+    this.ring.set(frame.bins, this.write * this.bins);
+    this.write = (this.write + 1) % SPECTRUM_HISTORY_ROWS;
+    this.filled = Math.min(this.filled + 1, SPECTRUM_HISTORY_ROWS);
+  }
+
+  read(): SpectrumHistory {
+    const rows = new Uint8Array(this.filled * this.bins);
+    // Unwrapped here rather than by the reader: oldest-first starts one row past the write cursor
+    // once the ring has wrapped, and the plot uploads its history in a single call.
+    const first = (this.write - this.filled + SPECTRUM_HISTORY_ROWS) % SPECTRUM_HISTORY_ROWS;
+    const head = Math.min(this.filled, SPECTRUM_HISTORY_ROWS - first);
+    rows.set(this.ring.subarray(first * this.bins, (first + head) * this.bins));
+    rows.set(this.ring.subarray(0, (this.filled - head) * this.bins), head * this.bins);
+    return { rows, count: this.filled, bins: this.bins, latest: this.last };
+  }
+}
+
+/** One lane's watchers and the past they share. The entry lives exactly as long as the server's
+ * stream does, which outlasts the last watcher by `RELEASE_GRACE_MS`. */
+interface Watched {
+  listeners: Set<(frame: SpectrumFrame) => void>;
+  history: History;
+  /** A pending stop, or 0 — non-zero is precisely "subscribed, but nothing is watching". */
+  release: number;
+}
+
 export class SpectrumHub {
   private socket: SpectrumSocket | null = null;
-  private readonly watchers = new Map<string, Set<(frame: SpectrumFrame) => void>>();
+  private readonly lanes = new Map<string, Watched>();
   /** Server-allocated stream id → lane key, from `StreamStarted`. Frames carry only the id. */
   private readonly ids = new Map<number, string>();
 
   private readonly onFrame = (frame: SpectrumFrame): void => {
     const key = this.ids.get(frame.streamId);
-    if (key === undefined) {
+    const lane = key === undefined ? undefined : this.lanes.get(key);
+    if (lane === undefined) {
       return;
     }
-    const listeners = this.watchers.get(key);
-    if (listeners === undefined) {
-      return;
-    }
-    for (const listener of listeners) {
+    // Recorded before it is delivered, and recorded through the grace as well: a lane whose faces
+    // are between mounts is exactly the one whose history has to stay unbroken.
+    lane.history.record(frame);
+    for (const listener of lane.listeners) {
       listener(frame);
     }
   };
@@ -119,40 +192,66 @@ export class SpectrumHub {
     socket.removeEventListener(this.onEvent);
   }
 
-  /** Watch one lane's spectrum. Returns the unsubscribe; the stream stops when the last watcher
-   * of that lane lets go, leaving every other lane of the same radio running. */
+  /** Watch one lane's spectrum. Returns the unsubscribe; the stream stops a grace period after
+   * the last watcher of that lane lets go, leaving every other lane of the same radio running. */
   subscribe(
     deviceSet: number,
     stream: number,
     listener: (frame: SpectrumFrame) => void,
   ): () => void {
     const key = laneKey(deviceSet, stream);
-    let listeners = this.watchers.get(key);
-    if (listeners === undefined) {
-      listeners = new Set();
-      this.watchers.set(key, listeners);
+    let lane = this.lanes.get(key);
+    if (lane === undefined) {
+      lane = { listeners: new Set(), history: new History(), release: 0 };
+      this.lanes.set(key, lane);
       this.send({ deviceSet, stream }, true);
+    } else if (lane.release !== 0) {
+      // Inside the grace the stream never stopped, so this is a cancelled stop and not a second
+      // subscribe: sending one would have the server replace the stream that is already feeding us.
+      clearTimeout(lane.release);
+      lane.release = 0;
     }
-    listeners.add(listener);
-    return () => {
-      const current = this.watchers.get(key);
-      if (current === undefined) {
-        return;
-      }
-      current.delete(listener);
-      if (current.size === 0) {
-        this.watchers.delete(key);
-        this.send({ deviceSet, stream }, false);
-      }
-    };
+    lane.listeners.add(listener);
+    return () => this.release(key, { deviceSet, stream }, listener);
   }
 
-  /** Lanes with at least one watcher — the test seam, and what a reconnect re-sends. */
+  /** What a face that has just mounted draws before its first frame arrives. Empty for a lane the
+   * hub has never carried, or one released long enough ago that its rows were dropped. */
+  history(deviceSet: number, stream: number): SpectrumHistory {
+    return (
+      this.lanes.get(laneKey(deviceSet, stream))?.history.read() ?? {
+        rows: new Uint8Array(0),
+        count: 0,
+        bins: 0,
+        latest: null,
+      }
+    );
+  }
+
+  /** Lanes the server is streaming: every watched one, and any still inside its release grace.
+   * The test seam, and what a reconnect re-sends. */
   watched(): Lane[] {
-    return [...this.watchers.keys()].map((key) => {
+    return [...this.lanes.keys()].map((key) => {
       const [deviceSet, stream] = key.split(":");
       return { deviceSet: Number(deviceSet), stream: Number(stream) };
     });
+  }
+
+  private release(key: string, lane: Lane, listener: (frame: SpectrumFrame) => void): void {
+    const watched = this.lanes.get(key);
+    if (watched === undefined) {
+      return;
+    }
+    watched.listeners.delete(listener);
+    if (watched.listeners.size > 0 || watched.release !== 0) {
+      return;
+    }
+    // The history goes with the stream, not with the last face: a lane nobody has watched for
+    // this long would otherwise come back showing rows from before the radio was left alone.
+    watched.release = setTimeout(() => {
+      this.lanes.delete(key);
+      this.send(lane, false);
+    }, RELEASE_GRACE_MS);
   }
 
   private send(lane: Lane, on: boolean): void {

--- a/web/src/lib/spectrum.ts
+++ b/web/src/lib/spectrum.ts
@@ -56,13 +56,13 @@ export interface Lane {
   stream: number;
 }
 
-/** A lane's recent past, for a face that has just mounted: `count` rows of `bins` bytes packed
- * oldest-first, and the frame the trace and the readout were last drawn from. */
+/** The waterfall a face that has just mounted opens on: `count` rows of `bins` bytes packed
+ * oldest-first. Read separately from `latest` because reading it copies the ring, and the trace
+ * and the readout want only the one frame. */
 export interface SpectrumHistory {
   rows: Uint8Array;
   count: number;
   bins: number;
-  latest: SpectrumFrame | null;
 }
 
 /** Map key for a lane. The pair is the identity; the id the server allocates is not, because it
@@ -77,10 +77,10 @@ class History {
   private bins = 0;
   private write = 0;
   private filled = 0;
-  private last: SpectrumFrame | null = null;
+  latest: SpectrumFrame | null = null;
 
   record(frame: SpectrumFrame): void {
-    this.last = frame;
+    this.latest = frame;
     if (frame.bins.length === 0) {
       return;
     }
@@ -107,7 +107,7 @@ class History {
     const head = Math.min(this.filled, SPECTRUM_HISTORY_ROWS - first);
     rows.set(this.ring.subarray(first * this.bins, (first + head) * this.bins));
     rows.set(this.ring.subarray(0, (this.filled - head) * this.bins), head * this.bins);
-    return { rows, count: this.filled, bins: this.bins, latest: this.last };
+    return { rows, count: this.filled, bins: this.bins };
   }
 }
 
@@ -215,17 +215,23 @@ export class SpectrumHub {
     return () => this.release(key, { deviceSet, stream }, listener);
   }
 
-  /** What a face that has just mounted draws before its first frame arrives. Empty for a lane the
-   * hub has never carried, or one released long enough ago that its rows were dropped. */
+  /** The waterfall a face that has just mounted opens on. Empty for a lane the hub has never
+   * carried, or one released long enough ago that its rows were dropped. Copies the ring, so it
+   * is a mount-time call and not a per-frame one. */
   history(deviceSet: number, stream: number): SpectrumHistory {
     return (
       this.lanes.get(laneKey(deviceSet, stream))?.history.read() ?? {
         rows: new Uint8Array(0),
         count: 0,
         bins: 0,
-        latest: null,
       }
     );
+  }
+
+  /** The lane's most recent frame — what a mounting face draws its trace and its readout from
+   * before one of its own arrives. */
+  latest(deviceSet: number, stream: number): SpectrumFrame | null {
+    return this.lanes.get(laneKey(deviceSet, stream))?.history.latest ?? null;
   }
 
   /** Lanes the server is streaming: every watched one, and any still inside its release grace.


### PR DESCRIPTION
## The break

Switching between the patch and the rack unmounts every face and mounts it again. A plot's history lives in its own GL texture, so the scope came back blank and refilled from the next frame — a running radio that reads as a stalled one. The readout went with it.

## The fix

The lane's recent rows now live in the spectrum hub (`lib/spectrum.ts`), where they outlive any one face, and the stream is stopped a 5 s grace after its last watcher rather than the instant it lets go — so the round trip costs neither the history nor a stream restart on the server.

A mounting plot uploads that history in one `texSubImage2D` (`gl/waterfall.ts` `seed`), and the last frame is read at **render**, not in an effect: the trace and the readout have to be there in the rack's first paint, or the switch still shows the blank the history exists to remove.

Retention is one ring buffer per lane, no allocation per frame; reading it copies the ring, which is why the last frame is a separate accessor from the rows.

## Intended tradeoff

The history lives exactly as long as the stream plus its grace. A scope that is *not* pinned to the rack, left alone for more than 5 s, still comes back blank — the history follows the stream, not the face. That is deliberate: rows from before a radio was left alone are worse than none.

## Tests

- `raster.ts` `seedPlacement` — the ring arithmetic (short history, overflowed, exact fit, empty), unit-tested.
- `spectrum.test.ts` — rows kept oldest-first through an unwatched gap, newest kept once the ring wraps, dropped on a bin-count change, forgotten after the grace, re-subscribed if the socket returns mid-grace, and no stop/re-subscribe for a face that lets go and comes straight back.
- `smoke.spec.ts` — the real remount with real GL: the scope's readout is present in the rack's first paint, asserted against the rack's own scope face rather than page-wide.

Discrimination checked: the smoke assertion fails `Received: 0` against unfixed code and passes with the fix; the branch then passed the smoke three consecutive times.

Also: rack faces now carry the `data-id` React Flow gives a patch node, so a face is addressable in either view — the assertion above was otherwise page-wide and would have passed on any MHz readout in the rack.

`typecheck`, `lint`, `biome`, 326 unit tests, and `cargo xtask smoke` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)