### PR TITLE
The scope's toolbar buttons work again

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -162,6 +162,36 @@ test.describe("the workspace", () => {
     ).toBeGreaterThan(0);
     await expect(rackNode(page, "scope").getByText(/waiting for the first frame/i)).toHaveCount(0);
 
+    // The plot's own toolbar, in the rack because a face there is always the active one
+    // (NodeShell) — so the plot's gestures are armed and this is where they used to swallow it.
+    // The plot captures the pointer on `pointerdown` to pan and tune, and a capture on the
+    // ancestor retargets the release: the button never saw a click, and the tune-on-click ran
+    // instead.
+    const scopePlot = rackNode(page, "scope");
+    // Where the radio sits: the shared centre and any per-stream override, because `tuneDelta`
+    // writes one or the other depending on what the radio scopes per stream.
+    const tunedTo = async (): Promise<string> => {
+      const state: StateSnapshot = await page.request.get("/api/state").then((r) => r.json());
+      const settings = state.device_sets[0]?.settings;
+      return JSON.stringify([settings?.center_hz ?? null, settings?.streams ?? []]);
+    };
+    const tuning = await tunedTo();
+
+    const maxHold = scopePlot.getByRole("button", { name: /max hold/i });
+    await maxHold.click();
+    await expect(maxHold).toHaveAttribute("aria-pressed", "true");
+    await maxHold.click();
+    await expect(maxHold).toHaveAttribute("aria-pressed", "false");
+
+    // The trigger is labelled with the colormap in force, so picking one shows in its name.
+    await scopePlot.getByRole("button", { name: /^magma$/i }).click();
+    await page.getByRole("button", { name: /^viridis$/i }).click();
+    await expect(scopePlot.getByRole("button", { name: /^viridis$/i })).toBeVisible();
+
+    // The point of all four clicks: none of them was a click on the *plot*. A radio that moved
+    // here is the actual complaint — the buttons were operating the scope.
+    expect(await tunedTo()).toBe(tuning);
+
     // Dragging the boundary between two faces makes one larger and the other smaller (CANVAS §5).
     // The whole point of the gesture is that it re-balances a full rack without a hole, so both
     // halves are asserted — and against the *stored* rack, since that is what survives a reload.

--- a/web/src/canvas/nodes/ScopeFace.tsx
+++ b/web/src/canvas/nodes/ScopeFace.tsx
@@ -298,6 +298,12 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
     if (!active || event.button !== 0 || plotRef.current === null || spanHz <= 0) {
       return;
     }
+    // The plot declines what is not its own surface, rather than every control stopping
+    // propagation: the popover is Base UI's, and its dismissal listens where a swallowed event
+    // would never arrive.
+    if (!onPlotSurface(event.target, plotRef.current)) {
+      return;
+    }
     const rect = plotRef.current.getBoundingClientRect();
     const at = pointerFraction(event.clientX);
     const grabbed = markerAt(set.channels, view, spanHz, at, GRAB_PX / rect.width);
@@ -386,7 +392,10 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       onDoubleClick={(event) => {
-        if (!active || meta === null) {
+        // Guarded here too, and not only in `onPointerDown`: this path never consults the
+        // gesture, so two quick jabs at a toolbar button would recentre the radio.
+        const plot = plotRef.current;
+        if (!active || meta === null || plot === null || !onPlotSurface(event.target, plot)) {
           return;
         }
         const at = pointerFraction(event.clientX);
@@ -422,7 +431,7 @@ function Spectrum({ node, set, stream }: { node: PatchNode; set: DeviceSet; stre
         </span>
         {/* Bottom-left: the only corner of the plot no data occupies, so the toolbar costs the
             trace nothing. */}
-        <div className="pointer-events-auto flex items-center gap-1 self-start">
+        <div data-plot-chrome className="pointer-events-auto flex items-center gap-1 self-start">
           <Popover label={colormap} triggerClass={plotButton(false)} width="w-36">
             {(close) => (
               <div className="flex flex-col gap-0.5">
@@ -494,6 +503,7 @@ function Divider({
       role="separator"
       aria-orientation="horizontal"
       aria-label={`Trace and waterfall split, ${Math.round(fraction * 100)}% trace`}
+      data-plot-chrome
       className="group relative z-10 -my-1 h-[9px] shrink-0 cursor-row-resize"
       onPointerDown={(event) => {
         event.stopPropagation();
@@ -622,6 +632,27 @@ function markerAt(
     }
   }
   return best;
+}
+
+/**
+ * Whether a pointer that reached the plot's handlers actually landed on the plot. Two ways it did
+ * not, and the plot has to decline both: it captures the pointer to pan and tune, and a capture
+ * on the ancestor retargets the release, so a control underneath never sees a click and the
+ * tune-on-click runs in its place.
+ *
+ * Chrome drawn over the plot — the toolbar, the split handle — is marked, because it is inside
+ * the plot and hit-testing alone cannot tell it apart. A portalled popup is the other way round:
+ * React dispatches synthetic events up the *component* tree, so a popover this subtree renders
+ * into `document.body` bubbles in here from outside the plot entirely.
+ *
+ * Channel markers are deliberately neither: dragging one to tune is a plot gesture that begins on
+ * a marker, and the plot has to receive it.
+ */
+function onPlotSurface(target: EventTarget | null, plot: HTMLElement): boolean {
+  if (!(target instanceof Node) || !plot.contains(target)) {
+    return false;
+  }
+  return !(target instanceof Element) || target.closest("[data-plot-chrome]") === null;
 }
 
 function metaOf(frame: SpectrumFrame): FrameMeta {


### PR DESCRIPTION
> Stacked on #5 — base is `t3code/preserve-scope-on-rack-switch`, not `main`, because the e2e additions land in the same rack section of `smoke.spec.ts`. Merge #5 first and this retargets to `main` cleanly.

## The break

Max hold, the colormap picker and reset zoom sit *over* the plot, and the plot captures the pointer on `pointerdown` to pan and tune. A capture on the ancestor retargets the release, so the button never saw a `click` and the plot's tune-on-click ran in its place — the toolbar operated the radio instead of itself.

A face in the rack is always the active one (`NodeShell`), so the plot's gestures are always armed there and the buttons failed every time. In the patch they failed as soon as the node was selected — i.e. as soon as you were actually using the scope.

Everything downstream was fine: `setColormap`, `accumulateHold` and `readColormap` all behave. One root cause, three beneficiaries.

## The fix

The plot declines pointers that did not land on its surface, rather than each control stopping propagation. Propagation is the wrong lever here: the colormap popover's dismissal is Base UI's, and it listens where a swallowed event would never arrive.

There are two ways a pointer is not the plot's, and they need different tests:

- **Chrome drawn over the plot** (toolbar, split handle) is *inside* the plot, so hit-testing can't distinguish it — it carries `data-plot-chrome`.
- **A portalled popup** is the other way round. React dispatches synthetic events up the *component* tree, so the popover this subtree renders into `document.body` bubbles into the plot's handlers from outside the plot's DOM entirely.

That second case is worth calling out: marking the toolbar alone fixed max hold and left the colormap options dead, which is what the intermediate test run showed. Containment in the plot is the check that catches it.

Channel markers are deliberately unmarked — dragging one to tune is a plot gesture that begins on a marker, so the plot must keep receiving those.

`onDoubleClick` is guarded too. It never consults the gesture ref, so without it two quick jabs at a button would still have recentred the radio.

## Tests

`smoke.spec.ts`, in the rack section — the always-broken case, and real Chromium is the only place a pointer-capture bug is visible at all:

- max hold toggles `aria-pressed` on and back off;
- the colormap trigger opens, an option is picked, and the trigger's accessible name changes to it;
- the radio's tuning is byte-identical across all four clicks — that last one asserts the actual complaint, which the toggle assertions alone do not.

Test-first: the assertions were written and run against unfixed code, failing at `aria-pressed` `"false"`. After the fix the smoke passed three consecutive times (this suite is `retries: 0` and somewhat flaky on my Linux box, hence the repeats).

`typecheck`, `lint`, `biome` and 326 unit tests pass. No new lint warnings — the 6 reported are pre-existing and in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)