### PR TITLE
HackRF independent baseband-filter bandwidth and hardware sweep mode

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -36,8 +36,9 @@ is a deliberate no. Within each section, shipped comes first.
 - **[shipped]** Auto-reconnect on replug — a faulted set whose radio re-enumerates is re-opened, its tuning re-applied and its channels rebuilt with ids, PCM identity and live audio subscriptions preserved
 - **[shipped]** Two-tier recovery — an in-place stream restart (measured 6.1–7.6 ms on the RTL-SDR, 0.8–1.2 ms on the HackRF, against ~1.6 s for a re-open) with a silent-stall detector on both radios, falling back to the engine's destructive fault path only when the restart budget is spent. Proven in three pieces (policy, transport, primitive); never yet driven by a genuinely halted pipe
 - **[shipped]** Soapy-free builds are a CI gate (`--no-default-features --features rtl-native,hackrf-native`)
+- **[shipped]** HackRF baseband filter as a control of its own — all sixteen MAX2837 widths offered, an off-grid request snapped down and *reported* at the width that landed, and a `0` that asks for whatever the sample rate implies. A rate change still carries the filter with it, but the width it lands on is now libhackrf's `0.75 × rate` rather than the rate itself: the old value asked for a filter wider than the passband it was there to bound, and no longer matched what the same radio does under `hackrf_transfer`
+- **[shipped]** HackRF hardware sweep mode — the firmware's `INIT_SWEEP` request and `RX_SWEEP` transceiver mode, the 16 KiB stamped-block framing, and a reader that hands out one located capture per block, half-duplex arbitrated against capture and transmit. Driver-level and Rust-only, like the transmit path: the plan encoding and the block parsing are golden-tested against libhackrf's and the firmware's own source, but no radio has run it and nothing above `device-hackrf` calls it yet (see §4)
 - **[planned]** Direct sampling (HF via RTL-SDR)
-- **[planned]** HackRF independent baseband-filter bandwidth and hardware sweep mode
 - **[planned]** rtl_tcp / SpyServer client device
 - **[planned]** KiwiSDR client device
 - **[planned]** Remote source/sink between sdr-- instances; local routing between device sets
@@ -70,7 +71,7 @@ is a deliberate no. Within each section, shipped comes first.
 - **[shipped]** Keyboard-first operation — tune, tune step, mode, squelch, audio, channel and view switching, with a `?` overlay rendering the same table the handler switches on
 - **[shipped]** Frequency manager: presets and bookmarks
 - **[shipped]** Frequency scanner — targets grouped into passband-sized tunings so one dwell measures every target in the passband, peak-hold over the dwell, post-retune settle and drain, hold-and-resume that parks a channel on the hit, and exclusive ownership of the set's centre frequency while it runs. Swept 88–108 MHz (201 targets) on both radios and held on real stations
-- **[planned]** Hardware-assisted wideband sweep — today's scanner sweeps by retuning; the HackRF's own sweep mode is not driven
+- **[planned]** Hardware-assisted wideband sweep — the HackRF driver now runs the radio's own sweep mode (§2), but the scanner still sweeps by retuning: a sweep delivers blocks stamped with their own frequency rather than a stream at one tuning, so the scanner's "measure the device-set spectrum tap" loop has nothing to read it with yet
 - **[planned]** Strongest-signal "close-call" finder
 - **[planned]** Signal-strength **hunt mode** — Geiger-style audio/visual feedback as you close on a transmitter
 - **[planned]** Percentile-anchored waterfall colour range — the range is the frame's own min…max today, so a high noise floor washes the display out

--- a/crates/device-hackrf/src/caps.rs
+++ b/crates/device-hackrf/src/caps.rs
@@ -8,7 +8,7 @@ use sdrmm_wire::{
     StreamScope,
 };
 
-use crate::driver::Config;
+use crate::driver::{Config, FILTER_WIDTHS_HZ, snap_filter_width};
 
 /// The HackRF has one SMA port shared by RX and TX; the list exists so the capability UI has
 /// a name for it, and so a preset captured elsewhere round-trips.
@@ -75,12 +75,10 @@ pub(crate) fn capabilities() -> Capabilities {
             },
         ],
         antennas: vec![ANTENNA.to_string()],
-        // The driver ties the MAX2837 baseband filter to the sample rate — its
-        // `set_sample_rate_hz` issues BASEBAND_FILTER_BANDWIDTH_SET with the same value and
-        // there is no independent setter — so there is no bandwidth to offer. An
-        // empty list here means "no such control", and [`validate`] rejects one rather than
-        // accepting a value nothing would honour.
-        bandwidths: Vec::new(),
+        // The MAX2837's filter has no continuous cutoff: these sixteen widths are the only ones
+        // its register encodes, which is why this is a list and not a range. Leaving it alone
+        // lets the filter follow the sample rate (see `FILTER_MATCH_RATE_HZ`).
+        bandwidths: FILTER_WIDTHS_HZ.iter().copied().map(f64::from).collect(),
         extra: vec![
             ExtraSetting::Bool {
                 name: AMP_SETTING.to_string(),
@@ -98,6 +96,12 @@ pub(crate) fn capabilities() -> Capabilities {
     }
 }
 
+/// The value of `bandwidth` that asks for whatever width the sample rate implies, the same
+/// "0 means automatic" the RTL-SDR backend takes. It is not in [`Capabilities::bandwidths`]:
+/// that list is what the filter can be *set* to, and a select offering "0 Hz" would read as a
+/// width rather than as the absence of one.
+const FILTER_MATCH_RATE_HZ: f64 = 0.0;
+
 /// The hardware writes one validated delta turns into. `None` is an untouched knob; every
 /// `Some` is already in the unit and on the grid the device takes, so [`validate`] cannot be
 /// followed by a rejection from the driver.
@@ -105,10 +109,21 @@ pub(crate) fn capabilities() -> Capabilities {
 pub(crate) struct Applied {
     pub(crate) frequency_hz: Option<u64>,
     pub(crate) sample_rate_hz: Option<u32>,
+    pub(crate) filter: Option<FilterWidth>,
     pub(crate) lna_gain_db: Option<u8>,
     pub(crate) vga_gain_db: Option<u8>,
     pub(crate) amp: Option<bool>,
     pub(crate) bias_tee: Option<bool>,
+}
+
+/// What a delta asked of the baseband filter. Applied *after* the sample rate, which moves the
+/// filter itself — so a delta carrying both lands on the width it asked for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FilterWidth {
+    /// Whatever the sample rate implies, resolved by the driver against the rate it now holds.
+    MatchRate,
+    /// This exact width, already snapped onto the MAX2837's table.
+    Hz(u32),
 }
 
 /// Quantise a gain onto the stage's hardware grid. The MAX2837 gain registers only take 8 dB
@@ -176,12 +191,20 @@ pub(crate) fn validate(
         ));
     }
 
-    // Same reasoning: the baseband filter follows the sample rate (see `capabilities`), so
-    // an explicit bandwidth would be dropped rather than applied.
-    if delta.bandwidth.is_some() {
-        return Err(DeviceError::Unsupported(
-            "bandwidth: the HackRF baseband filter follows sample_rate".to_string(),
-        ));
+    // Snapped rather than refused, for the same reason a gain is: the widths are a hardware
+    // grid, not a contract, and `settings()` reports back the one that landed. The bounds *are*
+    // a contract, so a request outside them is still a refusal.
+    if let Some(bandwidth) = delta.bandwidth {
+        let widest = FILTER_WIDTHS_HZ[FILTER_WIDTHS_HZ.len() - 1];
+        applied.filter = Some(if bandwidth == FILTER_MATCH_RATE_HZ {
+            FilterWidth::MatchRate
+        } else if bandwidth.is_finite() && bandwidth > 0.0 && bandwidth <= f64::from(widest) {
+            FilterWidth::Hz(snap_filter_width(bandwidth.round() as u32))
+        } else {
+            return Err(DeviceError::Unsupported(format!(
+                "bandwidth {bandwidth} outside 0..{widest} Hz (0 matches sample_rate)"
+            )));
+        });
     }
 
     if let Some(antenna) = &delta.antenna
@@ -241,14 +264,18 @@ pub(crate) fn validate(
 /// Mirror the driver's record of the last successfully applied configuration into the wire
 /// model. This is the only path that writes `settings()`, so a snapped gain and a batch that
 /// failed halfway are both reported as what the hardware actually holds — never as what was
-/// asked for. `ppm`/`bandwidth` stay unset because [`validate`] refuses them.
+/// asked for. `ppm` stays unset because [`validate`] refuses it.
+///
+/// The filter reports its width whether it was asked for or carried there by the rate: the
+/// MAX2837 is always at *some* width, and reporting nothing would leave the control the client
+/// renders showing a value the radio is not at.
 pub(crate) fn settings_from_config(config: &Config) -> DeviceSettings {
     DeviceSettings {
         center_hz: Some(config.frequency_hz as f64),
         sample_rate: Some(f64::from(config.sample_rate_hz)),
         ppm: None,
         antenna: Some(ANTENNA.to_string()),
-        bandwidth: None,
+        bandwidth: Some(f64::from(config.filter_width_hz)),
         gains: vec![
             GainValue {
                 stage: LNA_STAGE.to_string(),
@@ -342,8 +369,12 @@ mod tests {
         assert_eq!(caps.gains[1].name, "VGA");
         assert_eq!(caps.gains[1].range.step, Some(2.0));
         assert_eq!(caps.antennas, vec!["RX".to_string()]);
-        // No independent baseband-filter setter exists, so no bandwidth may be advertised.
-        assert!(caps.bandwidths.is_empty());
+        // Exactly the MAX2837's own widths, ascending — the select the client renders is this
+        // list, so an entry the register cannot encode would be an unselectable option.
+        assert_eq!(caps.bandwidths.len(), 16);
+        assert_eq!(caps.bandwidths.first(), Some(&1.75e6));
+        assert_eq!(caps.bandwidths.last(), Some(&28e6));
+        assert!(caps.bandwidths.windows(2).all(|pair| pair[0] < pair[1]));
         assert_eq!(
             caps.extra.iter().map(extra_name).collect::<Vec<_>>(),
             vec!["amp", "bias_tee"]
@@ -394,6 +425,7 @@ mod tests {
             center_hz: Some(433_920_000.0),
             sample_rate: Some(8_000_000.0),
             antenna: Some("RX".to_string()),
+            bandwidth: Some(5_000_000.0),
             gains: vec![gain("LNA", 24.0), gain("VGA", 20.0)],
             extra: vec![extra_bool("amp", true), extra_bool("bias_tee", false)],
             ..DeviceSettings::default()
@@ -403,6 +435,7 @@ mod tests {
             Applied {
                 frequency_hz: Some(433_920_000),
                 sample_rate_hz: Some(8_000_000),
+                filter: Some(FilterWidth::Hz(5_000_000)),
                 lna_gain_db: Some(24),
                 vga_gain_db: Some(20),
                 amp: Some(true),
@@ -560,27 +593,73 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_ppm_and_bandwidth_the_hardware_cannot_honour() {
-        for delta in [
-            DeviceSettings {
-                ppm: Some(1.5),
+    fn validate_rejects_ppm_the_hardware_cannot_honour() {
+        for ppm in [1.5, 0.0] {
+            let delta = DeviceSettings {
+                ppm: Some(ppm),
                 ..DeviceSettings::default()
-            },
-            DeviceSettings {
-                ppm: Some(0.0),
-                ..DeviceSettings::default()
-            },
-            DeviceSettings {
-                bandwidth: Some(5e6),
-                ..DeviceSettings::default()
-            },
-        ] {
+            };
             assert!(
                 matches!(
                     validate(&delta, &capabilities()),
                     Err(DeviceError::Unsupported(_))
                 ),
-                "{delta:?} must be rejected"
+                "ppm {ppm} must be rejected"
+            );
+        }
+    }
+
+    fn filter_of(bandwidth: f64) -> Result<Option<FilterWidth>, DeviceError> {
+        let delta = DeviceSettings {
+            bandwidth: Some(bandwidth),
+            ..DeviceSettings::default()
+        };
+        validate(&delta, &capabilities()).map(|applied| applied.filter)
+    }
+
+    #[test]
+    fn validate_takes_every_listed_filter_width_as_it_is() {
+        for width in FILTER_WIDTHS_HZ {
+            assert_eq!(
+                filter_of(f64::from(width)).unwrap(),
+                Some(FilterWidth::Hz(width)),
+                "{width}"
+            );
+        }
+    }
+
+    /// A width between two register steps has no encoding, so it snaps down the way a gain
+    /// snaps onto the MAX2837's gain grid — and `settings()` reports where it landed.
+    #[test]
+    fn validate_snaps_a_width_between_two_register_steps() {
+        assert_eq!(filter_of(7.5e6).unwrap(), Some(FilterWidth::Hz(7e6 as u32)));
+        assert_eq!(filter_of(1.0).unwrap(), Some(FilterWidth::Hz(1_750_000)));
+        assert_eq!(
+            filter_of(27_999_999.0).unwrap(),
+            Some(FilterWidth::Hz(24_000_000))
+        );
+    }
+
+    /// Zero is the one value that is not a width: it asks for whatever the rate implies, the
+    /// same "0 means automatic" the RTL-SDR path takes. An *absent* bandwidth asks for nothing
+    /// at all, which is a different thing — the rate then carries the filter on its own.
+    #[test]
+    fn validate_reads_zero_as_matching_the_sample_rate() {
+        assert_eq!(filter_of(0.0).unwrap(), Some(FilterWidth::MatchRate));
+        assert_eq!(
+            validate(&DeviceSettings::default(), &capabilities())
+                .unwrap()
+                .filter,
+            None
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_width_no_filter_could_hold() {
+        for bad in [-1.0, 28_000_001.0, 1e9, f64::NAN, f64::INFINITY] {
+            assert!(
+                matches!(filter_of(bad), Err(DeviceError::Unsupported(_))),
+                "bandwidth {bad} must be rejected"
             );
         }
     }
@@ -633,6 +712,7 @@ mod tests {
             lna_gain_db: 16,
             vga_gain_db: 30,
             tx_vga_gain_db: 0,
+            filter_width_hz: 1_750_000,
             amp_enabled: true,
             bias_tee_enabled: false,
         };
@@ -641,13 +721,21 @@ mod tests {
         assert_eq!(settings.sample_rate, Some(2e6));
         assert_eq!(settings.antenna.as_deref(), Some("RX"));
         assert_eq!(settings.ppm, None);
-        assert_eq!(settings.bandwidth, None);
+        // The filter is always at *some* width, so it always reports one — whether it was asked
+        // for or carried there by the rate.
+        assert_eq!(settings.bandwidth, Some(1.75e6));
         assert_eq!(settings.gains, vec![gain("LNA", 16.0), gain("VGA", 30.0)]);
         assert_eq!(
             settings.extra,
             vec![extra_bool("amp", true), extra_bool("bias_tee", false)]
         );
         // Every reported value must be one the capability model can express back.
-        assert!(validate(&settings, &capabilities()).is_ok());
+        let round_trip = validate(&settings, &capabilities()).expect("reported settings re-apply");
+        // What a stored workspace does on restore. The rate alone would put the filter at
+        // 1.75 MHz here anyway, but the width the radio was actually at is what has to come
+        // back — a reported setting that re-applies as a *different* one is the whole defect
+        // `settings_from_config` exists to prevent.
+        assert_eq!(round_trip.sample_rate_hz, Some(2_000_000));
+        assert_eq!(round_trip.filter, Some(FilterWidth::Hz(1_750_000)));
     }
 }

--- a/crates/device-hackrf/src/convert.rs
+++ b/crates/device-hackrf/src/convert.rs
@@ -14,7 +14,7 @@
 
 use sdrmm_device::{LutConverter, Sample};
 
-use crate::driver::RX_TRANSFER_SIZE;
+use crate::driver::{RX_TRANSFER_SIZE, SWEEP_BLOCK_SAMPLES};
 
 /// Half the code span of a signed 8-bit sample, so −128..=127 maps to −1.0..=0.992.
 const FULL_SCALE: f32 = 128.0;
@@ -36,6 +36,13 @@ const fn build_table() -> [f32; 256] {
 /// A converter for one capture thread, sized so a whole transfer fits without growing.
 pub(crate) fn converter() -> LutConverter {
     LutConverter::new(&CODE_TO_F32, RX_TRANSFER_SIZE / 2)
+}
+
+/// A converter for a sweep, which is fed one located block at a time rather than a whole
+/// transfer — the samples either side of a retune belong to different frequencies and must
+/// never be handed downstream as one run.
+pub(crate) fn sweep_converter() -> LutConverter {
+    LutConverter::new(&CODE_TO_F32, SWEEP_BLOCK_SAMPLES)
 }
 
 /// One sample to its transmit code. Non-finite input becomes silence rather than a wrapped

--- a/crates/device-hackrf/src/driver/commands.rs
+++ b/crates/device-hackrf/src/driver/commands.rs
@@ -16,6 +16,7 @@ pub(crate) enum VendorRequest {
     SetVgaGain = 20,
     SetTxVgaGain = 21,
     AntennaEnable = 23,
+    InitSweep = 26,
     GetBufferSize = 61,
 }
 
@@ -26,4 +27,6 @@ pub(crate) enum TransceiverMode {
     Off = 0,
     Receive = 1,
     Transmit = 2,
+    /// Receive while the firmware retunes itself between blocks (`hackrf_sweep`'s mode).
+    RxSweep = 5,
 }

--- a/crates/device-hackrf/src/driver/config.rs
+++ b/crates/device-hackrf/src/driver/config.rs
@@ -9,6 +9,21 @@ const DEFAULT_LNA_GAIN_DB: u8 = 8;
 const DEFAULT_VGA_GAIN_DB: u8 = 20;
 const DEFAULT_TX_VGA_GAIN_DB: u8 = 0;
 
+/// Every width the MAX2837's baseband filter can actually be programmed to, ascending —
+/// libhackrf's `max2837_ft` table. The part has no continuous cutoff, so a width off this list
+/// has no register encoding at all and the firmware would substitute one of its own.
+pub(crate) const FILTER_WIDTHS_HZ: [u32; 16] = [
+    1_750_000, 2_500_000, 3_500_000, 5_000_000, 5_500_000, 6_000_000, 7_000_000, 8_000_000,
+    9_000_000, 10_000_000, 12_000_000, 14_000_000, 15_000_000, 20_000_000, 24_000_000, 28_000_000,
+];
+
+/// Fraction of the sample rate the filter is set to, as a rational so the arithmetic is exact.
+/// libhackrf's `hackrf_set_sample_rate_manual` picks `0.75 × rate`: three quarters of the
+/// complex bandwidth is what is left flat after the filter's own transition, so the passband is
+/// usable to its edges instead of rolling off inside the span the client is shown.
+const FILTER_RATE_FRACTION_NUM: u64 = 3;
+const FILTER_RATE_FRACTION_DEN: u64 = 4;
+
 /// What the radio holds.
 ///
 /// A plain value record with no invariants of its own — validation lives on the `Device`
@@ -29,6 +44,9 @@ pub(crate) struct Config {
     /// MAX2837 transmit VGA gain in dB. Powers up at zero, so a transmit that was never asked
     /// for cannot reach the antenna at full drive.
     pub(crate) tx_vga_gain_db: u8,
+    /// Width the MAX2837 baseband filter is programmed to, in Hz — always one of
+    /// [`FILTER_WIDTHS_HZ`], whether it was asked for or derived from the sample rate.
+    pub(crate) filter_width_hz: u32,
     /// Whether the RF amplifier is on.
     pub(crate) amp_enabled: bool,
     /// Whether the antenna port is powered.
@@ -43,6 +61,7 @@ impl Default for Config {
             lna_gain_db: DEFAULT_LNA_GAIN_DB,
             vga_gain_db: DEFAULT_VGA_GAIN_DB,
             tx_vga_gain_db: DEFAULT_TX_VGA_GAIN_DB,
+            filter_width_hz: filter_width_for_rate(DEFAULT_SAMPLE_RATE_HZ),
             amp_enabled: false,
             bias_tee_enabled: false,
         }
@@ -69,6 +88,38 @@ pub(crate) fn validate_sample_rate(value: u32) -> Result<()> {
         Err(Error::invalid_config(
             "sample_rate_hz",
             "must be between 2 MHz and 20 MHz inclusive",
+        ))
+    }
+}
+
+/// The widest listed filter that is no wider than `bandwidth_hz`, or the narrowest one when the
+/// request is under the whole table — libhackrf's `hackrf_compute_baseband_filter_bw`. Rounding
+/// *down* is the safe direction: a filter wider than asked for passes energy the caller said it
+/// did not want, while a narrower one only costs span.
+pub(crate) fn snap_filter_width(bandwidth_hz: u32) -> u32 {
+    FILTER_WIDTHS_HZ
+        .iter()
+        .rev()
+        .copied()
+        .find(|width| *width <= bandwidth_hz)
+        .unwrap_or(FILTER_WIDTHS_HZ[0])
+}
+
+/// The width the filter is carried to by a sample rate of `sample_rate_hz`.
+pub(crate) fn filter_width_for_rate(sample_rate_hz: u32) -> u32 {
+    let target = u64::from(sample_rate_hz) * FILTER_RATE_FRACTION_NUM / FILTER_RATE_FRACTION_DEN;
+    snap_filter_width(target as u32)
+}
+
+/// The filter takes only the widths its register encodes; [`snap_filter_width`] is how a caller
+/// turns an arbitrary request into one.
+pub(crate) fn validate_filter_width(value: u32) -> Result<()> {
+    if FILTER_WIDTHS_HZ.contains(&value) {
+        Ok(())
+    } else {
+        Err(Error::invalid_config(
+            "filter_width_hz",
+            "must be one of the MAX2837 baseband filter widths, 1.75 MHz through 28 MHz",
         ))
     }
 }
@@ -121,8 +172,53 @@ mod tests {
         assert_eq!(config.lna_gain_db, 8);
         assert_eq!(config.vga_gain_db, 20);
         assert_eq!(config.tx_vga_gain_db, 0);
+        // 0.75 × 10 Msps is 7.5 MHz, which the table has no entry for.
+        assert_eq!(config.filter_width_hz, 7_000_000);
         assert!(!config.amp_enabled);
         assert!(!config.bias_tee_enabled);
+    }
+
+    /// Golden vectors against libhackrf's `hackrf_compute_baseband_filter_bw`, which is what
+    /// every other host tool snaps with — a HackRF opened here and in `hackrf_transfer` must
+    /// land on the same filter.
+    #[test]
+    fn filter_widths_snap_down_onto_the_max2837_table() {
+        assert_eq!(snap_filter_width(1_750_000), 1_750_000);
+        assert_eq!(snap_filter_width(2_499_999), 1_750_000);
+        assert_eq!(snap_filter_width(2_500_000), 2_500_000);
+        assert_eq!(snap_filter_width(7_500_000), 7_000_000);
+        assert_eq!(snap_filter_width(28_000_000), 28_000_000);
+        assert_eq!(snap_filter_width(100_000_000), 28_000_000);
+        // Under the narrowest entry libhackrf returns the first one rather than nothing.
+        assert_eq!(snap_filter_width(0), 1_750_000);
+        assert_eq!(snap_filter_width(1_000_000), 1_750_000);
+    }
+
+    /// Every listed width is its own snap, so the table and the snapping cannot disagree.
+    #[test]
+    fn every_listed_width_snaps_to_itself_and_validates() {
+        for width in FILTER_WIDTHS_HZ {
+            assert_eq!(snap_filter_width(width), width);
+            assert!(validate_filter_width(width).is_ok(), "{width}");
+        }
+        for off_table in [0, 1_000_000, 7_500_000, 11_000_000, 28_000_001] {
+            assert!(validate_filter_width(off_table).is_err(), "{off_table}");
+        }
+    }
+
+    /// The rate-derived width is 0.75 × rate snapped down, and never wider than the rate
+    /// itself — a filter wider than the complex bandwidth would alias its own skirts back in.
+    #[test]
+    fn the_rate_derived_width_is_three_quarters_of_the_rate() {
+        assert_eq!(filter_width_for_rate(2_000_000), 1_750_000);
+        assert_eq!(filter_width_for_rate(8_000_000), 6_000_000);
+        assert_eq!(filter_width_for_rate(10_000_000), 7_000_000);
+        assert_eq!(filter_width_for_rate(20_000_000), 15_000_000);
+        for rate in (2_000_000..=20_000_000).step_by(250_000) {
+            let width = filter_width_for_rate(rate);
+            assert!(width <= rate, "{width} Hz filter at {rate} Hz");
+            assert!(validate_filter_width(width).is_ok(), "rate {rate}");
+        }
     }
 
     #[test]

--- a/crates/device-hackrf/src/driver/control.rs
+++ b/crates/device-hackrf/src/driver/control.rs
@@ -100,6 +100,19 @@ impl VendorControlRequest {
         )
     }
 
+    /// Arm the firmware's sweep. Like the bandwidth request the 32-bit argument — here the
+    /// bytes captured per tuning — straddles `wValue`/`wIndex`, while the range list travels as
+    /// the data stage; the firmware reads the range count back out of the transfer *length*, so
+    /// the payload must be exactly `9 + 4 × ranges` bytes.
+    pub(crate) fn init_sweep(bytes_per_tuning: u32, payload: Vec<u8>) -> Self {
+        Self::out_request(
+            VendorRequest::InitSweep,
+            bytes_per_tuning as u16,
+            (bytes_per_tuning >> 16) as u16,
+            payload,
+        )
+    }
+
     pub(crate) fn set_lna_gain(gain_db: u8) -> Self {
         Self::in_request(VendorRequest::SetLnaGain, 0, u16::from(gain_db), 1)
     }
@@ -282,6 +295,19 @@ mod tests {
         let request = VendorControlRequest::set_baseband_bandwidth(20_000_000);
         assert_eq!(request.value, 20_000_000_u32 as u16);
         assert_eq!(request.index, (20_000_000_u32 >> 16) as u16);
+    }
+
+    /// The dwell straddles the two 16-bit control fields the same way the bandwidth does, and
+    /// the payload is passed through untouched — the firmware counts ranges from its length.
+    #[test]
+    fn init_sweep_splits_the_dwell_and_carries_the_range_list() {
+        let payload = vec![0xaa; 13];
+        let request = VendorControlRequest::init_sweep(0x0004_0000, payload.clone());
+        assert_eq!(request.request, VendorRequest::InitSweep);
+        assert_eq!(request.value, 0x0000);
+        assert_eq!(request.index, 0x0004);
+        assert_eq!(request.data, payload);
+        assert_eq!(request.length, 13);
     }
 
     #[test]

--- a/crates/device-hackrf/src/driver/mod.rs
+++ b/crates/device-hackrf/src/driver/mod.rs
@@ -1,5 +1,6 @@
 //! The HackRF driver itself: USB enumeration, the vendor control protocol, the validated
-//! configuration the radio holds, and the RX stream lifecycle.
+//! configuration the radio holds, and the stream lifecycles — plain receive, transmit, and the
+//! firmware's self-retuning sweep.
 //!
 //! Everything here is device-level and knows nothing about the wire capability model — `caps` is
 //! the only place that translates. Streaming is not here either: the transfer queue and the USB
@@ -19,11 +20,14 @@ mod control;
 mod discovery;
 mod error;
 mod radio;
+mod sweep;
 mod tx;
 mod types;
 
-pub(crate) use config::Config;
+pub(crate) use config::{Config, FILTER_WIDTHS_HZ, snap_filter_width};
 pub(crate) use discovery::DeviceDescriptor;
 pub(crate) use error::Error;
 pub(crate) use radio::{HackRf, RX_TRANSFER_SIZE};
+pub(crate) use sweep::{BLOCK_SAMPLES as SWEEP_BLOCK_SAMPLES, SweepBlocks};
+pub use sweep::{SweepPlan, SweepRange, SweepStyle};
 pub(crate) use tx::{BurstQueue, TX_TRANSFER_SIZE};

--- a/crates/device-hackrf/src/driver/radio.rs
+++ b/crates/device-hackrf/src/driver/radio.rs
@@ -13,6 +13,7 @@ use super::{
     },
     discovery::{self, DeviceDescriptor},
     error::{Error, Result},
+    sweep::{SweepPlan, TRANSFER_BYTES as SWEEP_TRANSFER_SIZE},
     tx::BurstQueue,
     types::{BoardId, DeviceInfo},
 };
@@ -33,6 +34,12 @@ const RX_CHANNEL_DEPTH: usize = 8;
 /// Firmware older than USB API 1.18 cannot be asked for its buffer size; libhackrf assumes this.
 const DEFAULT_FLUSH_SIZE: usize = 32 * 1024;
 
+/// USB API the sweep request and the sweep transceiver mode arrived in, as libhackrf's
+/// `USB_API_REQUIRED` gates them. Below these the firmware answers the request with a stall,
+/// which reads as a plain I/O error and says nothing about why.
+const SWEEP_INIT_USB_API: u16 = 0x0102;
+const SWEEP_MODE_USB_API: u16 = 0x0104;
+
 /// An opened HackRF.
 ///
 /// Every setter writes through to the radio and only then updates [`HackRf::config`], so the
@@ -49,6 +56,8 @@ pub(crate) struct HackRf {
     /// Length of the zero-filled transfer that marks the end of a transmit burst, as the
     /// firmware reports it.
     flush_size: usize,
+    /// What the firmware answered on open, for the requests that only newer firmware has.
+    usb_api_version: u16,
 }
 
 impl HackRf {
@@ -108,6 +117,7 @@ impl HackRf {
             control,
             config: Config::default(),
             flush_size,
+            usb_api_version,
         };
         // The radio powers up with no usable tuning, so the defaults are written through and the
         // reported configuration is true from the first read.
@@ -139,19 +149,38 @@ impl HackRf {
         Ok(())
     }
 
-    /// Set the complex sample rate, and the baseband filter to match it.
+    /// Set the complex sample rate, and carry the baseband filter to match it.
     ///
-    /// The two are one operation on purpose: a filter left at the old width either folds
-    /// out-of-band energy into a wider passband or clips a narrower one.
+    /// A filter left at the old width either folds out-of-band energy into a wider passband or
+    /// clips a narrower one, so the rate takes it along — libhackrf's `set_sample_rate_manual`
+    /// does the same. A caller that wants a different width sets it *after* the rate, in the
+    /// same batch; nothing here remembers a width across a later rate change, because the width
+    /// this leaves behind is reported back and shows up on the control the client renders.
+    /// (The RTL-SDR path has to remember one instead: librtlsdr never says what its tuner
+    /// picked, so a revert there would be invisible rather than merely automatic.)
     pub(crate) fn set_sample_rate_hz(&mut self, sample_rate_hz: u32) -> Result<()> {
         config::validate_sample_rate(sample_rate_hz)?;
         self.control
             .control_out(&VendorControlRequest::set_sample_rate(sample_rate_hz))?;
-        self.control
-            .control_out(&VendorControlRequest::set_baseband_bandwidth(
-                sample_rate_hz,
-            ))?;
         self.config.sample_rate_hz = sample_rate_hz;
+        self.write_filter_width(config::filter_width_for_rate(sample_rate_hz))
+    }
+
+    /// Set the MAX2837 baseband filter to one of its own widths, independent of the sample rate.
+    pub(crate) fn set_filter_width_hz(&mut self, width_hz: u32) -> Result<()> {
+        config::validate_filter_width(width_hz)?;
+        self.write_filter_width(width_hz)
+    }
+
+    /// Move the filter to the width the current sample rate implies.
+    pub(crate) fn set_filter_to_match_rate(&mut self) -> Result<()> {
+        self.write_filter_width(config::filter_width_for_rate(self.config.sample_rate_hz))
+    }
+
+    fn write_filter_width(&mut self, width_hz: u32) -> Result<()> {
+        self.control
+            .control_out(&VendorControlRequest::set_baseband_bandwidth(width_hz))?;
+        self.config.filter_width_hz = width_hz;
         Ok(())
     }
 
@@ -215,6 +244,40 @@ impl HackRf {
         config.channel_depth = RX_CHANNEL_DEPTH;
         let stream = sdrmm_usb_stream::start(endpoint, config)?;
         self.select(TransceiverMode::Receive)?;
+        Ok(stream)
+    }
+
+    /// Start the firmware's own sweep.
+    ///
+    /// The plan is validated and armed *before* the stream exists, so a plan the firmware would
+    /// stall on costs nothing and leaves the radio switched off. After this the LPC owns the
+    /// tuning: [`Config::frequency_hz`] is whatever was last written by hand and is not where
+    /// the radio is, which is why every block carries its own frequency instead.
+    pub(crate) fn start_rx_sweep(&mut self, plan: &SweepPlan) -> Result<RxStream> {
+        if self.usb_api_version < SWEEP_INIT_USB_API {
+            return Err(Error::invalid_config(
+                "sweep",
+                "the firmware is older than USB API 1.02 and has no sweep request",
+            ));
+        }
+        if self.usb_api_version < SWEEP_MODE_USB_API {
+            return Err(Error::invalid_config(
+                "sweep",
+                "the firmware is older than USB API 1.04 and has no sweep transceiver mode",
+            ));
+        }
+        let (bytes_per_tuning, payload) = plan.encode()?;
+        // Whatever the radio was doing, it is not doing it now: the firmware reads its sweep
+        // range list once, when the mode is selected, so arming it mid-stream would arm the
+        // wrong thing.
+        self.set_mode_off()?;
+        self.control
+            .control_out(&VendorControlRequest::init_sweep(bytes_per_tuning, payload))?;
+        let endpoint = NusbBulkIn::open(self.control.interface(), RX_ENDPOINT)?;
+        let mut config = StreamConfig::new(SWEEP_TRANSFER_SIZE, "sdrmm-hackrf-sweep");
+        config.channel_depth = RX_CHANNEL_DEPTH;
+        let stream = sdrmm_usb_stream::start(endpoint, config)?;
+        self.select(TransceiverMode::RxSweep)?;
         Ok(stream)
     }
 

--- a/crates/device-hackrf/src/driver/sweep.rs
+++ b/crates/device-hackrf/src/driver/sweep.rs
@@ -1,0 +1,502 @@
+//! The firmware's own sweep: what to ask it for, and how to read what comes back.
+//!
+//! In sweep mode the LPC retunes the radio itself between captures, so a wideband survey costs
+//! one control transfer instead of a host round trip per step — the retune happens inside the
+//! ~760 µs the M0 spends discarding buffers, which no host-driven scanner can match.
+//!
+//! What arrives on the bulk endpoint is no longer a plain sample stream. It is a run of
+//! [`BLOCK_BYTES`]-sized blocks, each stamped with the frequency it was captured at, because the
+//! host no longer knows where the radio is pointing:
+//!
+//! ```text
+//! 0        2                       10                                  16384
+//! | 7f 7f  | sweep_freq, u64 LE Hz  | interleaved signed 8-bit IQ ...   |
+//! ```
+//!
+//! Two things about that stamp are easy to get wrong, and both are load-bearing:
+//!
+//! - It is the *low edge* the firmware is sweeping from, not the tuned centre. The radio sits at
+//!   `sweep_freq + offset` ([`SweepPlan::offset_hz`]) — see [`SweepBlock::tuned_hz`].
+//! - A pass wraps silently. The way to see it is the way `hackrf_sweep` sees it: the stamp comes
+//!   back to the first range's start.
+//!
+//! Everything here is pure. The plan is encoded and the blocks are parsed without touching USB,
+//! which is the only way any of it is testable (PLAN §14: no hardware in CI, ever).
+
+use super::error::{Error, Result};
+
+/// Bytes the firmware emits per capture, header included. Fixed in `usb_api_sweep.c` as the M0's
+/// buffer size; the dwell request is denominated in these and nothing else divides evenly.
+pub(crate) const BLOCK_BYTES: usize = 16_384;
+/// Frequency stamp: two magic bytes then a little-endian `u64` of Hz.
+const HEADER_BYTES: usize = 10;
+/// IQ pairs one block carries once its stamp is stripped.
+pub(crate) const BLOCK_SAMPLES: usize = (BLOCK_BYTES - HEADER_BYTES) / 2;
+/// USB transfer size a sweep streams at. A whole number of blocks, because a transfer that
+/// ended mid-block would split a capture across two deliveries and strand the half without the
+/// stamp; sixteen of them is the same 256 KiB the plain receive path runs at, which is what the
+/// shared transport's queue depth and error policy are tuned for.
+pub(crate) const TRANSFER_BYTES: usize = 16 * BLOCK_BYTES;
+/// What marks the start of a block. A transfer that does not begin with it is out of step with
+/// the firmware's framing, and its samples belong to no frequency anyone can name.
+const MAGIC: [u8; 2] = [0x7f, 0x7f];
+/// Ranges the firmware has room for (`MAX_RANGES` in `usb_api_sweep.c`).
+const MAX_RANGES: usize = 10;
+/// The firmware keeps its range list as whole MHz in a `u16`, so nothing finer can be asked for.
+const RANGE_GRANULARITY_HZ: u64 = 1_000_000;
+/// Tuner limits, as [`config::validate_frequency`] enforces them for a manual tune.
+const FREQ_MIN_HZ: u64 = 1_000_000;
+const FREQ_MAX_HZ: u64 = 6_000_000_000;
+
+/// How the firmware walks a range.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SweepStyle {
+    /// One tuning per `step_width_hz`, in order.
+    Linear = 0,
+    /// Tunings alternate `+step/4` and `+3·step/4`, so the two quarter-band slices either side
+    /// of the tuned centre tile the range without a gap. This is what `hackrf_sweep` runs, and
+    /// the reason it can cover a band with a filter narrower than the sample rate.
+    #[default]
+    Interleaved = 1,
+}
+
+/// One span to sweep. Inclusive of `start_hz`, exclusive of `stop_hz` — the firmware advances
+/// while the *next* tuning would still be below the top, so the last capture sits under it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SweepRange {
+    pub start_hz: u64,
+    pub stop_hz: u64,
+}
+
+/// What the firmware is asked to sweep, and how.
+///
+/// Construct it with [`SweepPlan::interleaved`] unless you have a reason not to: the defaults
+/// there are `hackrf_sweep`'s, and they are the ones the slice arithmetic below assumes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SweepPlan {
+    pub ranges: Vec<SweepRange>,
+    /// Captures per tuning. One is `hackrf_sweep`'s default and the fastest possible sweep;
+    /// more trades sweep rate for averaging depth at each step.
+    pub blocks_per_tuning: u32,
+    /// How far the firmware advances between tunings.
+    pub step_width_hz: u32,
+    /// Distance from the stamped frequency to the tuned centre.
+    pub offset_hz: u32,
+    pub style: SweepStyle,
+}
+
+impl SweepPlan {
+    /// `hackrf_sweep`'s geometry at `sample_rate_hz`: step a whole passband at a time and tune
+    /// three eighths of it above the stamp, which is what puts the two usable quarter-band
+    /// slices at `[stamp, stamp + rate/4]` and `[stamp + rate/2, stamp + 3·rate/4]` and lets
+    /// consecutive interleaved tunings tile a range with no gap and no overlap.
+    #[must_use]
+    pub fn interleaved(ranges: Vec<SweepRange>, sample_rate_hz: u32) -> Self {
+        Self {
+            ranges,
+            blocks_per_tuning: 1,
+            step_width_hz: sample_rate_hz,
+            offset_hz: (u64::from(sample_rate_hz) * 3 / 8) as u32,
+            style: SweepStyle::Interleaved,
+        }
+    }
+
+    /// Bytes the firmware captures per tuning, which is how the dwell is expressed on the wire.
+    fn bytes_per_tuning(&self) -> u64 {
+        u64::from(self.blocks_per_tuning) * BLOCK_BYTES as u64
+    }
+
+    /// Reject everything the firmware would stall on, plus the arithmetic traps it would take
+    /// silently — before any control transfer runs, so a bad plan cannot leave the radio in
+    /// sweep mode with a range list it will never finish.
+    fn validate(&self) -> Result<()> {
+        if self.ranges.is_empty() || self.ranges.len() > MAX_RANGES {
+            return Err(Error::invalid_config(
+                "sweep ranges",
+                "a sweep needs between 1 and 10 ranges",
+            ));
+        }
+        if self.blocks_per_tuning == 0 {
+            return Err(Error::invalid_config(
+                "blocks_per_tuning",
+                "each tuning must capture at least one block",
+            ));
+        }
+        if u32::try_from(self.bytes_per_tuning()).is_err() {
+            return Err(Error::invalid_config(
+                "blocks_per_tuning",
+                "the dwell must fit in the request's 32-bit byte count",
+            ));
+        }
+        if self.step_width_hz == 0 {
+            return Err(Error::invalid_config(
+                "step_width_hz",
+                "the sweep must advance by at least 1 Hz per tuning",
+            ));
+        }
+        // The firmware advances an interleaved sweep by `step/4` then `3·step/4`, each an
+        // integer division: a step that is not a multiple of four loses the remainder every
+        // pair of tunings and the sweep walks off its own grid.
+        if self.style == SweepStyle::Interleaved && !self.step_width_hz.is_multiple_of(4) {
+            return Err(Error::invalid_config(
+                "step_width_hz",
+                "an interleaved sweep steps in quarters, so the width must be a multiple of 4 Hz",
+            ));
+        }
+        for range in &self.ranges {
+            self.validate_range(range)?;
+        }
+        Ok(())
+    }
+
+    fn validate_range(&self, range: &SweepRange) -> Result<()> {
+        if !range.start_hz.is_multiple_of(RANGE_GRANULARITY_HZ)
+            || !range.stop_hz.is_multiple_of(RANGE_GRANULARITY_HZ)
+        {
+            return Err(Error::invalid_config(
+                "sweep range",
+                "the firmware holds range bounds as whole MHz",
+            ));
+        }
+        if range.start_hz < FREQ_MIN_HZ || range.stop_hz > FREQ_MAX_HZ {
+            return Err(Error::invalid_config(
+                "sweep range",
+                "must be between 1 MHz and 6 GHz inclusive",
+            ));
+        }
+        if range.start_hz >= range.stop_hz {
+            return Err(Error::invalid_config(
+                "sweep range",
+                "must end above where it starts",
+            ));
+        }
+        // Conservative by up to one step: the highest tuning is the last stamp *below* the top
+        // plus the offset, so this refuses a plan whose final tunings would ask the synthesizer
+        // for a frequency it cannot reach — where the firmware would simply fail to lock and
+        // hand back blocks of noise stamped with a frequency the radio was never on.
+        if range.stop_hz + u64::from(self.offset_hz) > FREQ_MAX_HZ {
+            return Err(Error::invalid_config(
+                "sweep range",
+                "the tuning offset carries the top of this range past 6 GHz",
+            ));
+        }
+        Ok(())
+    }
+
+    /// The validated request: the `wValue`/`wIndex` byte count and the payload, in libhackrf's
+    /// `hackrf_init_sweep` layout.
+    pub(crate) fn encode(&self) -> Result<(u32, Vec<u8>)> {
+        self.validate()?;
+        let mut data = Vec::with_capacity(9 + self.ranges.len() * 4);
+        data.extend_from_slice(&self.step_width_hz.to_le_bytes());
+        data.extend_from_slice(&self.offset_hz.to_le_bytes());
+        data.push(self.style as u8);
+        for range in &self.ranges {
+            for bound in [range.start_hz, range.stop_hz] {
+                let mhz = (bound / RANGE_GRANULARITY_HZ) as u16;
+                data.extend_from_slice(&mhz.to_le_bytes());
+            }
+        }
+        Ok((self.bytes_per_tuning() as u32, data))
+    }
+
+    /// Where a pass starts over. `hackrf_sweep` counts a sweep complete when the stamp comes
+    /// back to it, and a consumer here has nothing else to go on.
+    #[must_use]
+    pub fn first_stamp_hz(&self) -> Option<u64> {
+        self.ranges.first().map(|range| range.start_hz)
+    }
+}
+
+/// One capture, located.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SweepBlock<'a> {
+    /// The firmware's own stamp: the low edge of the span this capture covers.
+    pub(crate) stamp_hz: u64,
+    /// Where the radio actually was — the stamp plus the plan's offset.
+    pub(crate) tuned_hz: u64,
+    /// The capture, interleaved signed 8-bit IQ, header stripped.
+    ///
+    /// `hackrf_sweep` reads only the *tail* of this: the retune that precedes a block settles
+    /// during it, so the last samples are the trustworthy ones. A consumer that wants one FFT
+    /// per tuning should take its window from the end.
+    pub(crate) iq: &'a [u8],
+}
+
+/// The blocks in one USB transfer, in order.
+///
+/// Blocks that do not carry the magic are skipped rather than decoded, exactly as
+/// `hackrf_sweep` does: a transfer that has slipped out of the firmware's framing holds samples
+/// belonging to no announced frequency, and guessing one would put a signal on the wrong dial.
+pub(crate) struct SweepBlocks<'a> {
+    rest: &'a [u8],
+    offset_hz: u64,
+}
+
+impl<'a> SweepBlocks<'a> {
+    pub(crate) const fn new(transfer: &'a [u8], offset_hz: u64) -> Self {
+        Self {
+            rest: transfer,
+            offset_hz,
+        }
+    }
+}
+
+impl<'a> Iterator for SweepBlocks<'a> {
+    type Item = SweepBlock<'a>;
+
+    fn next(&mut self) -> Option<SweepBlock<'a>> {
+        loop {
+            let (block, rest) = self.rest.split_at_checked(BLOCK_BYTES)?;
+            self.rest = rest;
+            let (header, iq) = block.split_at(HEADER_BYTES);
+            let (magic, stamp) = header.split_at(MAGIC.len());
+            // Both `Option`s are `Some` for any [`BLOCK_BYTES`] slice; matching rather than
+            // asserting keeps the framing check and the decode in one expression.
+            let (Some(stamp), true) = (stamp.first_chunk::<8>(), magic == MAGIC) else {
+                continue;
+            };
+            let stamp_hz = u64::from_le_bytes(*stamp);
+            return Some(SweepBlock {
+                stamp_hz,
+                tuned_hz: stamp_hz.saturating_add(self.offset_hz),
+                iq,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start_mhz: u64, stop_mhz: u64) -> SweepRange {
+        SweepRange {
+            start_hz: start_mhz * 1_000_000,
+            stop_hz: stop_mhz * 1_000_000,
+        }
+    }
+
+    fn plan() -> SweepPlan {
+        SweepPlan::interleaved(vec![range(88, 108)], 20_000_000)
+    }
+
+    /// The geometry `hackrf_sweep` runs with, spelled out — a different offset silently moves
+    /// every measurement by megahertz.
+    #[test]
+    fn the_interleaved_default_is_hackrf_sweeps_geometry() {
+        let plan = plan();
+        assert_eq!(plan.step_width_hz, 20_000_000);
+        assert_eq!(plan.offset_hz, 7_500_000);
+        assert_eq!(plan.blocks_per_tuning, 1);
+        assert_eq!(plan.style, SweepStyle::Interleaved);
+    }
+
+    /// Golden bytes against libhackrf's `hackrf_init_sweep`: four bytes of step width, four of
+    /// offset, the style, then the range bounds as little-endian MHz pairs.
+    #[test]
+    fn a_plan_encodes_in_libhackrfs_layout() {
+        let (bytes_per_tuning, data) = plan().encode().expect("a valid plan");
+        assert_eq!(bytes_per_tuning, 16_384);
+        assert_eq!(data.len(), 9 + 4);
+        assert_eq!(&data[0..4], &20_000_000_u32.to_le_bytes());
+        assert_eq!(&data[4..8], &7_500_000_u32.to_le_bytes());
+        assert_eq!(data[8], 1, "interleaved");
+        assert_eq!(&data[9..11], &88_u16.to_le_bytes());
+        assert_eq!(&data[11..13], &108_u16.to_le_bytes());
+    }
+
+    /// The firmware reads its range count out of the request length, so every extra range must
+    /// add exactly four bytes and nothing else may.
+    #[test]
+    fn each_range_adds_one_le_mhz_pair() {
+        let mut plan = plan();
+        plan.ranges.push(range(430, 440));
+        plan.style = SweepStyle::Linear;
+        let (_, data) = plan.encode().expect("two ranges");
+        assert_eq!(data.len(), 9 + 8);
+        assert_eq!(data[8], 0, "linear");
+        assert_eq!(&data[13..15], &430_u16.to_le_bytes());
+        assert_eq!(&data[15..17], &440_u16.to_le_bytes());
+        // What the firmware divides back out to get the range count.
+        assert_eq!((data.len() - 9) / 4, 2);
+    }
+
+    /// A dwell is denominated in whole blocks because that is the only unit the firmware's
+    /// `num_bytes / 0x4000` divides evenly.
+    #[test]
+    fn the_dwell_is_a_whole_number_of_blocks() {
+        let mut plan = plan();
+        plan.blocks_per_tuning = 8;
+        assert_eq!(plan.encode().expect("eight blocks").0, 8 * 16_384);
+    }
+
+    #[test]
+    fn a_plan_the_firmware_would_stall_on_is_refused() {
+        let cases: Vec<(&str, SweepPlan)> = vec![
+            ("no ranges", SweepPlan::interleaved(Vec::new(), 20_000_000)),
+            (
+                "eleven ranges",
+                SweepPlan::interleaved(
+                    (0..11).map(|i| range(100 + i * 2, 101 + i * 2)).collect(),
+                    20_000_000,
+                ),
+            ),
+            (
+                "zero dwell",
+                SweepPlan {
+                    blocks_per_tuning: 0,
+                    ..plan()
+                },
+            ),
+            (
+                "zero step",
+                SweepPlan {
+                    step_width_hz: 0,
+                    ..plan()
+                },
+            ),
+            // Interleaved stepping divides by four; a remainder walks the sweep off its grid.
+            (
+                "odd step",
+                SweepPlan {
+                    step_width_hz: 20_000_001,
+                    ..plan()
+                },
+            ),
+            (
+                "sub-MHz bound",
+                SweepPlan {
+                    ranges: vec![SweepRange {
+                        start_hz: 88_500_000,
+                        stop_hz: 108_000_000,
+                    }],
+                    ..plan()
+                },
+            ),
+            (
+                "inverted",
+                SweepPlan {
+                    ranges: vec![range(108, 88)],
+                    ..plan()
+                },
+            ),
+            (
+                "empty range",
+                SweepPlan {
+                    ranges: vec![range(88, 88)],
+                    ..plan()
+                },
+            ),
+            (
+                "below the tuner",
+                SweepPlan {
+                    ranges: vec![SweepRange {
+                        start_hz: 0,
+                        stop_hz: 10_000_000,
+                    }],
+                    ..plan()
+                },
+            ),
+            (
+                "above the tuner",
+                SweepPlan {
+                    ranges: vec![range(5_000, 6_001)],
+                    ..plan()
+                },
+            ),
+            // 6000 MHz + a 7.5 MHz offset is past the synthesizer, whatever the range says.
+            (
+                "offset past the top",
+                SweepPlan {
+                    ranges: vec![range(5_900, 6_000)],
+                    ..plan()
+                },
+            ),
+        ];
+        for (name, plan) in cases {
+            assert!(plan.encode().is_err(), "{name} must be refused");
+        }
+    }
+
+    /// A linear sweep steps whole, so it has no multiple-of-four constraint to break.
+    #[test]
+    fn a_linear_sweep_takes_any_step_width() {
+        let plan = SweepPlan {
+            step_width_hz: 20_000_001,
+            style: SweepStyle::Linear,
+            ..plan()
+        };
+        assert!(plan.encode().is_ok());
+    }
+
+    fn block(stamp_hz: u64, magic: [u8; 2], fill: u8) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(BLOCK_BYTES);
+        bytes.extend_from_slice(&magic);
+        bytes.extend_from_slice(&stamp_hz.to_le_bytes());
+        bytes.resize(BLOCK_BYTES, fill);
+        bytes
+    }
+
+    #[test]
+    fn a_transfer_splits_into_stamped_blocks() {
+        let mut transfer = block(88_000_000, MAGIC, 0x11);
+        transfer.extend(block(93_000_000, MAGIC, 0x22));
+        let blocks: Vec<_> = SweepBlocks::new(&transfer, 7_500_000).collect();
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].stamp_hz, 88_000_000);
+        // The stamp is the low edge; the radio is three eighths of a passband above it.
+        assert_eq!(blocks[0].tuned_hz, 95_500_000);
+        assert_eq!(blocks[0].iq.len(), BLOCK_BYTES - HEADER_BYTES);
+        assert!(blocks[0].iq.iter().all(|byte| *byte == 0x11));
+        assert_eq!(blocks[1].stamp_hz, 93_000_000);
+        assert_eq!(blocks[1].tuned_hz, 100_500_000);
+    }
+
+    /// A block without the magic belongs to no announced frequency. Skipping it is what
+    /// `hackrf_sweep` does, and the alternative — decoding it under the previous stamp — would
+    /// draw a signal at a frequency the radio was never tuned to.
+    #[test]
+    fn blocks_without_the_magic_are_skipped_not_guessed() {
+        let mut transfer = block(88_000_000, [0x00, 0x00], 0x11);
+        transfer.extend(block(93_000_000, MAGIC, 0x22));
+        let blocks: Vec<_> = SweepBlocks::new(&transfer, 0).collect();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].stamp_hz, 93_000_000);
+    }
+
+    /// A short tail is not a block: half a capture stamped with half a frequency is worse than
+    /// no capture at all.
+    #[test]
+    fn a_partial_trailing_block_is_dropped() {
+        let mut transfer = block(88_000_000, MAGIC, 0x11);
+        transfer.extend_from_slice(&block(93_000_000, MAGIC, 0x22)[..BLOCK_BYTES - 1]);
+        let blocks: Vec<_> = SweepBlocks::new(&transfer, 0).collect();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].stamp_hz, 88_000_000);
+
+        assert_eq!(SweepBlocks::new(&[], 0).count(), 0);
+        assert_eq!(SweepBlocks::new(&[0x7f, 0x7f], 0).count(), 0);
+    }
+
+    /// Two framing invariants the reader depends on and cannot check at runtime: a transfer is
+    /// a whole number of blocks (so no capture is ever split across two of them), and a block's
+    /// payload is a whole number of IQ pairs (so the shared converter's carry byte — which
+    /// exists for short blocks and would shift every later sample by one — never engages).
+    #[test]
+    fn the_framing_divides_evenly_at_both_levels() {
+        assert_eq!(TRANSFER_BYTES % BLOCK_BYTES, 0);
+        assert_eq!((BLOCK_BYTES - HEADER_BYTES) % 2, 0);
+        assert_eq!(BLOCK_SAMPLES, 8_187);
+    }
+
+    #[test]
+    fn the_first_stamp_is_where_a_pass_starts_over() {
+        assert_eq!(plan().first_stamp_hz(), Some(88_000_000));
+        assert_eq!(
+            SweepPlan::interleaved(Vec::new(), 20_000_000).first_stamp_hz(),
+            None
+        );
+    }
+}

--- a/crates/device-hackrf/src/lib.rs
+++ b/crates/device-hackrf/src/lib.rs
@@ -367,6 +367,12 @@ impl HackRfDevice {
     /// sweep"), because the scanner measures off the device set's spectrum tap and a sweep
     /// produces a different shape of data entirely.
     ///
+    /// The sample rate must not change while the sweep runs: a plan's step and offset are
+    /// geometry derived from the rate the caller built it at, and the firmware would keep
+    /// walking the old grid over a new passband. Nothing enforces it here, because nothing
+    /// above this crate can hold a sweep and an [`SdrDevice::apply`] at the same time — whoever
+    /// wires §4 owns the device and owns this rule with it.
+    ///
     /// # Errors
     /// [`DeviceError::Unsupported`] for a plan the firmware would refuse or firmware too old to
     /// sweep, and [`DeviceError::Io`] if the radio will not start.

--- a/crates/device-hackrf/src/lib.rs
+++ b/crates/device-hackrf/src/lib.rs
@@ -3,8 +3,10 @@
 //! launch with no libhackrf, no libSoapySDR and no C dependency at all (PLAN §15).
 //!
 //! What it buys over the Soapy view of the same radio is the real per-stage gain model — LNA
-//! and VGA separately, each on its own MAX2837 step grid — plus the RF amplifier and
-//! antenna-port bias power as typed extras.
+//! and VGA separately, each on its own MAX2837 step grid — the baseband filter as a width of its
+//! own rather than a shadow of the sample rate, and the RF amplifier and antenna-port bias power
+//! as typed extras. The firmware's self-retuning sweep is here too, as
+//! [`HackRfDevice::sweep_start`]; nothing above this crate drives it yet.
 //!
 //! Four layers, in dependency order:
 //!
@@ -25,15 +27,16 @@
 //! transmit burst, and vice versa.
 
 use std::{
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard, mpsc::RecvTimeoutError},
     time::Duration,
 };
 
 use convert::samples_to_cs8;
-use driver::{BurstQueue, DeviceDescriptor, HackRf, TX_TRANSFER_SIZE};
+use driver::{BurstQueue, DeviceDescriptor, HackRf, SweepBlocks, TX_TRANSFER_SIZE};
+pub use driver::{SweepPlan, SweepRange, SweepStyle};
 use sdrmm_device::{
     Capture, CaptureConfig, CaptureRadio, DeviceDriver, DeviceError, Direction, DuplexState,
-    RxSink, Sample, SdrDevice, TxStream, lock, single_rx_sink,
+    LutConverter, RxSink, Sample, SampleConverter, SdrDevice, TxStream, lock, single_rx_sink,
 };
 use sdrmm_usb_stream::{NusbBulkOut, RxStream};
 use sdrmm_wire::{Capabilities, DeviceInfo, DeviceSettings};
@@ -247,8 +250,15 @@ fn write_to_hardware(device: &mut HackRf, applied: &caps::Applied) -> Result<(),
     if let Some(hz) = applied.frequency_hz {
         device.set_frequency_hz(hz).map_err(map_err)?;
     }
+    // Rate before filter, always: setting the rate moves the filter to match, so a width
+    // written first would be overwritten by the rate that came after it in the same delta.
     if let Some(rate) = applied.sample_rate_hz {
         device.set_sample_rate_hz(rate).map_err(map_err)?;
+    }
+    match applied.filter {
+        Some(caps::FilterWidth::Hz(hz)) => device.set_filter_width_hz(hz).map_err(map_err)?,
+        Some(caps::FilterWidth::MatchRate) => device.set_filter_to_match_rate().map_err(map_err)?,
+        None => {}
     }
     if let Some(db) = applied.lna_gain_db {
         device.set_lna_gain_db(db).map_err(map_err)?;
@@ -342,6 +352,40 @@ impl SdrDevice for HackRfDevice {
 }
 
 impl HackRfDevice {
+    /// Hand the tuning to the firmware and start sweeping.
+    ///
+    /// A sweep is a receive stream that retunes itself, so it takes the receive claim and is
+    /// arbitrated against everything else the radio could be doing: a capture running here is
+    /// [`DeviceError::AlreadyStreaming`], and a burst on the air is a
+    /// [`DeviceError::DuplexConflict`]. It deliberately does *not* go through [`Capture`]: that
+    /// supervisor's restart path re-arms with `start_rx`, which would silently drop a faulted
+    /// sweep back into a plain capture on one frequency — so a sweep that faults surfaces the
+    /// fault instead, and the caller decides.
+    ///
+    /// Not a wire setting, and reachable only from Rust — like [`SdrDevice::tx_start`]. Driving
+    /// it from the scanner is its own piece of work (FEATURES §4, "hardware-assisted wideband
+    /// sweep"), because the scanner measures off the device set's spectrum tap and a sweep
+    /// produces a different shape of data entirely.
+    ///
+    /// # Errors
+    /// [`DeviceError::Unsupported`] for a plan the firmware would refuse or firmware too old to
+    /// sweep, and [`DeviceError::Io`] if the radio will not start.
+    pub fn sweep_start(&mut self, plan: &SweepPlan) -> Result<HackRfSweep, DeviceError> {
+        lock(&self.duplex).claim(Direction::Rx)?;
+        match self.radio.lock().start_rx_sweep(plan) {
+            Ok(stream) => Ok(HackRfSweep {
+                radio: self.radio.clone(),
+                duplex: self.duplex.clone(),
+                stream: Some(stream),
+                decoder: SweepDecoder::new(u64::from(plan.offset_hz)),
+            }),
+            Err(e) => {
+                lock(&self.duplex).release(Direction::Rx);
+                Err(map_err(e))
+            }
+        }
+    }
+
     /// The transmit VGA, 0–47 dB. It powers up at zero and is set back to zero when the device
     /// is opened, so the radio cannot be made to radiate at drive by a mode change alone.
     ///
@@ -355,6 +399,127 @@ impl HackRfDevice {
             .lock()
             .set_tx_vga_gain_db(gain_db)
             .map_err(map_err)
+    }
+}
+
+/// One located capture from a running sweep.
+#[derive(Debug)]
+pub struct SweepCapture<'a> {
+    /// The firmware's own stamp: the low edge of the span this capture covers.
+    pub stamp_hz: u64,
+    /// Where the radio was — the stamp plus the plan's tuning offset.
+    pub tuned_hz: u64,
+    /// The capture. `hackrf_sweep` takes its FFT window from the *end* of this, because the
+    /// retune that precedes a block is still settling at the start of it.
+    pub samples: &'a [Sample],
+}
+
+/// The sample side of a sweep: one USB transfer in, its located captures out.
+///
+/// Split from [`HackRfSweep`] because it is the half with no radio in it, and therefore the half
+/// that can be tested at all (PLAN §14: no hardware in CI, ever). Everything the transport half
+/// adds is a `recv` and an error mapping.
+struct SweepDecoder {
+    /// Reused across blocks, so a running sweep allocates nothing.
+    converter: LutConverter,
+    offset_hz: u64,
+}
+
+impl SweepDecoder {
+    fn new(offset_hz: u64) -> Self {
+        Self {
+            converter: convert::sweep_converter(),
+            offset_hz,
+        }
+    }
+
+    fn decode(&mut self, transfer: &[u8], mut visit: impl FnMut(SweepCapture<'_>)) -> usize {
+        let mut delivered = 0;
+        for block in SweepBlocks::new(transfer, self.offset_hz) {
+            visit(SweepCapture {
+                stamp_hz: block.stamp_hz,
+                tuned_hz: block.tuned_hz,
+                samples: self.converter.convert(block.iq),
+            });
+            delivered += 1;
+        }
+        delivered
+    }
+}
+
+/// A running sweep. Dropping it takes the radio out of sweep mode.
+pub struct HackRfSweep {
+    radio: Arc<HackRfRadio>,
+    /// Released when the sweep ends, and only the receive half of it.
+    duplex: Arc<Mutex<DuplexState>>,
+    /// Taken by [`HackRfSweep::stop`]; `None` afterwards, so a stopped sweep neither yields more
+    /// blocks nor tears the radio down twice.
+    stream: Option<RxStream>,
+    decoder: SweepDecoder,
+}
+
+impl HackRfSweep {
+    /// Wait up to `timeout` for the next transfer and hand each located capture in it to
+    /// `visit`, returning how many there were.
+    ///
+    /// Zero means the timeout expired with nothing to show, which is not an error: it is how a
+    /// caller stays responsive to its own stop flag while the firmware works through a range
+    /// whose blocks the transport has not filled a transfer with yet.
+    ///
+    /// A visitor rather than an iterator because the sample buffer is reused between captures:
+    /// two blocks from one transfer are two different frequencies, and handing both out at once
+    /// would mean either an allocation per block or a caller holding a slice that has already
+    /// been overwritten.
+    ///
+    /// # Errors
+    /// [`DeviceError::Io`] once the stream is over — a fault, or a [`HackRfSweep::stop`] that
+    /// already happened.
+    pub fn read(
+        &mut self,
+        timeout: Duration,
+        visit: impl FnMut(SweepCapture<'_>),
+    ) -> Result<usize, DeviceError> {
+        let Some(stream) = self.stream.as_ref() else {
+            return Err(DeviceError::Io("sweep is stopped".to_string()));
+        };
+        let transfer = match stream.recv_timeout(timeout) {
+            Ok(transfer) => transfer,
+            Err(RecvTimeoutError::Timeout) => return Ok(0),
+            Err(RecvTimeoutError::Disconnected) => {
+                let reason = stream.error().map_or_else(
+                    || "sweep stream ended".to_string(),
+                    |error| format!("sweep stream failed: {error}"),
+                );
+                return Err(DeviceError::Io(reason));
+            }
+        };
+        Ok(self.decoder.decode(&transfer, visit))
+    }
+
+    /// Stop sweeping and give the radio back. Idempotent.
+    ///
+    /// # Errors
+    /// [`DeviceError::Io`] if the radio would not leave sweep mode. The claim is released
+    /// either way — a radio nobody can talk to must not also be a radio nobody can re-open.
+    pub fn stop(&mut self) -> Result<(), DeviceError> {
+        let Some(mut stream) = self.stream.take() else {
+            return Ok(());
+        };
+        // Mode off first: the firmware would otherwise keep filling transfers the pump is no
+        // longer draining, which is exactly the backlog `set_mode_off` before teardown avoids on
+        // the plain receive path.
+        let stopped = self.radio.lock().set_mode_off();
+        tracing::info!(stats = ?stream.stop(), "hackrf sweep finished");
+        lock(&self.duplex).release(Direction::Rx);
+        stopped.map_err(map_err)
+    }
+}
+
+impl Drop for HackRfSweep {
+    fn drop(&mut self) {
+        if let Err(e) = self.stop() {
+            tracing::debug!("hackrf sweep stop failed: {e}");
+        }
     }
 }
 
@@ -438,6 +603,14 @@ mod tests {
     use super::*;
 
     const SERIAL: u128 = 0x0000_0000_0000_0000_675c_62dc_3b2d_4b8b;
+
+    /// One firmware sweep block: the magic, the stamp, then `code` for every IQ byte.
+    fn sweep_block(stamp_hz: u64, code: u8) -> Vec<u8> {
+        let mut bytes = vec![0x7f, 0x7f];
+        bytes.extend_from_slice(&stamp_hz.to_le_bytes());
+        bytes.resize(16_384, code);
+        bytes
+    }
 
     fn descriptor(serial: Option<u128>, product_string: Option<&str>) -> DeviceDescriptor {
         DeviceDescriptor {
@@ -543,6 +716,62 @@ mod tests {
         // Releasing the receive claim frees the path, and nothing else.
         state.release(Direction::Rx);
         state.claim(Direction::Tx).expect("transmit");
+    }
+
+    /// Sixteen blocks per transfer, each stamped and converted on its own — a sweep's samples
+    /// are only meaningful next to the frequency they were captured at, so the reader must
+    /// never hand out a run that spans two of them.
+    #[test]
+    fn a_sweep_transfer_decodes_into_one_capture_per_block() {
+        let mut transfer = sweep_block(88_000_000, 0x7f);
+        transfer.extend(sweep_block(93_000_000, 0x80));
+        let mut decoder = SweepDecoder::new(7_500_000);
+        let mut seen = Vec::new();
+        let delivered = decoder.decode(&transfer, |capture| {
+            seen.push((
+                capture.stamp_hz,
+                capture.tuned_hz,
+                capture.samples.len(),
+                capture.samples[0],
+            ));
+        });
+        assert_eq!(delivered, 2);
+        assert_eq!(
+            seen,
+            vec![
+                // 0x7f and 0x80 are the extremes of the signed coding, so this also pins that
+                // the sweep path reads the same table the capture path does.
+                (
+                    88_000_000,
+                    95_500_000,
+                    8_187,
+                    Sample::new(127.0 / 128.0, 127.0 / 128.0)
+                ),
+                (93_000_000, 100_500_000, 8_187, Sample::new(-1.0, -1.0)),
+            ]
+        );
+    }
+
+    /// The decoder is fed whole transfers for the life of a sweep; a per-block allocation would
+    /// be one every 8187 samples at 20 Msps.
+    #[test]
+    fn a_running_sweep_does_not_allocate_per_block() {
+        let transfer = sweep_block(88_000_000, 0x00);
+        let mut decoder = SweepDecoder::new(0);
+        let mut first = None;
+        decoder.decode(&transfer, |capture| first = Some(capture.samples.as_ptr()));
+        let mut second = None;
+        decoder.decode(&transfer, |capture| second = Some(capture.samples.as_ptr()));
+        assert_eq!(first, second);
+    }
+
+    /// A transfer the firmware never framed yields nothing rather than samples at a guessed
+    /// frequency — the reader's count is what tells a caller its sweep is not producing.
+    #[test]
+    fn an_unframed_transfer_decodes_to_nothing() {
+        let mut decoder = SweepDecoder::new(0);
+        let delivered = decoder.decode(&vec![0u8; 16_384], |_| panic!("nothing to decode"));
+        assert_eq!(delivered, 0);
     }
 
     /// `tx_start` hands back a trait object, so the burst has to be object-safe — the property


### PR DESCRIPTION
Closes the two remaining HackRF gaps from FEATURES §2 ("HackRF independent baseband-filter bandwidth and hardware sweep mode").

## Scope

FEATURES has these as **two separate planned lines**: §2 line 40 (this one) and §4 "Hardware-assisted wideband sweep — today's scanner sweeps by retuning". This PR is line 40. Bandwidth lands end-to-end; the sweep lands at the driver level, exactly the way the transmit path already ships — fully implemented, fully tested, deliberately unreachable above `device-hackrf`. Wiring the scanner to it is §4's line and stays planned; both FEATURES entries are updated to say so.

**No wire types change**, so no OpenAPI or TS codegen churn: `DeviceSettings.bandwidth` and `Capabilities.bandwidths` already exist and `RadioSettings.tsx` already renders the select. Populating the list is the whole client story — zero frontend code.

## Baseband filter

`set_sample_rate_hz` issued `BASEBAND_FILTER_BANDWIDTH_SET` with the sample rate itself and there was no other way to reach the register, so `bandwidths` was empty and `validate` refused a bandwidth outright.

Two problems, not one. The width was not selectable — and the value written was wrong. libhackrf's `hackrf_set_sample_rate_manual` sets `hackrf_compute_baseband_filter_bw(0.75 × rate)`, because three quarters of the complex bandwidth is what is left flat after the filter's own transition. The old value asked for a filter *wider* than the passband it was there to bound, and did not match what the same radio does under `hackrf_transfer`.

- All sixteen MAX2837 widths (libhackrf's `max2837_ft` table) advertised in `Capabilities.bandwidths`.
- An off-grid request snaps **down** — a filter wider than asked for passes energy the caller said it did not want, a narrower one only costs span — and is *reported* at the width that landed, the same snap-and-report the gain stages already do.
- `bandwidth: 0` asks for whatever the rate implies, the same "0 = automatic" convention the RTL-SDR backend already uses. It is not in the `bandwidths` list, because a select offering "0 Hz" would read as a width rather than the absence of one.
- Out-of-range is still a refusal: a grid is a rounding, bounds are a contract.

**No sticky pin.** A rate change carries the filter with it, always. That is the opposite of the RTL-SDR path, which has to remember a pinned width — and the reason is the difference between the two: librtlsdr never reports what its tuner picked, so a revert there is *invisible*, while here the resulting width is reported and moves the control the client renders. It also means reported settings re-apply to the same width, which is what a stored workspace does on restore (asserted in `settings_mirror_the_drivers_applied_config`).

## Hardware sweep

`INIT_SWEEP` (vendor request **26** — 30 is `RESET`) and the `RX_SWEEP` transceiver mode (5), the plan encoded in libhackrf's `hackrf_init_sweep` layout, and a reader over the firmware's framing:

```
0        2                       10                                  16384
| 7f 7f  | sweep_freq, u64 LE Hz  | interleaved signed 8-bit IQ ...   |
```

- **The stamp is not the tuned centre.** It is the low edge the firmware is sweeping from; the radio sits at `stamp + offset`. `SweepCapture` carries both.
- Blocks without the magic are **skipped, not decoded** — as `hackrf_sweep` does. Decoding one under the previous stamp would draw a signal at a frequency the radio was never on.
- `SweepPlan::interleaved` reproduces `hackrf_sweep`'s geometry (step = rate, offset = 3/8 rate), which is what makes consecutive interleaved tunings tile a range with no gap.
- Validation mirrors every condition `usb_api_sweep.c` stalls on (1–10 ranges, dwell a non-zero whole number of 16 KiB blocks, step ≥ 1, whole-MHz bounds), plus two the firmware would take silently: the interleaved step's `step/4` + `3·step/4` integer division needs a multiple of four or the sweep walks off its own grid, and an offset that carries a range past 6 GHz would hand back noise stamped with a frequency the synthesizer never locked to.
- USB API gates (1.02 init, 1.04 mode) are refused by name rather than surfacing as a bare stall.

Lifecycle: a sweep takes the receive claim on the existing `DuplexState`, so it arbitrates against capture (`AlreadyStreaming`) and transmit (`DuplexConflict`). It deliberately does **not** go through `Capture` — that supervisor's restart path re-arms via `start_rx`, which would silently drop a faulted sweep back into a plain capture on one frequency.

## Tests

78 tests in the crate, up from 67, none needing hardware (PLAN §14):

- Filter table, snapping and the `0.75 × rate` derivation as **golden vectors against libhackrf's C**, including that every listed width snaps to itself and no derived width is ever wider than its rate.
- `init_sweep` control-transfer bytes against libhackrf's layout; the plan payload byte for byte, including the `(len - 9) / 4` the firmware divides back out to count ranges.
- Every stall condition refused, named case by case.
- Block parsing: stamps, tuned frequencies, skipped unframed blocks, dropped partial tails, and the two framing invariants the reader cannot check at runtime (a transfer is a whole number of blocks; a payload is a whole number of IQ pairs, so the shared converter's carry byte never engages).
- The sample half of the reader is split into a radio-free `SweepDecoder` so it is testable at all: one capture per block with the right stamp, the same code table the capture path uses, and no per-block allocation.

## Verification

`cargo xtask check` and `cargo xtask test` both green, codegen drift check clean (no wire change, as expected). Protocol details were taken from the current `greatscottgadgets/hackrf` sources rather than memory — `firmware/hackrf_usb/usb_api_sweep.c`, `host/libhackrf/src/hackrf.c`, `host/hackrf-tools/src/hackrf_sweep.c`.

**Not verified on hardware.** No HackRF was attached; the bandwidth path is a small change to setters the field session already exercised, but the sweep path has never run against a radio. That is stated plainly in the FEATURES entry rather than implied away.