### PR TITLE
Decoders: Mic-E, CTCSS/DCS on NFM, Mode S DF4/5/11/20/21

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -176,7 +176,7 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 - **[shipped]** RTTY — ITA2 with LTRS/FIGS and unshift-on-space, start/stop framing with stop-bit rejection, 45.45/50/75 baud, 170/450/850 Hz shifts
 - **[shipped]** Morse — envelope + adaptive keying slicer, element/gap clustering that tracks sending speed, unknown sequences surface as `*` rather than vanishing, pure noise decodes to nothing
 - **[shipped]** APRS / AX.25 — AFSK1200 and 9600 G3RUH, SSIDs and the has-been-repeated flag, TNC2 line, uncompressed and base-91 compressed positions, course/speed, `/A=` altitude
-- **[planned]** Mic-E position encoding — the one AX.25 form still undecoded (it yields a valid packet with no position rather than a wrong one)
+- **[shipped]** Mic-E — the one APRS form that is not a text format: six latitude digits and three indicator bits unpacked from the destination *callsign*, longitude/course/speed/symbol from an information field offset by 28, all 15 message codes named (and the standard/custom mixture the spec itself refuses to name), position ambiguity carried from the latitude into the longitude, telemetry told apart from status text, and the base-91 `xxx}` altitude
 - **[planned]** APRS *feature* — station/position collection, distinct from the channel
 - **[planned]** FLEX and further pager formats, ERMES
 - **[planned]** CW skimmer — every CW signal in the passband at once

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -158,7 +158,8 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 
 ## 10. Aviation & marine
 
-- **[shipped]** ADS-B + map — level-relative preamble correlation, Mode S CRC-24 with single-bit repair, DF17/18 only, identification, airborne/surface CPR position, velocity, Gillham and 25 ft altitude, bounded per-ICAO CPR cache
+- **[shipped]** ADS-B + map — level-relative preamble correlation, Mode S CRC-24 with single-bit repair, identification, airborne/surface CPR position, velocity, Gillham and 25 ft altitude, bounded per-ICAO CPR cache
+- **[shipped]** Mode S beyond the extended squitter — DF11 all-call replies, DF4/20 altitude and DF5/21 identity (squawk) replies, plus the BDS 2,0 callsign a Comm-B reply may carry. A roll-call reply keys its address onto the parity and so proves nothing by itself: it is decoded only when that address was proved in the clear (DF11/17/18) within the last minute, and single-bit repair is confined to the bare-parity formats where it cannot invent a different aircraft
 - **[shipped]** ADS-B at **any receiver rate 2–4 MHz** — the decoder meets the radio instead of the radio meeting the decoder: per-chip half-chip boundaries, eight sub-sample phase tables arbitrated by the CRC, and overlap-weighted energy per half-chip. Measured 0% → 100% at 2.048 Msps off-grid and band-limited (98% at 34 dB SNR); 2.000 Msps keeps a physical half-sample blind spot that real 2.048 receivers do not have
 - **[shipped]** AIS + map — GMSK via discriminator and Gaussian matched filter, NRZI + HDLC + CRC-16/X-25, types 1/2/3/5/18/24, `!AIVDM` output
 - **[shipped]** ACARS — MSK on an AM carrier, mirrored-spectrum tolerant, strict validation: character parity *and* the ARINC 618 CRC both pass or the block is dropped, uplink/downlink field layouts distinguished

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -147,7 +147,8 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 - **[planned]** WFM **stereo** — the audio path becomes two-channel end to end (PCM, Opus, frame layout, worklet)
 - **[planned]** ATV (analog TV)
 - **[planned]** Notch and audio filters per channel
-- **[planned]** CTCSS/DCS detection on NFM; Selcall (CCIR/ZVEI)
+- **[shipped]** CTCSS/DCS on NFM — the subaudible band decimated off the discriminator, a bank of 50 sliding correlators (half-second window, because the closest pair of standard tones is 2.3 Hz apart) and a DCS reader: Golay(23,12) at 134.4 bit/s, sliced against a tracked baseline so a carrier offset is not a decision threshold. Detect names what a repeater uses without gating; CTCSS and DCS gate on it, muting rather than skipping so the client's jitter buffer keeps its samples, and a 300 Hz highpass keeps the tone out of the audio it lets through. **The 83 standard DCS codes are part of the decoder, not a dropdown**: the code is cyclic, so a sliding window finds a valid word at all 23 alignments, and only that set reads back unambiguously — which is also why an inverted transmission comes out as the code's inverse-pair partner (023 ↔ 047) instead of needing a polarity switch
+- **[planned]** Selcall (CCIR/ZVEI)
 
 ## 9. Digital voice
 

--- a/crates/channels/src/adsb.rs
+++ b/crates/channels/src/adsb.rs
@@ -16,14 +16,22 @@
 //! (see [`Timing`]). dump1090 hard-codes the same two ideas for 2.4 Msps; this is the
 //! any-rate form of them.
 //!
-//! Only DF17/DF18 extended squitters are accepted. Every other downlink format overlays the
-//! aircraft address (or the interrogator id) on the parity, so a zero syndrome is not
-//! evidence that the frame is real — accepting them off-air would mean inventing aircraft.
+//! Which downlink formats are accepted is a question about *proof of identity*, not about
+//! parsing. DF17/18 extended squitters carry the address in the clear under a bare parity, so
+//! a clean frame proves itself outright. DF4/5/20/21 roll-call replies carry no address at
+//! all — it is only keyed onto the parity — so every 24-bit value reads as a valid frame and
+//! decoding one off-air unconditionally would mean inventing aircraft out of noise.
+//!
+//! So a roll-call reply is decoded only when the address recovered from its parity belongs to
+//! an aircraft a self-proving frame put on the air in the last [`ROLL_CALL_MAX_AGE_S`]
+//! seconds. That is what makes Mode S worth having here: an aircraft with a transponder but no
+//! ADS-B is heard through its all-call replies (DF11) and answers interrogations with altitude
+//! (DF4/20) and squawk (DF5/21), none of which an extended-squitter-only decoder ever sees.
 
 use std::sync::LazyLock;
 
 use num_complex::Complex;
-use sdrmm_dsp::{bits_be, mode_s_fix_single_bit, mode_s_syndrome};
+use sdrmm_dsp::{bits_be, mode_s_fix_single_bit, mode_s_overlay};
 use sdrmm_wire::{
     AdsbMessage, AdsbParams, ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent,
 };
@@ -152,6 +160,32 @@ impl Timing {
 const ICAO_OFFSET_BITS: usize = 8;
 const ME_OFFSET_BITS: usize = 32;
 
+/// The 3 bits after DF are the capability of an all-call reply (ICAO Annex 10 Vol IV
+/// §3.1.2.5.2.2.1) and the flight status of a surveillance reply (§3.1.2.6.5.1) — the same
+/// three bits, two unrelated meanings, hence two names for the one offset.
+const CAPABILITY_OFFSET_BITS: usize = 5;
+const FLIGHT_STATUS_OFFSET_BITS: usize = 5;
+/// A surveillance reply's header is DF(5) FS(3) DR(5) UM(6), and the 13-bit AC (DF4/20) or ID
+/// (DF5/21) field follows it. The Comm-B message field of a DF20/21 starts where an extended
+/// squitter's ME field does — both follow 32 header bits.
+const REPLY_FIELD_OFFSET_BITS: usize = 19;
+const MB_OFFSET_BITS: usize = ME_OFFSET_BITS;
+
+/// BDS 2,0 — "aircraft identification" — is the one Comm-B register worth sniffing for here:
+/// it holds the same 8-character callsign an extended squitter sends, for aircraft that never
+/// send one (DO-181E §2.2.19.1.12).
+const BDS_IDENTIFICATION: u64 = 0x20;
+
+/// Legal PI values in an all-call reply: bits 1–17 are zero and only the 3-bit code label and
+/// the 4-bit interrogator code remain (ICAO Annex 10 Vol IV §3.1.2.3.2.1.4).
+const ALL_CALL_PI_MAX: u32 = 0x7F;
+
+/// How long a self-proving frame vouches for its address. An aircraft in range sends all-call
+/// replies at every antenna sweep and extended squitters twice a second, so a minute is many
+/// missed frames — while an address that has gone quiet for one stops admitting replies that
+/// nothing else can attribute.
+const ROLL_CALL_MAX_AGE_S: f64 = 60.0;
+
 /// 6-bit identification charset (DO-260B §2.2.3.2.5.2): index 0 and the reserved ranges are
 /// `#`, 32 is a space.
 const IDENT_CHARSET: &[u8; 64] =
@@ -194,7 +228,12 @@ struct Aircraft {
     icao: u32,
     even: Option<CprFix>,
     odd: Option<CprFix>,
+    /// Stream position of the most recent accepted frame — the cache's eviction key.
     last: u64,
+    /// Stream position of the most recent frame that *proved* this address, which is a
+    /// stronger thing than having heard it: only a frame carrying the address in the clear
+    /// may vouch for a reply that carries it nowhere but on the parity.
+    proven: Option<u64>,
 }
 
 impl Aircraft {
@@ -204,6 +243,7 @@ impl Aircraft {
             even: None,
             odd: None,
             last: at,
+            proven: None,
         }
     }
 }
@@ -218,6 +258,8 @@ pub struct AdsbChannel {
     frame_span: usize,
     /// How far apart two CPR frames may be and still solve globally, in samples at this rate.
     cpr_pair_max_age: u64,
+    /// How long a proved address vouches for a roll-call reply, in samples at this rate.
+    roll_call_max_age: u64,
     /// Sample magnitudes: the tail of the previous block followed by the current one.
     mag: Vec<f32>,
     /// Absolute stream index of `mag[0]`.
@@ -381,14 +423,76 @@ fn gillham_altitude(ac12: u32) -> Option<i32> {
     (steps >= -12).then_some(steps * 100)
 }
 
-fn callsign(frame: &[u8]) -> Option<String> {
+/// 13-bit AC field of a DF4/DF20 altitude reply (ICAO Annex 10 Vol IV §3.1.2.6.5.4). It is the
+/// extended squitter's 12-bit field with an M bit inserted after A4: M clear means feet, and
+/// the Q bit below it then selects the 25 ft or Gillham encoding exactly as it does there.
+fn surveillance_altitude(ac13: u32) -> Option<i32> {
+    // All zero is "no altitude information", and the metric encoding M marks is not defined by
+    // the standard — reporting either as an altitude would be inventing one.
+    if ac13 == 0 || ac13 & 0x0040 != 0 {
+        return None;
+    }
+    barometric_altitude((ac13 & 0x1F80) >> 1 | (ac13 & 0x003F))
+}
+
+/// 13-bit ID field of a DF5/DF21 identity reply as the four octal digits a controller reads
+/// (ICAO Annex 10 Vol IV §3.1.2.6.7.1). Field order is C1 A1 C2 A2 C4 A4 X B1 D1 B2 D2 B4 D4,
+/// and each digit's bits are named for their weight, so the layout is an interleave rather
+/// than four consecutive triples.
+fn squawk(id13: u32) -> String {
+    let bit = |index: u32| (id13 >> (12 - index)) & 1;
+    let digit = |four: u32, two: u32, one: u32| bit(four) << 2 | bit(two) << 1 | bit(one);
+    let (a, b, c, d) = (
+        digit(5, 3, 1),
+        digit(11, 9, 7),
+        digit(4, 2, 0),
+        digit(12, 10, 8),
+    );
+    format!("{a}{b}{c}{d}")
+}
+
+/// Flight status of a surveillance reply, as the airborne/on-ground answer it contains
+/// (ICAO Annex 10 Vol IV §3.1.2.6.5.1). Codes 4 and 5 report the SPI ident pulse and say
+/// nothing about the air/ground state, so they leave it unknown rather than guessing.
+fn flight_status_on_ground(fs: u64) -> Option<bool> {
+    (fs <= 3).then_some(fs == 1 || fs == 3)
+}
+
+/// Capability field of an all-call reply (ICAO Annex 10 Vol IV §3.1.2.5.2.2.1): 4 and 5 are a
+/// level-2+ transponder declaring itself on the ground and airborne; 6 means it can be either
+/// and 0–3 say nothing.
+fn capability_on_ground(ca: u64) -> Option<bool> {
+    match ca {
+        4 => Some(true),
+        5 => Some(false),
+        _ => None,
+    }
+}
+
+/// The 8 six-bit characters starting at `offset_bits`, trailing pad removed. Both the extended
+/// squitter's identification field and the Comm-B identification register spell a callsign this
+/// way, at different offsets in different frames.
+fn callsign(frame: &[u8], offset_bits: usize) -> Option<String> {
     let mut text = String::with_capacity(8);
     for i in 0..8 {
-        let code = bits_be(frame, ME_OFFSET_BITS + 8 + i * 6, 6) as usize;
+        let code = bits_be(frame, offset_bits + i * 6, 6) as usize;
         text.push(char::from(*IDENT_CHARSET.get(code)?));
     }
     let trimmed = text.trim_end();
     (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+/// Callsign from a DF20/DF21 Comm-B reply, when its MB field reads as BDS 2,0.
+///
+/// A Comm-B register says nowhere which register it is, so this is a guess, checked twice: the
+/// leading octet must be the register's own code, and all 8 characters must be defined ones.
+/// A `#` means some other register was read as this one and the callsign would be an artefact.
+fn comm_b_callsign(frame: &[u8]) -> Option<String> {
+    if bits_be(frame, MB_OFFSET_BITS, 8) != BDS_IDENTIFICATION {
+        return None;
+    }
+    let text = callsign(frame, MB_OFFSET_BITS + 8)?;
+    (!text.contains('#')).then_some(text)
 }
 
 /// Airborne velocity, TC 19 subtypes 1 and 2 (DO-260B §2.2.3.2.6.1). Subtypes 3/4 report
@@ -570,6 +674,26 @@ fn cpr_local(fix: &CprFix, odd: bool, ref_lat: f64, ref_lon: f64, zone: f64) -> 
     Some((lat, lon))
 }
 
+/// The AA field: the aircraft address as DF11/17/18 transmit it, in the clear.
+fn clear_address(frame: &[u8]) -> u32 {
+    bits_be(frame, ICAO_OFFSET_BITS, 24) as u32
+}
+
+/// A DF4/5/20/21 reply to a ground interrogation. The 13-bit field after the header is an
+/// altitude in the altitude formats and an identity code in the identity ones; the Comm-B
+/// formats carry 56 further bits whose register the frame does not name.
+fn surveillance_reply(frame: &[u8], df: u8, msg: &mut AdsbMessage) {
+    msg.on_ground = flight_status_on_ground(bits_be(frame, FLIGHT_STATUS_OFFSET_BITS, 3));
+    let field = bits_be(frame, REPLY_FIELD_OFFSET_BITS, 13) as u32;
+    match df {
+        4 | 20 => msg.altitude_ft = surveillance_altitude(field),
+        _ => msg.squawk = Some(squawk(field)),
+    }
+    if matches!(df, 20 | 21) {
+        msg.callsign = comm_b_callsign(frame);
+    }
+}
+
 impl AdsbChannel {
     /// Cache slot for `icao`, evicting the least recently heard aircraft when full.
     fn slot(&mut self, icao: u32, at: u64) -> Option<&mut Aircraft> {
@@ -635,29 +759,66 @@ impl AdsbChannel {
         }
     }
 
-    fn message(&mut self, frame: &[u8], df: u8, at: u64) -> AdsbMessage {
-        let icao = bits_be(frame, ICAO_OFFSET_BITS, 24) as u32;
-        let type_code = bits_be(frame, ME_OFFSET_BITS, 5) as u8;
+    /// Note that `icao` was heard, and — for a frame carrying it in the clear — that it was
+    /// proved. Only the latter admits roll-call replies (see [`AdsbChannel::vouched`]).
+    fn observe(&mut self, icao: u32, at: u64, proved: bool) {
+        let Some(entry) = self.slot(icao, at) else {
+            return;
+        };
+        entry.last = at;
+        if proved {
+            entry.proven = Some(at);
+        }
+    }
+
+    /// Whether a frame recent enough to vouch for a roll-call reply has proved `icao`.
+    ///
+    /// A reply refreshes `last` — it is evidence the aircraft is still there, and the cache
+    /// should not evict it — but never `proven`: proof of identity does not decay into
+    /// hearsay, or one lucky parity match would keep a bogus address alive forever.
+    fn vouched(&self, icao: u32, at: u64) -> bool {
+        self.cpr.iter().any(|a| {
+            a.icao == icao
+                && a.proven
+                    .is_some_and(|t| at.abs_diff(t) <= self.roll_call_max_age)
+        })
+    }
+
+    fn message(&mut self, frame: &[u8], df: u8, icao: u32, at: u64) -> AdsbMessage {
         let mut msg = AdsbMessage {
             icao: format!("{icao:06X}"),
             df,
-            type_code: Some(type_code),
             raw: hex_upper(frame),
             ..AdsbMessage::default()
         };
+        match df {
+            17 | 18 => self.extended_squitter(frame, icao, at, &mut msg),
+            11 => {
+                msg.on_ground = capability_on_ground(bits_be(frame, CAPABILITY_OFFSET_BITS, 3));
+            }
+            _ => surveillance_reply(frame, df, &mut msg),
+        }
+        msg
+    }
+
+    /// The ME field of an extended squitter: what the aircraft chose to broadcast about
+    /// itself, selected by the 5-bit type code.
+    fn extended_squitter(&mut self, frame: &[u8], icao: u32, at: u64, msg: &mut AdsbMessage) {
+        let type_code = bits_be(frame, ME_OFFSET_BITS, 5) as u8;
+        msg.type_code = Some(type_code);
         let altitude = || bits_be(frame, ME_OFFSET_BITS + 8, 12) as u32;
         match type_code {
-            1..=4 => msg.callsign = callsign(frame),
+            1..=4 => msg.callsign = callsign(frame, ME_OFFSET_BITS + 8),
             5..=8 => {
                 msg.on_ground = Some(true);
-                self.fill_position(frame, icao, at, SURFACE_ZONE_DEG, &mut msg);
+                self.fill_position(frame, icao, at, SURFACE_ZONE_DEG, msg);
             }
             9..=18 => {
                 msg.on_ground = Some(false);
                 msg.altitude_ft = barometric_altitude(altitude());
-                self.fill_position(frame, icao, at, AIRBORNE_ZONE_DEG, &mut msg);
+                self.fill_position(frame, icao, at, AIRBORNE_ZONE_DEG, msg);
             }
-            19 => velocity(frame, &mut msg),
+            19 => velocity(frame, msg),
             // The type code selects the altitude *source* (GNSS height above the ellipsoid
             // rather than barometric), not its encoding: the AC12 field is the same Q-bit /
             // Gillham code in feet. Reading it as metres is the mode-s.org interpretation
@@ -667,17 +828,53 @@ impl AdsbChannel {
             20..=22 => {
                 msg.on_ground = Some(false);
                 msg.altitude_ft = barometric_altitude(altitude());
-                self.fill_position(frame, icao, at, AIRBORNE_ZONE_DEG, &mut msg);
+                self.fill_position(frame, icao, at, AIRBORNE_ZONE_DEG, msg);
             }
             _ => {}
         }
-        msg
+    }
+
+    /// Who sent this frame, and whether the frame itself is proof of it.
+    ///
+    /// `None` rejects the frame. Every accept here is a claim that an aircraft exists, so each
+    /// downlink format is admitted on the strength of its own parity and nothing weaker:
+    ///
+    /// - DF17/18 transmit their parity bare, so a clean frame is a 1-in-16-million coincidence
+    ///   away from certain, and the address sits in the clear beside it.
+    /// - DF11 keys the interrogator identifier onto the parity, leaving 17 bits bare. The
+    ///   address is still in the clear, and the residual 1-in-131-072 is what buys the aircraft
+    ///   that never send an extended squitter at all.
+    /// - DF4/5/20/21 key the *address* onto the parity, so the frame proves nothing by itself:
+    ///   every value reads as valid, and the recovered address has to have been proved
+    ///   already by one of the formats above.
+    fn attribute(&self, frame: &mut [u8], df: u8, at: u64) -> Option<(u32, bool)> {
+        match df {
+            17 | 18 => {
+                if mode_s_overlay(frame)? != 0 {
+                    // A flipped bit inside DF picks the wrong frame length, so the syndrome
+                    // cannot close over the right byte count: such frames are dropped, never
+                    // mis-repaired. Repair is for bare parity only — on an overlaid one it
+                    // would "fix" a real frame into a different aircraft's.
+                    if !self.crc_fix || mode_s_fix_single_bit(frame).is_none() {
+                        return None;
+                    }
+                }
+                Some((clear_address(frame), true))
+            }
+            11 => (mode_s_overlay(frame)? <= ALL_CALL_PI_MAX).then(|| (clear_address(frame), true)),
+            4 | 5 | 20 | 21 => {
+                let icao = mode_s_overlay(frame)?;
+                self.vouched(icao, at).then_some((icao, false))
+            }
+            _ => None,
+        }
     }
 
     /// Try to decode a frame starting at `at` in [`Self::mag`], returning the samples it
-    /// consumed. Every phase table gets its chance and the first CRC pass wins; `None` means
-    /// "not a frame here at any phase" and the scan advances one sample.
+    /// consumed. Every phase table gets its chance and the first accepted frame wins; `None`
+    /// means "not a frame here at any phase" and the scan advances one sample.
     fn try_frame(&mut self, at: usize, out: &mut ChannelOutputs) -> Option<usize> {
+        let stamp = self.stream_pos + at as u64;
         let mut hit = None;
         for timing in &self.timings {
             let Some(window) = self.mag.get(at..at + timing.frame_samples()) else {
@@ -689,27 +886,27 @@ impl AdsbChannel {
             let mut frame = [0u8; LONG_BYTES];
             slice_bits(timing, window, &mut frame);
 
-            let long = frame.first().is_some_and(|&b| b >> 3 >= 16);
-            let len = if long { LONG_BYTES } else { SHORT_BYTES };
+            let df = frame.first().map_or(0, |&b| b >> 3);
+            let len = if df >= 16 { LONG_BYTES } else { SHORT_BYTES };
             let Some(bytes) = frame.get_mut(..len) else {
                 continue;
             };
-            if mode_s_syndrome(bytes) != 0 {
-                // A flipped bit inside DF picks the wrong frame length, so the syndrome cannot
-                // close over the right byte count: such frames are dropped, never mis-repaired.
-                if !self.crc_fix || mode_s_fix_single_bit(bytes).is_none() {
-                    continue;
-                }
-            }
-            let df = bytes.first().map_or(0, |&b| b >> 3);
-            if df != 17 && df != 18 {
+            let Some((icao, proved)) = self.attribute(bytes, df, stamp) else {
                 continue;
-            }
-            hit = Some((frame, len, df, timing.start(PREAMBLE_CHIPS + len * 8 * 2)));
+            };
+            hit = Some((
+                frame,
+                len,
+                df,
+                icao,
+                proved,
+                timing.start(PREAMBLE_CHIPS + len * 8 * 2),
+            ));
             break;
         }
-        let (frame, len, df, consumed) = hit?;
-        let message = self.message(frame.get(..len)?, df, self.stream_pos + at as u64);
+        let (frame, len, df, icao, proved, consumed) = hit?;
+        self.observe(icao, stamp, proved);
+        let message = self.message(frame.get(..len)?, df, icao, stamp);
         out.events.push(DecoderEvent::Adsb(message));
         Some(consumed)
     }
@@ -732,6 +929,7 @@ impl ChannelRx for AdsbChannel {
             timings,
             frame_span,
             cpr_pair_max_age: (CPR_PAIR_MAX_AGE_S * ctx.input_rate) as u64,
+            roll_call_max_age: (ROLL_CALL_MAX_AGE_S * ctx.input_rate) as u64,
             mag: Vec::new(),
             stream_pos: 0,
             cpr: Vec::with_capacity(CPR_CACHE_LEN),
@@ -763,6 +961,13 @@ impl ChannelRx for AdsbChannel {
         // the longest phase table) behind them are scanned, and those are exactly the ones
         // dropped here, so results never depend on where the host cut the block — and no
         // frame is emitted twice.
+        //
+        // The window is the *long* frame's for every candidate, so a short reply (DF4/5/11)
+        // waits for a long frame's worth of samples — 232 µs — before the scan reaches it.
+        // On a live stream that is latency and nothing else; a capture that ends inside those
+        // 232 µs loses its last short frame. Decoding one earlier means scanning positions
+        // that a later block would have to be stopped from re-scanning, which is a watermark
+        // this decoder does not carry.
         let keep = self.mag.len().saturating_sub(frame_span - 1);
         self.mag.drain(..keep);
         self.stream_pos += keep as u64;
@@ -780,9 +985,10 @@ mod tests {
         testgen::{
             add_noise,
             adsb::{
-                me_airborne_position, me_airborne_position_gnss, me_identification,
-                me_surface_position, me_velocity, position_me_raw, squitter, transmission,
-                transmission_at_phase,
+                all_call_reply, altitude_reply, comm_b_altitude_reply, comm_b_identity_reply,
+                identity_reply, mb_identification, me_airborne_position, me_airborne_position_gnss,
+                me_identification, me_surface_position, me_velocity, position_me_raw, squitter,
+                transmission, transmission_at_phase,
             },
         },
         testutil::settings,
@@ -1253,11 +1459,246 @@ mod tests {
         let stale = chan.cpr_pair_max_age;
         let even = published("8D40621D58C382D690C8AC");
         let odd = published("8D40621D58C386435CC412");
-        assert!(chan.message(&even, 17, 0).lat.is_none());
-        assert!(chan.message(&odd, 17, stale + 1).lat.is_none());
+        let icao = 0x40_621D;
+        assert!(chan.message(&even, 17, icao, 0).lat.is_none());
+        assert!(chan.message(&odd, 17, icao, stale + 1).lat.is_none());
         // Fresh again once a new even frame arrives.
-        assert!(chan.message(&even, 17, stale + 2).lat.is_some());
+        assert!(chan.message(&even, 17, icao, stale + 2).lat.is_some());
         assert_eq!(chan.cpr.first().map(|a| a.icao), Some(0x40_621D));
+    }
+
+    // ── Mode S beyond the extended squitter ────────────────────────────────────────────────
+
+    /// A proving frame, so the roll-call replies under test have an address to be attributed
+    /// to. Everything after it in the same transmission is inside the vouching window.
+    fn proof(icao: u32) -> Vec<u8> {
+        squitter(icao, me_identification("DLH123"))
+    }
+
+    /// A short frame is only scanned once a long frame's worth of samples sits behind it (see
+    /// [`AdsbChannel::process`]), so a transmission ending on one leaves that much room —
+    /// otherwise "decoded nothing" would mean "the scan never got there".
+    fn decode_replies(p: AdsbParams, frames: &[Vec<u8>]) -> Vec<AdsbMessage> {
+        let iq = transmission(frames, 300.0, LEVEL, INPUT_RATE_HZ);
+        feed(&mut channel(p), &iq, &[4_096])
+    }
+
+    /// An all-call reply is self-proving — the address rides in the clear — so it needs no
+    /// help, and it is the only thing a Mode S aircraft that never squitters volunteers.
+    #[test]
+    fn an_all_call_reply_reports_the_aircraft_and_its_air_ground_state() {
+        for (capability, on_ground) in [(4, Some(true)), (5, Some(false)), (6, None), (0, None)] {
+            let msg = only(decode_replies(
+                AdsbParams::default(),
+                &[all_call_reply(0x3C_6444, capability, 0)],
+            ));
+            assert_eq!(msg.df, 11);
+            assert_eq!(msg.icao, "3C6444");
+            assert_eq!(msg.on_ground, on_ground, "capability {capability}");
+            // DF11 has no ME field, so claiming a type code would be reading the address as one.
+            assert_eq!(msg.type_code, None);
+        }
+    }
+
+    /// The interrogator identifier is keyed onto an all-call reply's parity, so the bits it
+    /// occupies are not evidence — but everything above them still is.
+    #[test]
+    fn an_all_call_reply_survives_its_interrogator_identifier() {
+        for interrogator in [0, 1, 15, ALL_CALL_PI_MAX] {
+            let msg = only(decode_replies(
+                AdsbParams::default(),
+                &[all_call_reply(0x40_621D, 5, interrogator)],
+            ));
+            assert_eq!(msg.icao, "40621D", "interrogator {interrogator}");
+        }
+        // Past the field the standard defines, the frame is indistinguishable from noise that
+        // happened to slice into 56 bits.
+        assert!(
+            decode_replies(
+                AdsbParams::default(),
+                &[all_call_reply(0x40_621D, 5, ALL_CALL_PI_MAX + 1)]
+            )
+            .is_empty()
+        );
+    }
+
+    /// The rule the whole roll-call path rests on. A DF4/5/20/21 reply carries its address
+    /// nowhere but on the parity, so *every* one of them checks out against *some* address —
+    /// decoding one unvouched would put an aircraft on the map that was never on the air.
+    #[test]
+    fn a_roll_call_reply_is_dropped_until_something_proves_the_address() {
+        let icao = 0x3C_6444;
+        let reply = altitude_reply(icao, 36_000, 0);
+
+        assert!(
+            decode_replies(AdsbParams::default(), std::slice::from_ref(&reply)).is_empty(),
+            "an unvouched reply must not become an aircraft"
+        );
+
+        let msgs = decode_replies(AdsbParams::default(), &[proof(icao), reply]);
+        assert_eq!(msgs.len(), 2, "{msgs:?}");
+        assert_eq!(msgs[1].df, 4);
+        assert_eq!(msgs[1].icao, "3C6444");
+        assert_eq!(msgs[1].altitude_ft, Some(36_000));
+    }
+
+    /// Proof expires: an address last seen in the clear a minute ago no longer vouches for a
+    /// reply that nothing else can attribute.
+    #[test]
+    fn proof_of_an_address_goes_stale() {
+        let mut chan = channel(AdsbParams::default());
+        let window = chan.roll_call_max_age;
+        chan.observe(0x3C_6444, 0, true);
+        assert!(chan.vouched(0x3C_6444, window));
+        assert!(!chan.vouched(0x3C_6444, window + 1));
+
+        // A reply refreshes the cache entry but not the proof — otherwise one lucky parity
+        // match would keep an address alive on the strength of frames that prove nothing.
+        chan.observe(0x3C_6444, window, false);
+        assert!(!chan.vouched(0x3C_6444, window + 1));
+    }
+
+    /// Noise cannot become an aircraft, and once one *is* on the whitelist it must not become
+    /// that aircraft's replies either: every 24-bit value is a legal roll-call address, so all
+    /// that stands between noise and a fabricated altitude is the preamble gate and the chance
+    /// of the recovered address being the one address that was proved.
+    #[test]
+    fn noise_does_not_become_replies_from_an_aircraft_already_known() {
+        let mut chan = channel(AdsbParams::default());
+        chan.observe(0x3C_6444, 0, true);
+        let mut iq = vec![Complex::new(0.0f32, 0.0); 4_000_000];
+        add_noise(&mut iq, 0x5EED_4321, 1.0);
+        assert!(feed(&mut chan, &iq, &[65_536]).is_empty());
+    }
+
+    /// Squawk is four octal digits interleaved bit by bit across the field; check the whole
+    /// code space rather than the three emergency codes everyone remembers.
+    #[test]
+    fn every_squawk_round_trips_through_an_identity_reply() {
+        let icao = 0x3C_6444;
+        let mut chan = channel(AdsbParams::default());
+        chan.observe(icao, 0, true);
+        for code in 0..4_096u32 {
+            let text = format!(
+                "{}{}{}{}",
+                code >> 9 & 7,
+                code >> 6 & 7,
+                code >> 3 & 7,
+                code & 7
+            );
+            let frame = identity_reply(icao, &text, 0);
+            let msg = chan.message(&frame, 5, icao, 0);
+            assert_eq!(msg.squawk.as_deref(), Some(text.as_str()));
+            assert_eq!(
+                msg.altitude_ft, None,
+                "an identity reply carries no altitude"
+            );
+        }
+    }
+
+    /// The AC13 field is the squitter's AC12 with an M bit wedged into it, so the same Q-bit
+    /// and Gillham paths have to come out of a different bit layout.
+    #[test]
+    fn a_surveillance_altitude_reply_decodes_on_both_sides_of_the_q_bit() {
+        let icao = 0x3C_6444;
+        let mut chan = channel(AdsbParams::default());
+        chan.observe(icao, 0, true);
+        for alt_ft in [-1_000, 0, 725, 36_000, 50_175, 50_200, 62_000] {
+            let frame = altitude_reply(icao, alt_ft, 0);
+            assert_eq!(
+                chan.message(&frame, 4, icao, 0).altitude_ft,
+                Some(alt_ft),
+                "{alt_ft} ft"
+            );
+        }
+        // An all-zero field is "no altitude information", not sea level.
+        assert_eq!(surveillance_altitude(0), None);
+        // M set selects metric units, whose encoding the standard leaves undefined.
+        assert_eq!(surveillance_altitude(0x0040 | 0x0010 | 0x0020), None);
+    }
+
+    /// Flight status is the only air/ground answer a surveillance reply carries, and two of
+    /// its codes report the ident pulse instead of answering at all.
+    #[test]
+    fn flight_status_answers_air_ground_only_when_it_says_so() {
+        let icao = 0x3C_6444;
+        let mut chan = channel(AdsbParams::default());
+        chan.observe(icao, 0, true);
+        for (fs, on_ground) in [
+            (0, Some(false)),
+            (1, Some(true)),
+            (2, Some(false)),
+            (3, Some(true)),
+            (4, None),
+            (5, None),
+        ] {
+            let frame = altitude_reply(icao, 5_000, fs);
+            assert_eq!(
+                chan.message(&frame, 4, icao, 0).on_ground,
+                on_ground,
+                "flight status {fs}"
+            );
+        }
+    }
+
+    /// Comm-B replies carry the surveillance field *and* 56 bits of register. BDS 2,0 is the
+    /// one worth reading: it is where an aircraft with no extended squitter puts its callsign.
+    #[test]
+    fn comm_b_replies_carry_the_surveillance_field_and_a_bds20_callsign() {
+        let icao = 0x40_621D;
+        let msgs = decode(
+            AdsbParams::default(),
+            &[
+                proof(icao),
+                comm_b_altitude_reply(icao, 24_000, 0, mb_identification("KLM1023")),
+                comm_b_identity_reply(icao, "7421", 1, mb_identification("KLM1023")),
+            ],
+        );
+        assert_eq!(msgs.len(), 3, "{msgs:?}");
+        let [_, altitude, identity] = &msgs[..] else {
+            unreachable!()
+        };
+        assert_eq!(altitude.df, 20);
+        assert_eq!(altitude.altitude_ft, Some(24_000));
+        assert_eq!(altitude.callsign.as_deref(), Some("KLM1023"));
+        assert_eq!(altitude.on_ground, Some(false));
+        assert_eq!(identity.df, 21);
+        assert_eq!(identity.squawk.as_deref(), Some("7421"));
+        assert_eq!(identity.callsign.as_deref(), Some("KLM1023"));
+        assert_eq!(identity.on_ground, Some(true));
+    }
+
+    /// A Comm-B register does not say which register it is, so reading one as BDS 2,0 is a
+    /// guess — and a guess that would otherwise turn any register into a plausible callsign.
+    #[test]
+    fn a_register_that_is_not_bds20_yields_no_callsign() {
+        let icao = 0x3C_6444;
+        let mut chan = channel(AdsbParams::default());
+        chan.observe(icao, 0, true);
+
+        // BDS 4,0 (selected vertical intention): a different code entirely.
+        let mut other = mb_identification("KLM1023");
+        other[0] = 0x40;
+        assert_eq!(
+            chan.message(&other_reply(icao, other), 20, icao, 0)
+                .callsign,
+            None
+        );
+
+        // The right code over characters the charset leaves undefined — the `#` the decoder
+        // must refuse rather than print.
+        let mut undefined = [0u8; 7];
+        undefined[0] = 0x20;
+        undefined[1] = 0xFF;
+        assert_eq!(
+            chan.message(&other_reply(icao, undefined), 20, icao, 0)
+                .callsign,
+            None
+        );
+    }
+
+    fn other_reply(icao: u32, mb: [u8; 7]) -> Vec<u8> {
+        comm_b_altitude_reply(icao, 10_000, 0, mb)
     }
 
     /// The NL table is 58 hand-typed constants; check every one of them against the closed

--- a/crates/channels/src/aprs.rs
+++ b/crates/channels/src/aprs.rs
@@ -353,6 +353,13 @@ fn parse_frame(frame: &[u8]) -> Option<AprsPacket> {
     Some(packet)
 }
 
+/// The 6 address characters without the SSID suffix [`decode_address`] appends. Mic-E reads
+/// them as data rather than as a callsign, and the SSID beside them carries a digipeater path
+/// this decoder has no use for.
+fn address_chars(call: &str) -> &str {
+    call.split('-').next().unwrap_or(call)
+}
+
 /// The TNC2 monitor line every APRS tool speaks: `SRC>DEST,PATH1,PATH2:info`.
 fn tnc2_line(packet: &AprsPacket) -> String {
     let mut line = String::with_capacity(packet.info.len() + 32);
@@ -385,17 +392,20 @@ struct Report {
 const TIMESTAMP_LEN: usize = 7;
 
 /// Fill in whatever the information field's data type identifier lets us read. Anything not
-/// recognised (status, messages, telemetry, Mic-E) leaves the packet with its raw info only.
+/// recognised (status, messages, telemetry) leaves the packet with its raw info only.
 fn apply_aprs(info: &[u8], packet: &mut AprsPacket) {
     let Some((kind, rest)) = info.split_first() else {
         return;
     };
-    let body = match kind {
-        b'!' | b'=' => Some(rest),
-        b'/' | b'@' => rest.get(TIMESTAMP_LEN..),
+    // Mic-E is the one form whose position is not in the information field alone: half of it
+    // is in the destination callsign, which is why it needs the packet rather than a slice.
+    let report = match *kind {
+        MIC_E_CURRENT | MIC_E_OLD | MIC_E_CURRENT_BETA | MIC_E_OLD_BETA => mic_e(rest, packet),
+        b'!' | b'=' => parse_position(rest),
+        b'/' | b'@' => rest.get(TIMESTAMP_LEN..).and_then(parse_position),
         _ => None,
     };
-    let Some(report) = body.and_then(parse_position) else {
+    let Some(report) = report else {
         return;
     };
     packet.lat = Some(report.lat);
@@ -540,6 +550,274 @@ fn compressed_course_speed(c: u8, s: u8) -> (Option<f64>, Option<f64>) {
     let course = f64::from(c - BASE91_MIN) * 4.0;
     let speed = 1.08_f64.powi(i32::from(s - BASE91_MIN)) - 1.0;
     (Some(course), Some(speed))
+}
+
+// ── Mic-E (APRS 1.0.1 ch. 10) ─────────────────────────────────────────────────────────────
+//
+// The one APRS form that is not a text format. The position is split across two fields that
+// were never meant to carry it: six latitude digits and three indicator bits ride in the
+// destination *callsign* (shifted ASCII, so every value stays a legal AX.25 address), and the
+// longitude, course, speed and symbol ride in an information field offset by 28 to keep it
+// almost printable. Neither half decodes without the other.
+
+/// Data type identifiers that open a Mic-E information field: current and old GPS data, and
+/// the two the Rev. 0 beta units send.
+const MIC_E_CURRENT: u8 = b'`';
+const MIC_E_OLD: u8 = b'\'';
+const MIC_E_CURRENT_BETA: u8 = 0x1C;
+const MIC_E_OLD_BETA: u8 = 0x1D;
+
+/// Longitude, speed/course, symbol code and symbol table id: the 8 bytes that must follow the
+/// data type identifier. Several of them are non-printing, and a link that drops those leaves
+/// a field that looks shorter than it is — which the spec says to ignore rather than decode a
+/// prefix of.
+const MIC_E_FIELD_LEN: usize = 8;
+
+/// Every value in the information field is transmitted with 28 added to it.
+const MIC_E_OFFSET: u8 = 28;
+
+/// Base-91 digits of the `xxx}` altitude are offset by 33, not by [`BASE91_MIN`]'s 33 for the
+/// same reason — but the datum is: metres above 10 km *below* mean sea level, the deepest
+/// ocean, so that no station on Earth needs a sign.
+const MIC_E_ALTITUDE_DATUM_M: i32 = 10_000;
+const MIC_E_ALTITUDE_LEN: usize = 4;
+const METRES_PER_FOOT: f64 = 0.304_8;
+
+/// How a destination character spells its message bit. The two tables of 1s are what makes a
+/// message standard or custom; `Zero` belongs to neither.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MessageBit {
+    Zero,
+    Standard,
+    Custom,
+}
+
+/// The half of a Mic-E report that rides in the destination callsign.
+struct MicEDestination {
+    /// Latitude magnitude in degrees; `north` carries the sign.
+    lat: f64,
+    north: bool,
+    /// The +100° the longitude degrees are computed with.
+    lon_offset: bool,
+    west: bool,
+    /// Trailing latitude digits blanked for position ambiguity, 0–4. The same count applies
+    /// to the longitude, which carries no ambiguity of its own.
+    ambiguity: usize,
+    /// The named message, or `None` where the three bits mix the two tables.
+    message: Option<&'static str>,
+}
+
+/// One destination character: its latitude digit (`None` under position ambiguity), the
+/// message bit it carries in bytes 1–3, and the indicator it carries in bytes 4–6 — one bit
+/// read three ways, as North, as +100° and as West.
+fn destination_char(c: u8) -> Option<(Option<u8>, MessageBit, bool)> {
+    match c {
+        b'0'..=b'9' => Some((Some(c - b'0'), MessageBit::Zero, false)),
+        b'A'..=b'J' => Some((Some(c - b'A'), MessageBit::Custom, false)),
+        b'K' => Some((None, MessageBit::Custom, false)),
+        b'L' => Some((None, MessageBit::Zero, false)),
+        b'P'..=b'Y' => Some((Some(c - b'P'), MessageBit::Standard, true)),
+        b'Z' => Some((None, MessageBit::Standard, true)),
+        _ => None,
+    }
+}
+
+const STANDARD_MESSAGES: [&str; 7] = [
+    "Priority",
+    "Special",
+    "Committed",
+    "Returning",
+    "In Service",
+    "En Route",
+    "Off Duty",
+];
+const CUSTOM_MESSAGES: [&str; 7] = [
+    "Custom-6", "Custom-5", "Custom-4", "Custom-3", "Custom-2", "Custom-1", "Custom-0",
+];
+
+/// Name the message the three bits select. All three zero is the emergency code in either
+/// table; a mixture of standard and custom 1s is a message the spec itself calls unknown, and
+/// naming it from one table would put words in an operator's mouth.
+fn message_type(bits: [MessageBit; 3]) -> Option<&'static str> {
+    let code = bits.iter().fold(0usize, |acc, &b| {
+        acc << 1 | usize::from(b != MessageBit::Zero)
+    });
+    if code == 0 {
+        return Some("Emergency");
+    }
+    let standard = bits.contains(&MessageBit::Standard);
+    let custom = bits.contains(&MessageBit::Custom);
+    match (standard, custom) {
+        (true, false) => STANDARD_MESSAGES.get(code - 1).copied(),
+        (false, true) => CUSTOM_MESSAGES.get(code - 1).copied(),
+        _ => None,
+    }
+}
+
+fn mic_e_destination(call: &str) -> Option<MicEDestination> {
+    let chars = address_chars(call).as_bytes();
+    if chars.len() != 6 {
+        return None;
+    }
+    let mut digits = [0u8; 6];
+    let mut bits = [MessageBit::Zero; 3];
+    let mut indicators = [false; 3];
+    let mut ambiguity = 0usize;
+    for (i, &c) in chars.iter().enumerate() {
+        let (digit, bit, indicator) = destination_char(c)?;
+        match digit {
+            // Ambiguity blanks digits from the right and a blanked digit is defined to read as
+            // zero, as it is in an uncompressed report; a digit *after* a blank is not
+            // ambiguity but a callsign that was never Mic-E.
+            Some(d) if ambiguity == 0 => digits[i] = d,
+            Some(_) => return None,
+            None => ambiguity += 1,
+        }
+        match i {
+            0..=2 => bits[i] = bit,
+            // A–K carry no indicator at all, so the spec does not use them here.
+            _ if bit == MessageBit::Custom => return None,
+            _ => indicators[i - 3] = indicator,
+        }
+    }
+    let degrees = f64::from(digits[0]) * 10.0 + f64::from(digits[1]);
+    let minutes = f64::from(digits[2]) * 10.0 + f64::from(digits[3]);
+    let hundredths = f64::from(digits[4]) * 10.0 + f64::from(digits[5]);
+    if degrees > 90.0 || minutes >= 60.0 {
+        return None;
+    }
+    Some(MicEDestination {
+        lat: degrees + (minutes + hundredths / 100.0) / 60.0,
+        north: indicators[0],
+        lon_offset: indicators[1],
+        west: indicators[2],
+        ambiguity,
+        message: message_type(bits),
+    })
+}
+
+/// Decode a Mic-E packet from its destination callsign and the information field after the
+/// data type identifier, naming the message on the packet as a side effect.
+fn mic_e(body: &[u8], packet: &mut AprsPacket) -> Option<Report> {
+    let destination = mic_e_destination(&packet.destination)?;
+    let report = mic_e_report(&destination, body)?;
+    packet.mic_e_message = destination.message.map(str::to_owned);
+    Some(report)
+}
+
+fn mic_e_report(destination: &MicEDestination, body: &[u8]) -> Option<Report> {
+    let field = body.get(..MIC_E_FIELD_LEN)?;
+    let value = |at: usize| field.get(at).and_then(|b| b.checked_sub(MIC_E_OFFSET));
+
+    let mut minutes = u32::from(value(1).filter(|&m| (10..=69).contains(&m))?);
+    // 0–9 minutes are encoded 60 higher, so that every byte of the field stays printable.
+    if minutes >= 60 {
+        minutes -= 60;
+    }
+    let mut hundredths = u32::from(value(2).filter(|&h| h <= 99)?);
+    let degrees = longitude_degrees(value(0)?, destination.lon_offset)?;
+    // Ambiguity is declared in the latitude and applies to the longitude unchanged: the same
+    // count of digits, from the right, carries no information.
+    if destination.ambiguity >= 1 {
+        hundredths -= hundredths % 10;
+    }
+    if destination.ambiguity >= 2 {
+        hundredths = 0;
+    }
+    if destination.ambiguity >= 3 {
+        minutes -= minutes % 10;
+    }
+    if destination.ambiguity >= 4 {
+        minutes = 0;
+    }
+    let lon = f64::from(degrees) + (f64::from(minutes) + f64::from(hundredths) / 100.0) / 60.0;
+    let (speed_kt, course_deg) = speed_course(value(3)?, value(4)?, value(5)?)?;
+    let symbol = symbol(*field.get(7)?, *field.get(6)?)?;
+    let status = body.get(MIC_E_FIELD_LEN..).unwrap_or_default();
+    let (comment, comment_alt_ft) = describe(mic_e_status(status));
+    Some(Report {
+        lat: if destination.north {
+            destination.lat
+        } else {
+            -destination.lat
+        },
+        lon: if destination.west { -lon } else { lon },
+        symbol,
+        course_deg,
+        speed_kt,
+        comment,
+        // An explicit `/A=` is the more precise statement of the two, as it is elsewhere.
+        altitude_ft: comment_alt_ft.or_else(|| mic_e_altitude_ft(status)),
+    })
+}
+
+/// Longitude degrees, 0–179. Four disjoint pieces of the byte range are folded into one
+/// number by the +100 the destination carries and two subtractions (APRS 1.0.1 ch. 10).
+fn longitude_degrees(raw: u8, offset: bool) -> Option<u32> {
+    if !(10..=99).contains(&raw) {
+        return None;
+    }
+    let mut degrees = u32::from(raw) + if offset { 100 } else { 0 };
+    if (180..=189).contains(&degrees) {
+        degrees -= 80;
+    } else if (190..=199).contains(&degrees) {
+        degrees -= 190;
+    }
+    Some(degrees)
+}
+
+/// Speed in knots and course in degrees, spread across three bytes: tens of knots, then units
+/// of knots *and* hundreds of degrees sharing a byte, then tens and units of degrees. The two
+/// subtractions at the end are what let the middle byte stay printable under either of the two
+/// encoding schemes in the field.
+fn speed_course(sp: u8, dc: u8, se: u8) -> Option<(Option<f64>, Option<f64>)> {
+    if sp > 99 || dc > 99 || se > 99 {
+        return None;
+    }
+    let mut speed = u32::from(sp) * 10 + u32::from(dc) / 10;
+    let mut course = u32::from(dc) % 10 * 100 + u32::from(se);
+    if speed >= 800 {
+        speed -= 800;
+    }
+    if course >= 400 {
+        course -= 400;
+    }
+    if course > 360 {
+        return None;
+    }
+    // 0° is "course unknown or indefinite" and 360° is due north (APRS 1.0.1 ch. 10), so the
+    // one value that must not be reported as a heading is the one that looks most like one.
+    let course_deg = (course != 0).then(|| f64::from(course % 360));
+    Some((Some(f64::from(speed)), course_deg))
+}
+
+/// The status text without the type code a Kenwood radio prefixes it with, which is a device
+/// marker rather than something the operator typed.
+fn mic_e_status(status: &[u8]) -> &[u8] {
+    match status.first().copied() {
+        // A telemetry flag here means the rest is telemetry channels, not text at all.
+        Some(MIC_E_CURRENT | MIC_E_OLD | MIC_E_OLD_BETA) => &[],
+        Some(b'>' | b']') => status.get(1..).unwrap_or_default(),
+        _ => status,
+    }
+}
+
+/// `xxx}` at the head of the status text: three base-91 digits of metres above 10 km below
+/// mean sea level. Only at the head — a `}` anywhere in free text would otherwise turn the
+/// three characters before it into an altitude.
+fn mic_e_altitude_ft(status: &[u8]) -> Option<i32> {
+    let field = mic_e_status(status).get(..MIC_E_ALTITUDE_LEN)?;
+    if *field.get(3)? != b'}' {
+        return None;
+    }
+    let mut metres = 0i32;
+    for &b in field.get(..3)? {
+        if !(BASE91_MIN..=BASE91_MAX).contains(&b) {
+            return None;
+        }
+        metres = metres * 91 + i32::from(b - BASE91_MIN);
+    }
+    Some(((f64::from(metres - MIC_E_ALTITUDE_DATUM_M) / METRES_PER_FOOT).round()) as i32)
 }
 
 fn symbol(table: u8, code: u8) -> Option<String> {
@@ -754,6 +1032,197 @@ fn baud(mode: AprsMode) -> f64 {
         AprsMode::Afsk1200 => AFSK_BAUD,
         AprsMode::G3ruh9600 => G3RUH_BAUD,
     }
+}
+
+// ── Mic-E reference encoder ───────────────────────────────────────────────────────────────
+
+/// Which of the two tables of 1s a Mic-E message bit is drawn from (APRS 1.0.1 ch. 10).
+///
+/// The encoder below shares no code with the decoder above it — its tables are written out
+/// forwards from the spec rather than inverted from the decoder's, because a generator that
+/// derived them from the thing under test could only ever agree with itself.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MicEBit {
+    #[default]
+    Zero,
+    Standard,
+    Custom,
+}
+
+/// A Mic-E position report, as the fields a transmitter holds before it packs them into a
+/// destination callsign and an information field.
+#[derive(Clone, Copy, Debug)]
+pub struct MicE<'a> {
+    pub lat: f64,
+    pub lon: f64,
+    /// 0–799 knots.
+    pub speed_kt: u32,
+    /// 0–360 degrees. 0 means "unknown or indefinite"; due north is 360.
+    pub course_deg: u32,
+    /// Symbol table identifier then symbol code, e.g. `/j` for a jeep — the order an APRS
+    /// symbol is quoted in, which is the reverse of the order Mic-E transmits it.
+    pub symbol: &'a str,
+    /// Message bits A, B and C.
+    pub bits: [MicEBit; 3],
+    /// Latitude digits blanked from the right for position ambiguity, 0–4.
+    pub ambiguity: usize,
+    /// Whatever follows the mandatory 8 bytes: status text, an altitude field, telemetry.
+    pub status: &'a str,
+}
+
+impl Default for MicE<'_> {
+    fn default() -> Self {
+        Self {
+            lat: 0.0,
+            lon: 0.0,
+            speed_kt: 0,
+            course_deg: 0,
+            symbol: "/>",
+            bits: [MicEBit::Zero; 3],
+            ambiguity: 0,
+            status: "",
+        }
+    }
+}
+
+impl MicE<'_> {
+    /// The destination callsign: six latitude digits, each carrying one further bit.
+    #[must_use]
+    pub fn destination(&self) -> String {
+        let digits = hundredths_of_a_minute(self.lat);
+        // Bytes 1–3 carry the message bits; 4–6 carry North, +100° and West.
+        let carried = [
+            self.bits[0],
+            self.bits[1],
+            self.bits[2],
+            indicator(self.lat >= 0.0),
+            indicator(!(10.0..100.0).contains(&self.lon.abs().trunc())),
+            indicator(self.lon < 0.0),
+        ];
+        (0..6)
+            .map(|i| {
+                let ambiguous = i + self.ambiguity >= 6;
+                encode_destination_char(digits[i], carried[i], ambiguous)
+            })
+            .collect()
+    }
+
+    /// The information field, data type identifier included.
+    #[must_use]
+    pub fn info(&self) -> String {
+        // Longitude degrees can need three digits, so only the minutes and hundredths of the
+        // split are read here; the degrees come from the value itself.
+        let digits = hundredths_of_a_minute(self.lon);
+        let minutes = u32::from(digits[2]) * 10 + u32::from(digits[3]);
+        let hundredths = u32::from(digits[4]) * 10 + u32::from(digits[5]);
+        let symbol = self.symbol.as_bytes();
+        let longitude = [
+            longitude_degrees_byte(self.lon.abs().trunc() as u32),
+            longitude_minutes_byte(minutes),
+            (hundredths + 28) as u8,
+        ];
+
+        let mut out = String::with_capacity(9 + self.status.len());
+        out.push('`');
+        for byte in longitude
+            .into_iter()
+            .chain(speed_course_bytes(self.speed_kt, self.course_deg))
+        {
+            out.push(char::from(byte));
+        }
+        // Transmitted symbol code first, table identifier second — the reverse of the order
+        // the pair is written in everywhere else in APRS.
+        out.push(char::from(symbol.get(1).copied().unwrap_or(b'>')));
+        out.push(char::from(symbol.first().copied().unwrap_or(b'/')));
+        out.push_str(self.status);
+        out
+    }
+}
+
+impl MicE<'_> {
+    /// The `xxx}` altitude field a status text may open with: metres above 10 km below mean
+    /// sea level, base 91, each digit offset by 33.
+    #[must_use]
+    pub fn altitude_field(alt_ft: i32) -> String {
+        let metres = (f64::from(alt_ft) * 0.304_8).round() as i32 + 10_000;
+        let clamped = metres.clamp(0, 91 * 91 * 91 - 1);
+        let digits = [clamped / (91 * 91), clamped / 91 % 91, clamped % 91];
+        digits
+            .iter()
+            .map(|&d| char::from(d as u8 + 33))
+            .chain(std::iter::once('}'))
+            .collect()
+    }
+}
+
+/// A latitude or longitude split into its six digits: two of degrees, two of minutes, two of
+/// hundredths of a minute. Longitude degrees can need three digits, so the first two are only
+/// meaningful for a latitude — the caller takes what it needs.
+fn hundredths_of_a_minute(degrees: f64) -> [u8; 6] {
+    let total = (degrees.abs() * 6_000.0).round() as u32;
+    let (deg, minutes, hundredths) = (total / 6_000, total / 100 % 60, total % 100);
+    [
+        (deg / 10 % 10) as u8,
+        (deg % 10) as u8,
+        (minutes / 10) as u8,
+        (minutes % 10) as u8,
+        (hundredths / 10) as u8,
+        (hundredths % 10) as u8,
+    ]
+}
+
+fn indicator(set: bool) -> MicEBit {
+    if set {
+        MicEBit::Standard
+    } else {
+        MicEBit::Zero
+    }
+}
+
+/// One destination character. The digit picks the offset within a range and the bit picks the
+/// range; an ambiguous digit picks the range's own placeholder.
+fn encode_destination_char(digit: u8, bit: MicEBit, ambiguous: bool) -> char {
+    let base = match bit {
+        MicEBit::Zero => b'0',
+        MicEBit::Standard => b'P',
+        MicEBit::Custom => b'A',
+    };
+    if ambiguous {
+        return char::from(match bit {
+            MicEBit::Zero => b'L',
+            MicEBit::Standard => b'Z',
+            MicEBit::Custom => b'K',
+        });
+    }
+    char::from(base + digit)
+}
+
+/// The four disjoint pieces of the d+28 range, chosen so the byte stays printable and the
+/// longitude offset in the destination completes the value.
+fn longitude_degrees_byte(degrees: u32) -> u8 {
+    let raw = match degrees {
+        0..=9 => degrees + 90,
+        10..=99 => degrees,
+        100..=109 => degrees - 20,
+        _ => degrees.saturating_sub(100),
+    };
+    (raw + 28).min(127) as u8
+}
+
+/// m+28. Minutes below 10 are sent 60 higher so that the byte stays printable.
+fn longitude_minutes_byte(minutes: u32) -> u8 {
+    let raw = if minutes < 10 { minutes + 60 } else { minutes };
+    (raw + 28) as u8
+}
+
+/// SP+28, DC+28 and SE+28. The +80 and +4 are the encoding scheme that keeps all three bytes
+/// printable; the receiver undoes them with the ≥ 800 and ≥ 400 subtractions.
+fn speed_course_bytes(speed_kt: u32, course_deg: u32) -> [u8; 3] {
+    let (tens, units) = (speed_kt.min(799) / 10, speed_kt.min(799) % 10);
+    let course = course_deg.min(360);
+    let sp = if tens < 20 { tens + 80 } else { tens };
+    let dc = units * 10 + course / 100 + 4;
+    [(sp + 28) as u8, (dc + 28) as u8, (course % 100 + 28) as u8]
 }
 
 impl AprsTx {
@@ -1195,10 +1664,13 @@ mod tests {
         assert_eq!(decoded[1].tnc2, "DL1ABC-2>APRS,WIDE1-1:>second");
     }
 
+    /// Both worked examples of APRS 1.0.1 ch. 10 in one frame. The destination `S32U6T` is the
+    /// chapter's destination example — 33°25.64'N, message bits 1/0/0 from the standard table,
+    /// longitude offset +0 — and `` `(_fn"Oj/ `` is its information-field example, which the
+    /// chapter decodes with a +100° offset. Under this destination's +0 the same bytes are
+    /// 12°07.74'W rather than the chapter's 112°, and everything else is its published answer.
     #[test]
-    fn mic_e_decodes_as_a_frame_without_a_position() {
-        // Mic-E encodes the position in the destination callsign and a binary information
-        // field; M4 decodes the frame but deliberately does not parse it.
+    fn the_spec_worked_example_decodes_to_its_published_values() {
         let frame = AprsTx::ui_frame("DL1ABC-7", "S32U6T", &["WIDE2-2"], "`(_fn\"Oj/");
         let packet = only(decode(
             AprsMode::Afsk1200,
@@ -1209,9 +1681,300 @@ mod tests {
         assert_eq!(packet.path, ["WIDE2-2"]);
         assert_eq!(packet.info, "`(_fn\"Oj/");
         assert_eq!(packet.tnc2, "DL1ABC-7>S32U6T,WIDE2-2:`(_fn\"Oj/");
+
+        let lat = packet.lat.unwrap();
+        assert!((lat - (33.0 + 25.64 / 60.0)).abs() < 1e-9, "lat {lat}");
+        let lon = packet.lon.unwrap();
+        assert!((lon + (12.0 + 7.74 / 60.0)).abs() < 1e-9, "lon {lon}");
+        assert_eq!(packet.speed_kt, Some(20.0));
+        assert_eq!(packet.course_deg, Some(251.0));
+        // The jeep from the primary table, quoted table-first though it is sent code-first.
+        assert_eq!(packet.symbol.as_deref(), Some("/j"));
+        assert_eq!(packet.mic_e_message.as_deref(), Some("Returning"));
+        assert_eq!(packet.comment, None);
+        assert_eq!(packet.altitude_ft, None);
+    }
+
+    /// The chapter's information-field example as it is actually written up: with the +100°
+    /// longitude offset its destination example does not set, giving 112°07.74'W.
+    #[test]
+    fn the_spec_longitude_example_needs_the_hundred_degree_offset() {
+        // `S32UVT` is the destination example with byte 5 moved into the P–Y range, which is
+        // the one change that turns the offset on.
+        let frame = AprsTx::ui_frame("DL1ABC-7", "S32UVT", &[], "`(_fn\"Oj/");
+        let packet = only(decode(
+            AprsMode::Afsk1200,
+            &keyed(AprsMode::Afsk1200, &frame),
+        ));
+        let lon = packet.lon.unwrap();
+        assert!((lon + (112.0 + 7.74 / 60.0)).abs() < 1e-9, "lon {lon}");
+        assert!((packet.lat.unwrap() - (33.0 + 25.64 / 60.0)).abs() < 1e-9);
+    }
+
+    fn mic_e_frame(report: &MicE) -> Vec<u8> {
+        AprsTx::ui_frame("DL1ABC-9", &report.destination(), &[], &report.info())
+    }
+
+    fn mic_e_packet(report: &MicE) -> AprsPacket {
+        only(decode(
+            AprsMode::Afsk1200,
+            &keyed(AprsMode::Afsk1200, &mic_e_frame(report)),
+        ))
+    }
+
+    /// Both halves of the encoding over the whole globe: the destination carries the latitude
+    /// and the hemispheres, the information field the longitude, and the four ranges the
+    /// longitude degrees are folded into are what a sign test alone would miss.
+    #[test]
+    fn mic_e_round_trips_positions_in_every_hemisphere_and_longitude_range() {
+        for (lat, lon) in [
+            (48.123_0, 11.516_67),   // the +0 offset range
+            (-33.875_0, -151.205_0), // southern, and 110–179° in the +100 range
+            (37.775_0, -122.418_3),  // 100–109°, the range folded by subtracting 80
+            (60.170_0, 5.183_3),     // 0–9°, the range folded by subtracting 190
+            (-1.283_3, 36.816_7),    // both minutes fields near zero
+            (0.0, 0.0),
+        ] {
+            let packet = mic_e_packet(&MicE {
+                lat,
+                lon,
+                ..MicE::default()
+            });
+            let (got_lat, got_lon) = (packet.lat.unwrap(), packet.lon.unwrap());
+            // A hundredth of a minute is the encoding's whole resolution.
+            assert!((got_lat - lat).abs() < 1.0 / 6_000.0, "{lat} -> {got_lat}");
+            assert!((got_lon - lon).abs() < 1.0 / 6_000.0, "{lon} -> {got_lon}");
+        }
+    }
+
+    /// Speed and course share a byte, and both fold through a subtraction at the top of their
+    /// range — so the values that matter are the ones on either side of the fold.
+    #[test]
+    fn mic_e_round_trips_speed_and_course() {
+        for (speed_kt, course_deg, expected_course) in [
+            (0, 0, None),
+            (20, 251, Some(251.0)),
+            (1, 1, Some(1.0)),
+            (199, 199, Some(199.0)),
+            (200, 200, Some(200.0)),
+            (799, 359, Some(359.0)),
+            // 360° is due north and 0° is "unknown", so only one of them is a heading.
+            (55, 360, Some(0.0)),
+        ] {
+            let packet = mic_e_packet(&MicE {
+                lat: 48.0,
+                lon: 11.0,
+                speed_kt,
+                course_deg,
+                ..MicE::default()
+            });
+            assert_eq!(
+                packet.speed_kt,
+                Some(f64::from(speed_kt)),
+                "{speed_kt} kt / {course_deg}°"
+            );
+            assert_eq!(
+                packet.course_deg, expected_course,
+                "{speed_kt} kt / {course_deg}°"
+            );
+        }
+    }
+
+    /// The 15 message codes, and the mixture the spec refuses to name.
+    #[test]
+    fn mic_e_names_every_message_code() {
+        use MicEBit::{Custom, Standard, Zero};
+        for (bits, name) in [
+            ([Standard, Standard, Standard], Some("Off Duty")),
+            ([Standard, Standard, Zero], Some("En Route")),
+            ([Standard, Zero, Standard], Some("In Service")),
+            ([Standard, Zero, Zero], Some("Returning")),
+            ([Zero, Standard, Standard], Some("Committed")),
+            ([Zero, Standard, Zero], Some("Special")),
+            ([Zero, Zero, Standard], Some("Priority")),
+            ([Zero, Zero, Zero], Some("Emergency")),
+            ([Custom, Custom, Custom], Some("Custom-0")),
+            ([Custom, Custom, Zero], Some("Custom-1")),
+            ([Custom, Zero, Custom], Some("Custom-2")),
+            ([Custom, Zero, Zero], Some("Custom-3")),
+            ([Zero, Custom, Custom], Some("Custom-4")),
+            ([Zero, Custom, Zero], Some("Custom-5")),
+            ([Zero, Zero, Custom], Some("Custom-6")),
+            // "If the A/B/C message identifier bits contain a mixture of Standard 1s and
+            // Custom 1s, the message type is unknown" — so it stays unnamed.
+            ([Standard, Custom, Zero], None),
+            ([Custom, Zero, Standard], None),
+        ] {
+            let packet = mic_e_packet(&MicE {
+                lat: 48.0,
+                lon: 11.0,
+                bits,
+                ..MicE::default()
+            });
+            assert_eq!(packet.mic_e_message.as_deref(), name, "{bits:?}");
+            // The position decodes whatever the message bits say.
+            assert!(packet.lat.is_some(), "{bits:?}");
+        }
+    }
+
+    /// Ambiguity is declared in the latitude and applies to the longitude too — the same
+    /// count of digits from the right, in a field that never mentions it.
+    #[test]
+    fn mic_e_position_ambiguity_blanks_both_coordinates() {
+        let (lat, lon) = (33.427_33, -112.129_0);
+        for (ambiguity, lat_hundredths, lon_hundredths) in [
+            (0usize, 25.64, 7.74),
+            (1, 25.60, 7.70),
+            (2, 25.00, 7.00),
+            (3, 20.00, 0.00),
+            (4, 0.00, 0.00),
+        ] {
+            let packet = mic_e_packet(&MicE {
+                lat,
+                lon,
+                ambiguity,
+                ..MicE::default()
+            });
+            let want_lat = 33.0 + lat_hundredths / 60.0;
+            let want_lon = -(112.0 + lon_hundredths / 60.0);
+            assert!(
+                (packet.lat.unwrap() - want_lat).abs() < 1e-9,
+                "ambiguity {ambiguity}: lat {:?}",
+                packet.lat
+            );
+            assert!(
+                (packet.lon.unwrap() - want_lon).abs() < 1e-9,
+                "ambiguity {ambiguity}: lon {:?}",
+                packet.lon
+            );
+        }
+    }
+
+    /// The status text's `xxx}` altitude, and the spec's own worked value for it.
+    #[test]
+    fn mic_e_altitude_decodes_from_the_status_text() {
+        assert_eq!(MicE::altitude_field(200), "\"4T}");
+        for alt_ft in [-30, 0, 200, 1_234, 38_000] {
+            let status = MicE::altitude_field(alt_ft);
+            let packet = mic_e_packet(&MicE {
+                lat: 48.0,
+                lon: 11.0,
+                status: &status,
+                ..MicE::default()
+            });
+            // The field is whole metres, so a foot is not recoverable to the foot.
+            let got = packet.altitude_ft.unwrap();
+            assert!((got - alt_ft).abs() <= 2, "{alt_ft} ft -> {got} ft");
+            assert_eq!(packet.comment.as_deref(), Some(status.as_str()));
+        }
+    }
+
+    /// A Kenwood radio stamps its own type code at the head of the status text, and the
+    /// altitude sits behind it.
+    #[test]
+    fn mic_e_altitude_survives_a_kenwood_type_code() {
+        for prefix in [">", "]"] {
+            let status = format!("{prefix}{} Hello", MicE::altitude_field(1_000));
+            let packet = mic_e_packet(&MicE {
+                lat: 48.0,
+                lon: 11.0,
+                status: &status,
+                ..MicE::default()
+            });
+            assert!(
+                (packet.altitude_ft.unwrap() - 1_000).abs() <= 2,
+                "{prefix}: {:?}",
+                packet.altitude_ft
+            );
+            assert_eq!(
+                packet.comment.as_deref(),
+                Some(format!("{} Hello", MicE::altitude_field(1_000)).as_str())
+            );
+        }
+    }
+
+    /// The altitude field is only an altitude field at the head of the status text. A `}`
+    /// further in is a character someone typed, and reading the three before it as base-91
+    /// would put a station 700 km up. Telemetry, likewise, is not a comment.
+    #[test]
+    fn mic_e_reads_neither_an_altitude_nor_a_comment_out_of_what_is_not_one() {
+        let packet = mic_e_packet(&MicE {
+            lat: 48.0,
+            lon: 11.0,
+            status: "not an altitude}",
+            ..MicE::default()
+        });
+        assert_eq!(packet.altitude_ft, None);
+        assert_eq!(packet.comment.as_deref(), Some("not an altitude}"));
+
+        // A telemetry flag where the status text would start means channels follow.
+        let packet = mic_e_packet(&MicE {
+            lat: 48.0,
+            lon: 11.0,
+            status: "'7200007100",
+            ..MicE::default()
+        });
+        assert_eq!(packet.comment, None);
+        assert_eq!(packet.altitude_ft, None);
+        assert!(packet.lat.is_some(), "telemetry must not lose the position");
+    }
+
+    /// An information field short of its 8 mandatory bytes is a packet whose non-printing
+    /// bytes were eaten in transit; the spec says to ignore it rather than decode a prefix.
+    #[test]
+    fn a_truncated_mic_e_field_yields_no_position() {
+        let frame = AprsTx::ui_frame("DL1ABC-9", "S32U6T", &[], "`(_fn\"O");
+        let packet = only(decode(
+            AprsMode::Afsk1200,
+            &keyed(AprsMode::Afsk1200, &frame),
+        ));
         assert_eq!(packet.lat, None);
-        assert_eq!(packet.lon, None);
-        assert_eq!(packet.symbol, None);
+        assert_eq!(packet.mic_e_message, None);
+        assert_eq!(packet.info, "`(_fn\"O");
+    }
+
+    /// A destination that is a plain callsign is not Mic-E data, however Mic-E the information
+    /// field looks — and inventing a latitude out of `APRS` would be worse than reading none.
+    #[test]
+    fn a_mic_e_information_field_under_an_ordinary_destination_decodes_nothing() {
+        for destination in ["APRS", "N0CALL", "S32U6"] {
+            let frame = AprsTx::ui_frame("DL1ABC-9", destination, &[], "`(_fn\"Oj/");
+            let packet = only(decode(
+                AprsMode::Afsk1200,
+                &keyed(AprsMode::Afsk1200, &frame),
+            ));
+            assert_eq!(packet.lat, None, "{destination}");
+            assert_eq!(packet.mic_e_message, None, "{destination}");
+        }
+    }
+
+    /// The generic digipeater path rides in the destination SSID, so a Mic-E destination is
+    /// routinely `S32U6T-3` — six data characters and a number that is not one of them.
+    #[test]
+    fn a_destination_ssid_does_not_disturb_the_six_data_characters() {
+        let frame = AprsTx::ui_frame("DL1ABC-9", "S32U6T-3", &[], "`(_fn\"Oj/");
+        let packet = only(decode(
+            AprsMode::Afsk1200,
+            &keyed(AprsMode::Afsk1200, &frame),
+        ));
+        assert_eq!(packet.destination, "S32U6T-3");
+        assert!((packet.lat.unwrap() - (33.0 + 25.64 / 60.0)).abs() < 1e-9);
+        assert_eq!(packet.mic_e_message.as_deref(), Some("Returning"));
+    }
+
+    /// The old-GPS identifier and the two the beta units send are the same format.
+    #[test]
+    fn every_mic_e_data_type_identifier_is_decoded() {
+        for id in ['`', '\'', '\u{1c}', '\u{1d}'] {
+            let info = format!("{id}(_fn\"Oj/");
+            let frame = AprsTx::ui_frame("DL1ABC-9", "S32U6T", &[], &info);
+            let packet = only(decode(
+                AprsMode::Afsk1200,
+                &keyed(AprsMode::Afsk1200, &frame),
+            ));
+            assert_eq!(packet.speed_kt, Some(20.0), "{id:?}");
+            assert!(packet.lat.is_some(), "{id:?}");
+        }
     }
 
     #[test]

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -17,6 +17,7 @@ mod rds;
 mod rtty;
 mod ssb;
 mod subghz;
+pub mod tone_squelch;
 mod tx;
 mod wfm;
 
@@ -204,6 +205,20 @@ pub trait ChannelRx: Send {
     /// Retunes arrive here rather than through [`ChannelRx::apply`], which the host does not
     /// call for an offset-only change.
     fn retuned(&mut self) {}
+
+    /// Whether the host must keep feeding this channel while the squelch is closed.
+    ///
+    /// A decoder measures time in the samples it has processed — its bit clock, its element
+    /// timing, its inter-frame gaps — so skipping the gated span would splice those spans out
+    /// of a stream that never had a gap in it. `true`, the default, is right for every one of
+    /// them, and the host reads it only for the types that emit events at all.
+    ///
+    /// A channel whose events describe something *inside* a carrier says otherwise when it has
+    /// nothing to describe: there is no subaudible tone under a closed squelch, and running
+    /// the demodulator on silence to find that out is what the squelch exists to avoid.
+    fn needs_gated_input(&self) -> bool {
+        true
+    }
 
     fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs);
 }
@@ -523,7 +538,7 @@ mod tests {
             assert_eq!(d.input_rate_hz, rate, "{}", d.type_id);
             assert!(!d.name.is_empty(), "{}", d.type_id);
             // Every channel type must be useful for something: audio, decoded frames, or
-            // both (WFM+RDS is the only current "both").
+            // both — WFM decodes RDS beside its audio, NFM the subaudible tone under it.
             assert!(
                 d.has_audio || d.decoder_kind.is_some(),
                 "{} produces neither audio nor decoder events",
@@ -624,7 +639,8 @@ mod tests {
     fn occupied_band_tracks_params_and_sideband() {
         assert_eq!(
             occupied_band(&ChannelParams::Nfm(NfmParams {
-                bandwidth_hz: 25_000.0
+                bandwidth_hz: 25_000.0,
+                ..NfmParams::default()
             })),
             (-12_500.0, 12_500.0)
         );
@@ -691,6 +707,7 @@ mod tests {
         for params in [
             ChannelParams::Nfm(NfmParams {
                 bandwidth_hz: f64::NAN,
+                ..NfmParams::default()
             }),
             ChannelParams::Am(AmParams {
                 bandwidth_hz: 0.0,

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -33,7 +33,7 @@ pub use acars::AcarsChannel;
 pub use adsb::AdsbChannel;
 pub use ais::AisChannelRx;
 pub use am::{AmChannel, AmTx};
-pub use aprs::{AprsChannel, AprsTx};
+pub use aprs::{AprsChannel, AprsTx, MicE, MicEBit};
 pub use morse::MorseChannel;
 pub use navtex::NavtexChannel;
 pub use nfm::{NfmChannel, NfmTx};

--- a/crates/channels/src/nfm.rs
+++ b/crates/channels/src/nfm.rs
@@ -2,18 +2,26 @@
 //! `bandwidth_hz` is the host's channel filter (see [`crate::channel_filter`]); here the
 //! bandwidth only sets the deviation the discriminator is scaled to.
 //!
+//! The channel also reads the subaudible signalling under the voice — CTCSS or DCS — and will
+//! gate the audio on it (see [`crate::tone_squelch`]). That path only exists when it is asked
+//! for: with [`NfmToneMode::Off`] the audio is what it always was, flat to DC.
+//!
 //! [`NfmTx`] is the modulator that pairs with it. Neither carries pre- or de-emphasis: the two
 //! have to agree, and a flat pair is the one that round-trips.
 
 use std::{f64::consts::TAU, sync::LazyLock};
 
 use num_complex::Complex;
-use sdrmm_dsp::{Decimator, FmDemod, RealDecimator, design_lowpass};
-use sdrmm_wire::{ChannelDescriptor, ChannelParams, ChannelSettings, NfmParams};
+use sdrmm_dsp::{Decimator, FmDemod, Highpass, RealDecimator, design_lowpass};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, NfmParams, NfmToneMode,
+    ToneSquelchStatus,
+};
 
 use crate::{
     AUDIO_RATE, ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, ChannelTx,
     TxPayload, check_input_rate, clamp_full_scale,
+    tone_squelch::{AUDIO_CORNER_HZ, ToneSquelch, is_standard_ctcss, is_standard_dcs},
     tx::{Burst, TxQueue},
 };
 
@@ -28,7 +36,7 @@ static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescrip
     bandwidth_hz: 12_500.0,
     input_rate_hz: 48_000.0,
     has_audio: true,
-    decoder_kind: None,
+    decoder_kind: Some("tone".to_owned()),
     ..ChannelDescriptor::default()
 });
 
@@ -36,6 +44,76 @@ pub struct NfmChannel {
     demod: FmDemod,
     audio_lp: RealDecimator,
     demod_buf: Vec<f32>,
+    /// `None` while [`NfmToneMode::Off`] — the subaudible path costs a decimation chain and
+    /// fifty correlators, and a channel that was not asked for it pays neither.
+    tone: Option<Tone>,
+}
+
+/// Everything the tone modes add to the channel: the detector, the highpass that keeps what it
+/// detects out of the audio, and the last status reported so that only changes are.
+struct Tone {
+    mode: NfmToneMode,
+    ctcss_hz: Option<f64>,
+    dcs_code: Option<u16>,
+    detector: ToneSquelch,
+    highpass: Highpass,
+    reported: ToneSquelchStatus,
+}
+
+impl Tone {
+    fn new(p: &NfmParams) -> Self {
+        Self {
+            mode: p.tone_mode,
+            ctcss_hz: p.ctcss_hz,
+            dcs_code: p.dcs_code,
+            detector: ToneSquelch::new(),
+            highpass: Highpass::new(DESCRIPTOR.input_rate_hz, AUDIO_CORNER_HZ),
+            // What a channel with nothing under it computes on its first block, so a silent
+            // start says nothing rather than announcing silence.
+            reported: ToneSquelchStatus {
+                ctcss_hz: None,
+                dcs_code: None,
+                open: p.tone_mode == NfmToneMode::Detect,
+            },
+        }
+    }
+
+    fn configure(&mut self, p: &NfmParams) {
+        self.mode = p.tone_mode;
+        self.ctcss_hz = p.ctcss_hz;
+        self.dcs_code = p.dcs_code;
+    }
+
+    fn reset(&mut self) {
+        self.detector.reset();
+        self.highpass.reset();
+    }
+
+    /// Read the subaudible band, take it out of `demodulated`, and report the gate.
+    fn step(&mut self, demodulated: &mut [f32], out: &mut ChannelOutputs) -> bool {
+        let heard = self.detector.process(demodulated);
+        self.highpass.process(demodulated);
+        let open = match self.mode {
+            // Detect never gates: it answers "what does this repeater use?", and muting the
+            // audio until the answer arrived would make that question unaskable.
+            NfmToneMode::Off | NfmToneMode::Detect => true,
+            NfmToneMode::Ctcss => match (heard.ctcss_hz, self.ctcss_hz) {
+                (Some(heard), Some(want)) => (heard - want).abs() < 0.05,
+                _ => false,
+            },
+            NfmToneMode::Dcs => heard.dcs_code.is_some() && heard.dcs_code == self.dcs_code,
+        };
+        let status = ToneSquelchStatus {
+            ctcss_hz: heard.ctcss_hz,
+            dcs_code: heard.dcs_code,
+            open,
+        };
+        if status != self.reported {
+            self.reported = status.clone();
+            out.events.push(DecoderEvent::Tone(status));
+        }
+        open
+    }
 }
 
 fn params(settings: &ChannelSettings) -> Result<&NfmParams, ChannelError> {
@@ -57,6 +135,27 @@ fn check_bandwidth(p: &NfmParams) -> Result<(), ChannelError> {
             "nfm bandwidth must be in (0, {rate}) Hz, got {}",
             p.bandwidth_hz
         )))
+    }
+}
+
+/// A tone the detector does not search for could never open the gate, so it is refused where
+/// the operator set it rather than left to look like a dead channel.
+fn check_params(p: &NfmParams) -> Result<(), ChannelError> {
+    check_bandwidth(p)?;
+    match p.tone_mode {
+        NfmToneMode::Ctcss if !p.ctcss_hz.is_some_and(is_standard_ctcss) => {
+            Err(ChannelError::InvalidSettings(format!(
+                "nfm ctcss squelch needs one of the 50 standard tones, got {:?}",
+                p.ctcss_hz
+            )))
+        }
+        NfmToneMode::Dcs if !p.dcs_code.is_some_and(is_standard_dcs) => {
+            Err(ChannelError::InvalidSettings(format!(
+                "nfm dcs squelch needs one of the 83 standard codes, got {:?}",
+                p.dcs_code
+            )))
+        }
+        _ => Ok(()),
     }
 }
 
@@ -91,25 +190,56 @@ impl ChannelRx for NfmChannel {
     fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
         check_input_rate(ctx, &DESCRIPTOR)?;
         let p = params(&settings)?;
-        check_bandwidth(p)?;
+        check_params(p)?;
         Ok(Self {
             demod: FmDemod::new(ctx.input_rate, deviation_hz(p)),
             audio_lp: audio_lowpass(),
             demod_buf: Vec::new(),
+            tone: (p.tone_mode != NfmToneMode::Off).then(|| Tone::new(p)),
         })
     }
 
     fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
         let p = params(&settings)?;
-        check_bandwidth(p)?;
+        check_params(p)?;
         self.demod = FmDemod::new(DESCRIPTOR.input_rate_hz, deviation_hz(p));
+        // Which tone is required is a comparison, not state, so retuning the gate keeps
+        // whatever the detector has already heard on this frequency.
+        match (&mut self.tone, p.tone_mode) {
+            (_, NfmToneMode::Off) => self.tone = None,
+            (Some(tone), _) => tone.configure(p),
+            (none, _) => *none = Some(Tone::new(p)),
+        }
         Ok(())
+    }
+
+    /// A subaudible tone belongs to the station that was sending it. The channel has left.
+    fn retuned(&mut self) {
+        if let Some(tone) = &mut self.tone {
+            tone.reset();
+        }
+    }
+
+    fn needs_gated_input(&self) -> bool {
+        // With a tone mode on, the gated span is what lets the detector *lose* a tone: the
+        // correlators decay over their window and the "no tone, muted" event follows. Off,
+        // there is nothing to measure and the host may skip the channel entirely.
+        self.tone.is_some()
     }
 
     fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
         self.demod.process(iq, &mut self.demod_buf);
+        let mut open = true;
+        if let Some(tone) = &mut self.tone {
+            open = tone.step(&mut self.demod_buf, out);
+        }
         self.audio_lp.process(&self.demod_buf, &mut out.audio_pcm);
         clamp_full_scale(&mut out.audio_pcm);
+        // Muted, not skipped: a closed tone gate still owes the client audio of the right
+        // duration, exactly as a closed squelch does.
+        if !open {
+            out.audio_pcm.fill(0.0);
+        }
         if !out.audio_pcm.is_empty() {
             out.audio_rate = AUDIO_RATE;
         }
@@ -202,7 +332,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        testgen::{burst, tone_audio},
+        testgen::{
+            burst, fm_modulate,
+            nfm::{ctcss_audio, dcs_audio, mix},
+            tone_audio,
+        },
         testutil::{complex_noise, dominant_tone, fm_iq, rms, run_ragged, settings},
         tx::MAX_QUEUE_S,
     };
@@ -237,6 +371,7 @@ mod tests {
         let mut chan = channel();
         chan.apply(settings(ChannelParams::Nfm(NfmParams {
             bandwidth_hz: 25_000.0,
+            ..NfmParams::default()
         })))
         .unwrap();
         // A ±5 kHz-deviation signal (standard for 25 kHz channels) must land at unit
@@ -267,7 +402,10 @@ mod tests {
         for bad in [0.0, -1.0, 48_000.0, f64::NAN] {
             let built = NfmChannel::new(
                 ChannelCtx { input_rate: RATE },
-                settings(ChannelParams::Nfm(NfmParams { bandwidth_hz: bad })),
+                settings(ChannelParams::Nfm(NfmParams {
+                    bandwidth_hz: bad,
+                    ..NfmParams::default()
+                })),
             );
             assert!(
                 matches!(built, Err(ChannelError::InvalidSettings(_))),
@@ -299,6 +437,306 @@ mod tests {
         assert!(matches!(built, Err(ChannelError::InvalidSettings(_))));
     }
 
+    // ── subaudible signalling ──────────────────────────────────────────────────────────────
+
+    /// A repeater keys its subaudible signalling at 10–15 % of deviation, under speech at
+    /// most of the rest. Both are fractions of full deviation, which is what the
+    /// discriminator hands back.
+    const SUBAUDIBLE: f32 = 0.15;
+    const VOICE: f32 = 0.6;
+    /// Long enough for the correlator bank to fill its half-second window twice over.
+    const TONE_LEN: usize = 48_000 * 2;
+
+    fn tone_params(mode: NfmToneMode, ctcss_hz: Option<f64>, dcs_code: Option<u16>) -> NfmParams {
+        NfmParams {
+            tone_mode: mode,
+            ctcss_hz,
+            dcs_code,
+            ..NfmParams::default()
+        }
+    }
+
+    fn tone_channel(p: NfmParams) -> NfmChannel {
+        NfmChannel::new(ctx(), settings(ChannelParams::Nfm(p))).unwrap()
+    }
+
+    /// A carrier with `subaudible` under a 1 kHz voice tone.
+    fn signalling_iq(subaudible: &[f32]) -> Vec<Complex<f32>> {
+        let voice = tone_audio(1_000.0, VOICE, RATE, subaudible.len());
+        fm_modulate(&mix(subaudible, &voice), DEVIATION_HZ, RATE)
+    }
+
+    /// Feed the channel in ragged blocks and return the last status it reported plus the
+    /// audio, which is what a listener would actually get.
+    fn run_tone(chan: &mut NfmChannel, iq: &[Complex<f32>]) -> (Vec<ToneSquelchStatus>, Vec<f32>) {
+        let mut out = ChannelOutputs::default();
+        let (mut statuses, mut audio) = (Vec::new(), Vec::new());
+        let mut pos = 0;
+        for len in [997usize, 4_096, 65, 2_048].iter().cycle() {
+            if pos >= iq.len() {
+                break;
+            }
+            let end = (pos + len).min(iq.len());
+            out.reset();
+            chan.process(&iq[pos..end], &mut out);
+            for event in &out.events {
+                let DecoderEvent::Tone(status) = event else {
+                    panic!("nfm emitted {}", event.kind())
+                };
+                statuses.push(status.clone());
+            }
+            audio.extend_from_slice(&out.audio_pcm);
+            pos = end;
+        }
+        (statuses, audio)
+    }
+
+    #[test]
+    fn detect_names_the_ctcss_tone_under_the_voice() {
+        for tone_hz in [67.0, 88.5, 162.2, 165.5, 254.1] {
+            let iq = signalling_iq(&ctcss_audio(tone_hz, SUBAUDIBLE, RATE, TONE_LEN));
+            let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+            let (statuses, _) = run_tone(&mut chan, &iq);
+            let last = statuses.last().expect("a tone must be reported");
+            assert_eq!(last.ctcss_hz, Some(tone_hz), "{tone_hz} Hz: {statuses:?}");
+            assert_eq!(last.dcs_code, None, "{tone_hz} Hz");
+            // Detect answers the question without acting on it.
+            assert!(last.open, "{tone_hz} Hz");
+        }
+    }
+
+    /// 162.2 and 165.5 are 3.3 Hz apart and the pair at 67.0/69.3 only 2.3 — the whole reason
+    /// the correlator window is half a second. A bank that named the neighbour would look
+    /// exactly like one that worked.
+    #[test]
+    fn a_neighbouring_standard_tone_is_not_named_instead() {
+        for (sent, neighbour) in [(69.3, 67.0), (162.2, 165.5), (206.5, 203.5)] {
+            let iq = signalling_iq(&ctcss_audio(sent, SUBAUDIBLE, RATE, TONE_LEN));
+            let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+            let (statuses, _) = run_tone(&mut chan, &iq);
+            let named = statuses.last().and_then(|s| s.ctcss_hz);
+            assert_eq!(named, Some(sent), "{sent} Hz was named {named:?}");
+            assert_ne!(named, Some(neighbour));
+        }
+    }
+
+    #[test]
+    fn detect_reads_the_dcs_code_under_the_voice() {
+        for code in [23u16, 114, 754, 172] {
+            let iq = signalling_iq(&dcs_audio(code, SUBAUDIBLE, RATE, TONE_LEN));
+            let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+            let (statuses, _) = run_tone(&mut chan, &iq);
+            let last = statuses.last().expect("a code must be reported");
+            assert_eq!(last.dcs_code, Some(code), "{code:03}: {statuses:?}");
+        }
+    }
+
+    /// A DCS transmission through an inverted discriminator is its inverse-pair partner, not
+    /// nothing and not the same code — which is why there is no polarity switch to get wrong.
+    #[test]
+    fn an_inverted_dcs_transmission_reads_as_the_partner_code() {
+        let inverted: Vec<f32> = dcs_audio(23, SUBAUDIBLE, RATE, TONE_LEN)
+            .iter()
+            .map(|s| -s)
+            .collect();
+        let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        let (statuses, _) = run_tone(&mut chan, &signalling_iq(&inverted));
+        assert_eq!(statuses.last().and_then(|s| s.dcs_code), Some(47));
+    }
+
+    /// The carrier is never exactly on frequency, and the tuning error arrives as DC on the
+    /// discriminator — right where a DCS slicer's decision threshold is.
+    #[test]
+    fn dcs_decodes_through_a_carrier_offset() {
+        for offset_hz in [-400.0f64, 250.0] {
+            let word = dcs_audio(23, SUBAUDIBLE, RATE, TONE_LEN);
+            // A constant frequency error is a constant term in the modulating waveform.
+            let bias = (offset_hz / DEVIATION_HZ) as f32;
+            let biased: Vec<f32> = word.iter().map(|s| s + bias).collect();
+            let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+            let (statuses, _) = run_tone(&mut chan, &signalling_iq(&biased));
+            assert_eq!(
+                statuses.last().and_then(|s| s.dcs_code),
+                Some(23),
+                "{offset_hz} Hz offset"
+            );
+        }
+    }
+
+    /// The gate, both ways round: the tone it was told to open on, and the one it was not.
+    #[test]
+    fn ctcss_squelch_passes_only_its_own_tone() {
+        for (sent, open) in [(88.5, true), (91.5, false)] {
+            let iq = signalling_iq(&ctcss_audio(sent, SUBAUDIBLE, RATE, TONE_LEN));
+            let mut chan = tone_channel(tone_params(NfmToneMode::Ctcss, Some(88.5), None));
+            let (statuses, audio) = run_tone(&mut chan, &iq);
+            assert_eq!(statuses.last().map(|s| s.open), Some(open), "{sent} Hz");
+            // Muted, not skipped: the client's jitter buffer still gets its samples.
+            assert_eq!(audio.len(), iq.len(), "{sent} Hz");
+            let settled = rms(&audio[audio.len() / 2..]);
+            if open {
+                assert!(settled > 0.3, "{sent} Hz: passed audio rms {settled}");
+            } else {
+                assert_eq!(settled, 0.0, "{sent} Hz: muted audio rms {settled}");
+            }
+        }
+    }
+
+    #[test]
+    fn dcs_squelch_passes_only_its_own_code() {
+        for (sent, open) in [(23u16, true), (114, false)] {
+            let iq = signalling_iq(&dcs_audio(sent, SUBAUDIBLE, RATE, TONE_LEN));
+            let mut chan = tone_channel(tone_params(NfmToneMode::Dcs, None, Some(23)));
+            let (statuses, audio) = run_tone(&mut chan, &iq);
+            assert_eq!(statuses.last().map(|s| s.open), Some(open), "{sent:03}");
+            let settled = rms(&audio[audio.len() / 2..]);
+            assert_eq!(settled > 0.3, open, "{sent:03}: audio rms {settled}");
+        }
+    }
+
+    /// The tone must not be audible in what it lets through — that is the difference between
+    /// tone squelch and a 67 Hz hum on every transmission.
+    #[test]
+    fn the_subaudible_tone_is_taken_out_of_the_audio_it_opens() {
+        let iq = signalling_iq(&ctcss_audio(88.5, SUBAUDIBLE, RATE, TONE_LEN));
+        let mut chan = tone_channel(tone_params(NfmToneMode::Ctcss, Some(88.5), None));
+        let (_, audio) = run_tone(&mut chan, &iq);
+        let settled = &audio[audio.len() / 2..];
+        let (freq, ratio) = dominant_tone(settled, RATE);
+        assert!((995.0..1_005.0).contains(&freq), "dominant {freq} Hz");
+        assert!(ratio > 10.0, "voice-to-rest ratio {ratio}");
+
+        // The same channel with the tone path off keeps the 88.5 Hz component it was carrying.
+        let mut plain = channel();
+        let (_, plain_audio) = run_tone(&mut plain, &iq);
+        let plain_settled = &plain_audio[plain_audio.len() / 2..];
+        assert!(
+            subaudible_rms(plain_settled) > 4.0 * subaudible_rms(settled),
+            "highpass removed {:.4} -> {:.4}",
+            subaudible_rms(plain_settled),
+            subaudible_rms(settled)
+        );
+    }
+
+    /// Energy below 300 Hz, measured with the same correlator the detector uses.
+    fn subaudible_rms(audio: &[f32]) -> f32 {
+        let mut correlator = sdrmm_dsp::ToneCorrelator::new(RATE, 88.5, (RATE * 0.1) as usize);
+        audio
+            .iter()
+            .map(|&s| correlator.push(s))
+            .fold(0.0, f32::max)
+    }
+
+    #[test]
+    fn a_tone_that_stops_closes_the_gate_again() {
+        let mut with_tone = ctcss_audio(88.5, SUBAUDIBLE, RATE, TONE_LEN);
+        with_tone.extend(std::iter::repeat_n(0.0, TONE_LEN));
+        let mut chan = tone_channel(tone_params(NfmToneMode::Ctcss, Some(88.5), None));
+        let (statuses, _) = run_tone(&mut chan, &signalling_iq(&with_tone));
+        assert_eq!(
+            statuses.first().map(|s| s.open),
+            Some(true),
+            "{statuses:?}: the gate never opened"
+        );
+        assert_eq!(statuses.last().map(|s| s.open), Some(false), "{statuses:?}");
+        assert_eq!(statuses.last().and_then(|s| s.ctcss_hz), None);
+    }
+
+    /// Continuous signalling would otherwise be a continuous event: one per block, forty a
+    /// second, forever.
+    #[test]
+    fn only_changes_are_reported() {
+        let iq = signalling_iq(&ctcss_audio(88.5, SUBAUDIBLE, RATE, TONE_LEN));
+        let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        let (statuses, _) = run_tone(&mut chan, &iq);
+        assert_eq!(statuses.len(), 1, "{statuses:?}");
+    }
+
+    /// Nothing under the carrier is nothing to say, and a channel that opens on silence in
+    /// tone-squelch mode would be a channel with no tone squelch.
+    #[test]
+    fn a_carrier_with_no_signalling_says_nothing_and_opens_nothing() {
+        let iq = signalling_iq(&vec![0.0; TONE_LEN]);
+        let mut detect = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        assert!(run_tone(&mut detect, &iq).0.is_empty());
+
+        let mut gated = tone_channel(tone_params(NfmToneMode::Ctcss, Some(88.5), None));
+        let (statuses, audio) = run_tone(&mut gated, &iq);
+        assert!(statuses.is_empty(), "{statuses:?}");
+        assert_eq!(rms(&audio[audio.len() / 2..]), 0.0);
+    }
+
+    /// Noise is not a tone: a bank that named the strongest of fifty bins whatever it read
+    /// would open a tone squelch on hiss.
+    #[test]
+    fn noise_names_no_tone_and_opens_no_gate() {
+        let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        let (statuses, _) = run_tone(&mut chan, &complex_noise(0x7013_5511, 0.5, TONE_LEN));
+        for status in &statuses {
+            assert_eq!(status.ctcss_hz, None, "{statuses:?}");
+            assert_eq!(status.dcs_code, None, "{statuses:?}");
+        }
+    }
+
+    /// What the channel accreted belongs to the station it was pointed at.
+    #[test]
+    fn retuning_forgets_the_tone() {
+        let iq = signalling_iq(&ctcss_audio(88.5, SUBAUDIBLE, RATE, TONE_LEN));
+        let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        assert_eq!(
+            run_tone(&mut chan, &iq).0.last().unwrap().ctcss_hz,
+            Some(88.5)
+        );
+        chan.retuned();
+        // A silent carrier on the new frequency must retract the tone, not keep reporting it.
+        let quiet = signalling_iq(&vec![0.0; TONE_LEN]);
+        let (statuses, _) = run_tone(&mut chan, &quiet);
+        assert_eq!(
+            statuses.last().and_then(|s| s.ctcss_hz),
+            None,
+            "{statuses:?}"
+        );
+    }
+
+    /// The channel only asks for gated input once it has something to measure under a carrier.
+    #[test]
+    fn only_a_tone_mode_needs_the_gated_span() {
+        assert!(!channel().needs_gated_input());
+        for mode in [NfmToneMode::Detect, NfmToneMode::Ctcss] {
+            let ctcss_hz = (mode == NfmToneMode::Ctcss).then_some(88.5);
+            assert!(tone_channel(tone_params(mode, ctcss_hz, None)).needs_gated_input());
+        }
+        // Turned off again, the channel goes back to being skippable.
+        let mut chan = tone_channel(tone_params(NfmToneMode::Detect, None, None));
+        chan.apply(settings(ChannelParams::Nfm(NfmParams::default())))
+            .unwrap();
+        assert!(!chan.needs_gated_input());
+    }
+
+    #[test]
+    fn a_tone_the_detector_does_not_search_for_is_refused() {
+        for p in [
+            tone_params(NfmToneMode::Ctcss, None, None),
+            tone_params(NfmToneMode::Ctcss, Some(88.0), None),
+            tone_params(NfmToneMode::Ctcss, Some(f64::NAN), None),
+            tone_params(NfmToneMode::Dcs, None, None),
+            tone_params(NfmToneMode::Dcs, None, Some(24)),
+            tone_params(NfmToneMode::Dcs, None, Some(999)),
+        ] {
+            let built = NfmChannel::new(ctx(), settings(ChannelParams::Nfm(p.clone())));
+            assert!(
+                matches!(built, Err(ChannelError::InvalidSettings(_))),
+                "{p:?} must be refused"
+            );
+            // And refused on the way in through `apply`, not only at construction.
+            let mut chan = channel();
+            assert!(matches!(
+                chan.apply(settings(ChannelParams::Nfm(p))),
+                Err(ChannelError::InvalidSettings(_))
+            ));
+        }
+    }
+
     const fn ctx() -> ChannelCtx {
         ChannelCtx { input_rate: RATE }
     }
@@ -315,7 +753,10 @@ mod tests {
     #[test]
     fn tx_round_trips_a_tone_through_the_demodulator() {
         for bandwidth_hz in [12_500.0, 25_000.0] {
-            let params = ChannelParams::Nfm(NfmParams { bandwidth_hz });
+            let params = ChannelParams::Nfm(NfmParams {
+                bandwidth_hz,
+                ..NfmParams::default()
+            });
             let mut tx = NfmTx::new(ctx(), settings(params.clone())).unwrap();
             tx.submit(TxPayload::Audio(tone_audio(1_000.0, 1.0, RATE, 24_000)))
                 .unwrap();
@@ -352,6 +793,7 @@ mod tests {
     fn tx_apply_rescales_deviation() {
         let wide = settings(ChannelParams::Nfm(NfmParams {
             bandwidth_hz: 25_000.0,
+            ..NfmParams::default()
         }));
         let mut tx = transmitter();
         tx.apply(wide.clone()).unwrap();

--- a/crates/channels/src/testgen/adsb.rs
+++ b/crates/channels/src/testgen/adsb.rs
@@ -1,5 +1,5 @@
-//! ADS-B reference modulator (PLAN §14): DF17 extended squitters, PPM-modulated onto complex
-//! baseband at 1 Mbit/s.
+//! Mode S reference modulator (PLAN §14): DF17 extended squitters and the DF4/5/11/20/21
+//! replies a transponder sends, PPM-modulated onto complex baseband at 1 Mbit/s.
 //!
 //! The CPR, Gillham and 6-bit-callsign encoders here are written straight from DO-260B rather
 //! than reused from [`crate::adsb`]. That is deliberate: NL(lat) is the closed form here and a
@@ -9,7 +9,7 @@
 use std::f64::consts::{PI, TAU};
 
 use num_complex::Complex;
-use sdrmm_dsp::mode_s_append_parity;
+use sdrmm_dsp::{mode_s_append_overlaid_parity, mode_s_append_parity};
 
 /// 6-bit identification charset (DO-260B §2.2.3.2.5.2).
 const IDENT_CHARSET: &[u8; 64] =
@@ -35,14 +35,29 @@ pub fn squitter(icao: u32, me: [u8; 7]) -> Vec<u8> {
     frame
 }
 
-fn put_bits(me: &mut [u8; 7], offset: usize, len: usize, value: u64) {
+fn put_bits(target: &mut [u8], offset: usize, len: usize, value: u64) {
     for i in 0..len {
         if value >> (len - 1 - i) & 1 == 1 {
             let bit = offset + i;
-            if let Some(byte) = me.get_mut(bit / 8) {
+            if let Some(byte) = target.get_mut(bit / 8) {
                 *byte |= 0x80 >> (bit % 8);
             }
         }
+    }
+}
+
+/// 8 six-bit characters at `offset`, upper-cased and space-padded — how both the extended
+/// squitter's identification field and the BDS 2,0 register spell a callsign.
+fn put_callsign(target: &mut [u8], offset: usize, callsign: &str) {
+    for (i, ch) in callsign
+        .chars()
+        .chain(std::iter::repeat(' '))
+        .take(8)
+        .enumerate()
+    {
+        let upper = ch.to_ascii_uppercase() as u8;
+        let code = IDENT_CHARSET.iter().position(|&c| c == upper).unwrap_or(0);
+        put_bits(target, offset + i * 6, 6, code as u64);
     }
 }
 
@@ -52,16 +67,7 @@ fn put_bits(me: &mut [u8; 7], offset: usize, len: usize, value: u64) {
 pub fn me_identification(callsign: &str) -> [u8; 7] {
     let mut me = [0u8; 7];
     put_bits(&mut me, 0, 5, 4);
-    for (i, ch) in callsign
-        .chars()
-        .chain(std::iter::repeat(' '))
-        .take(8)
-        .enumerate()
-    {
-        let upper = ch.to_ascii_uppercase() as u8;
-        let code = IDENT_CHARSET.iter().position(|&c| c == upper).unwrap_or(0);
-        put_bits(&mut me, 8 + i * 6, 6, code as u64);
-    }
+    put_callsign(&mut me, 8, callsign);
     me
 }
 
@@ -137,6 +143,110 @@ pub fn me_velocity(ground_speed_kt: f64, track_deg: f64, vertical_rate_fpm: i32)
     let rate = (f64::from(vertical_rate_fpm.abs()) / 64.0).round() as u64;
     put_bits(&mut me, 37, 9, (rate + 1).min(511));
     me
+}
+
+/// The BDS 2,0 Comm-B register: the register's own code followed by the same 8 six-bit
+/// characters an identification squitter sends (DO-181E §2.2.19.1.12).
+#[must_use]
+pub fn mb_identification(callsign: &str) -> [u8; 7] {
+    let mut mb = [0u8; 7];
+    put_bits(&mut mb, 0, 8, 0x20);
+    put_callsign(&mut mb, 8, callsign);
+    mb
+}
+
+/// An all-call reply (DF11): the address in the clear, and the parity keyed with the
+/// identifier of the interrogator that triggered it.
+#[must_use]
+pub fn all_call_reply(icao: u32, capability: u64, interrogator: u32) -> Vec<u8> {
+    let mut frame = vec![0u8; 4];
+    put_bits(&mut frame, 0, 5, 11);
+    put_bits(&mut frame, 5, 3, capability);
+    put_bits(&mut frame, 8, 24, u64::from(icao));
+    mode_s_append_overlaid_parity(&mut frame, interrogator);
+    frame
+}
+
+/// A surveillance altitude reply (DF4).
+#[must_use]
+pub fn altitude_reply(icao: u32, alt_ft: i32, flight_status: u64) -> Vec<u8> {
+    reply(4, icao, flight_status, altitude_field13(alt_ft), None)
+}
+
+/// A surveillance identity reply (DF5) carrying the four octal squawk digits.
+///
+/// # Panics
+/// If `squawk` is not four octal digits.
+#[must_use]
+pub fn identity_reply(icao: u32, squawk: &str, flight_status: u64) -> Vec<u8> {
+    reply(5, icao, flight_status, identity_field13(squawk), None)
+}
+
+/// A Comm-B altitude reply (DF20): a [`altitude_reply`] with 56 further bits of register.
+#[must_use]
+pub fn comm_b_altitude_reply(icao: u32, alt_ft: i32, flight_status: u64, mb: [u8; 7]) -> Vec<u8> {
+    reply(20, icao, flight_status, altitude_field13(alt_ft), Some(mb))
+}
+
+/// A Comm-B identity reply (DF21): an [`identity_reply`] with 56 further bits of register.
+///
+/// # Panics
+/// If `squawk` is not four octal digits.
+#[must_use]
+pub fn comm_b_identity_reply(icao: u32, squawk: &str, flight_status: u64, mb: [u8; 7]) -> Vec<u8> {
+    reply(21, icao, flight_status, identity_field13(squawk), Some(mb))
+}
+
+/// A reply to a roll-call interrogation: DF(5) FS(3) DR(5) UM(6) then the 13-bit AC or ID
+/// field, optionally 56 bits of Comm-B, and the parity with the address keyed onto it. DR and
+/// UM are left at "no request" and "no information", which is what a transponder with nothing
+/// pending sends.
+fn reply(df: u64, icao: u32, flight_status: u64, field13: u64, mb: Option<[u8; 7]>) -> Vec<u8> {
+    let mut frame = vec![0u8; 4];
+    put_bits(&mut frame, 0, 5, df);
+    put_bits(&mut frame, 5, 3, flight_status);
+    put_bits(&mut frame, 19, 13, field13);
+    if let Some(mb) = mb {
+        frame.extend_from_slice(&mb);
+    }
+    mode_s_append_overlaid_parity(&mut frame, icao);
+    frame
+}
+
+/// The 13-bit AC field of a surveillance reply: the extended squitter's 12-bit field with the
+/// M bit — metric units, which nothing sends — inserted clear after A4.
+fn altitude_field13(alt_ft: i32) -> u64 {
+    let ac12 = barometric_field(alt_ft);
+    (ac12 & 0xFC0) << 1 | (ac12 & 0x03F)
+}
+
+/// The 13-bit ID field, from four octal digits. Each digit's bits are named for their weight
+/// and interleaved with the others': C1 A1 C2 A2 C4 A4 X B1 D1 B2 D2 B4 D4.
+///
+/// # Panics
+/// If `squawk` is not four octal digits.
+fn identity_field13(squawk: &str) -> u64 {
+    let digits: Vec<u64> = squawk
+        .chars()
+        .filter_map(|c| c.to_digit(8))
+        .map(u64::from)
+        .collect();
+    let [a, b, c, d] = digits[..] else {
+        panic!("squawk must be four octal digits, got {squawk:?}")
+    };
+    let mut field = 0u64;
+    // (weight bit of the digit, index in the field), most significant index first.
+    for (value, places) in [
+        (a, [1, 3, 5]),
+        (b, [7, 9, 11]),
+        (c, [0, 2, 4]),
+        (d, [8, 10, 12]),
+    ] {
+        for (weight, index) in places.into_iter().enumerate() {
+            field |= (value >> weight & 1) << (12 - index);
+        }
+    }
+    field
 }
 
 /// The 12-bit AC field: 25 ft steps with the Q bit set, Gillham-coded 100 ft steps above

--- a/crates/channels/src/testgen/mod.rs
+++ b/crates/channels/src/testgen/mod.rs
@@ -26,6 +26,7 @@ pub mod adsb;
 pub mod ais;
 pub mod morse;
 pub mod navtex;
+pub mod nfm;
 pub mod pocsag;
 pub mod rds;
 pub mod rtty;

--- a/crates/channels/src/testgen/nfm.rs
+++ b/crates/channels/src/testgen/nfm.rs
@@ -1,0 +1,85 @@
+//! Subaudible-signalling reference modulator (PLAN §14): the CTCSS tone or DCS word a
+//! repeater keys under the voice, as the modulating waveform an FM transmitter carries.
+//!
+//! Deviations are expressed as a fraction of the channel's own full deviation, which is what
+//! the discriminator hands back: a repeater keys its subaudible signalling at 10–15 % of
+//! deviation, so that is what these default to.
+
+use sdrmm_dsp::golay23_encode;
+
+/// DCS bit rate (see [`crate::tone_squelch`] for the two figures in the literature).
+const DCS_BAUD: f64 = 134.4;
+const DCS_WORD_BITS: u32 = 23;
+/// The 3 fixed data bits above the code.
+const DCS_SIGNATURE: u16 = 0b100;
+
+/// A CTCSS tone as the modulating waveform: a continuous sinusoid below the voice band.
+#[must_use]
+pub fn ctcss_audio(hz: f64, deviation: f32, rate: f64, len: usize) -> Vec<f32> {
+    super::tone_audio(hz, deviation, rate, len)
+}
+
+/// The DCS word for `code` (three octal digits) as the modulating waveform: the 23-bit Golay
+/// codeword keyed as NRZ at 134.4 bit/s and repeated for the whole length, least significant
+/// bit of the word first.
+///
+/// Built from the code here rather than taken from the decoder's table, so a mistyped entry in
+/// that table shows up as a failing test instead of agreeing with itself.
+#[must_use]
+pub fn dcs_audio(code: u16, deviation: f32, rate: f64, len: usize) -> Vec<f32> {
+    let digits = u32::from(code);
+    let raw = (digits / 100 % 10) << 6 | (digits / 10 % 10) << 3 | (digits % 10);
+    let word = golay23_encode((u32::from(DCS_SIGNATURE) << 9 | raw) as u16);
+    let samples_per_bit = rate / DCS_BAUD;
+    (0..len)
+        .map(|k| {
+            let bit = (k as f64 / samples_per_bit) as u32 % DCS_WORD_BITS;
+            if word >> bit & 1 == 1 {
+                deviation
+            } else {
+                -deviation
+            }
+        })
+        .collect()
+}
+
+/// Sum two modulating waveforms — subaudible signalling under speech — truncated to the
+/// shorter of them.
+#[must_use]
+pub fn mix(a: &[f32], b: &[f32]) -> Vec<f32> {
+    a.iter().zip(b).map(|(x, y)| x + y).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The published DCS 023 word, keyed out at one sample per bit: transmission order is the
+    /// word backwards, which is the one thing about DCS that is easy to get wrong.
+    #[test]
+    fn the_dcs_waveform_is_the_published_word_sent_backwards() {
+        let rate = DCS_BAUD;
+        let audio = dcs_audio(23, 1.0, rate, DCS_WORD_BITS as usize);
+        let sent: String = audio
+            .iter()
+            .map(|&s| if s > 0.0 { '1' } else { '0' })
+            .collect();
+        let word: String = "10000001001111101100011".chars().rev().collect();
+        assert_eq!(sent, word);
+    }
+
+    #[test]
+    fn the_word_repeats_for_as_long_as_it_is_asked_to() {
+        let rate = DCS_BAUD * 4.0;
+        let bits = DCS_WORD_BITS as usize * 3;
+        let audio = dcs_audio(754, 0.2, rate, bits * 4);
+        assert_eq!(audio.len(), bits * 4);
+        for (k, &s) in audio.iter().enumerate() {
+            assert_eq!(s.abs(), 0.2, "sample {k} is not a keyed level");
+            let period = DCS_WORD_BITS as usize * 4;
+            if k >= period {
+                assert_eq!(s, audio[k - period], "word did not repeat at {k}");
+            }
+        }
+    }
+}

--- a/crates/channels/src/tone_squelch.rs
+++ b/crates/channels/src/tone_squelch.rs
@@ -1,0 +1,461 @@
+//! Subaudible signalling under an FM channel's voice: CTCSS tone squelch and DCS.
+//!
+//! Both live in the same place — a few percent of deviation below 300 Hz, where the voice is
+//! not — and both are read off the same discriminator output the audio path uses, so the whole
+//! detector hangs off one decimation to [`TONE_RATE`]. CTCSS is a continuous tone from a table
+//! of 50; DCS is a 23-bit Golay word repeating at 134.4 bit/s.
+//!
+//! The two run together whenever the channel is doing this at all, even when it was told to
+//! gate on only one of them: a receiver that can say "you are set to CTCSS 88.5 and this
+//! repeater sends DCS 023" is worth the fifty sliding correlators, which cost less than the
+//! decimation that feeds them.
+
+use sdrmm_dsp::{BitSync, DcBlocker, RealDecimator, ToneCorrelator, design_lowpass, golay23_ok};
+
+/// Input rate every NFM channel hands this, and the rate the two decimation stages are
+/// designed against.
+pub(crate) const INPUT_RATE_HZ: f64 = 48_000.0;
+
+/// Rate the detector runs at. Two decades below the input, which puts the whole subaudible
+/// band comfortably inside it and leaves DCS nine samples per bit; a single 48 kHz → 1.2 kHz
+/// stage would need a filter ten times as long for the same stopband, and it buys nothing.
+const TONE_RATE: f64 = 1_200.0;
+const STAGE1_DECIM: usize = 10;
+const STAGE2_DECIM: usize = 4;
+const STAGE1_TAPS: usize = 63;
+const STAGE2_TAPS: usize = 63;
+/// Everything the detector cares about is below this; everything above it would fold into the
+/// band if it were not removed first.
+const TONE_CUTOFF_HZ: f64 = 300.0;
+
+/// Corner of the highpass that keeps the tone out of the audio (see [`sdrmm_dsp::Highpass`]).
+pub(crate) const AUDIO_CORNER_HZ: f64 = 300.0;
+
+/// The 50 standard CTCSS tones (EIA/TIA-603), in Hz.
+pub const CTCSS_TONES_HZ: [f64; 50] = [
+    67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5, 85.4, 88.5, 91.5, 94.8, 97.4, 100.0, 103.5, 107.2,
+    110.9, 114.8, 118.8, 123.0, 127.3, 131.8, 136.5, 141.3, 146.2, 151.4, 156.7, 159.8, 162.2,
+    165.5, 167.9, 171.3, 173.8, 177.3, 179.9, 183.5, 186.2, 189.9, 192.8, 196.6, 199.5, 203.5,
+    206.5, 210.7, 218.1, 225.7, 229.1, 233.6, 241.8, 250.3, 254.1,
+];
+
+/// The 83 standard DCS codes, as the three octal digits a radio displays them with.
+///
+/// Only 83 of the 512 possible codes are standard, and the reason is the code itself: Golay
+/// (23,12) is cyclic, so every rotation of a word is also a word, and a receiver sliding over
+/// a continuously repeating transmission finds a valid one at all 23 alignments. The standard
+/// set is chosen so that *at most one* of those readings is ever a standard code — which makes
+/// this table part of the detector, not a list for a dropdown.
+pub const DCS_CODES: [u16; 83] = [
+    23, 25, 26, 31, 32, 43, 47, 51, 54, 65, //
+    71, 72, 73, 74, 114, 115, 116, 125, 131, 132, //
+    134, 143, 152, 155, 156, 162, 165, 172, 174, 205, //
+    223, 226, 243, 244, 245, 251, 261, 263, 265, 271, //
+    306, 311, 315, 331, 343, 346, 351, 364, 365, 371, //
+    411, 412, 413, 423, 431, 432, 445, 464, 465, 466, //
+    503, 506, 516, 532, 546, 565, 606, 612, 624, 627, //
+    631, 632, 654, 662, 664, 703, 712, 723, 731, 732, //
+    734, 743, 754,
+];
+
+/// Whether `hz` is one of the standard tones. Compared with a tolerance because the tones are
+/// quoted to a tenth of a hertz and a client may send back a rounded float.
+#[must_use]
+pub fn is_standard_ctcss(hz: f64) -> bool {
+    CTCSS_TONES_HZ.iter().any(|&t| (t - hz).abs() < 0.05)
+}
+
+#[must_use]
+pub fn is_standard_dcs(code: u16) -> bool {
+    DCS_CODES.contains(&code)
+}
+
+/// What the detector believes is under the voice right now.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Subaudible {
+    pub ctcss_hz: Option<f64>,
+    pub dcs_code: Option<u16>,
+}
+
+/// Both detectors behind one decimation chain.
+pub struct ToneSquelch {
+    stage1: RealDecimator,
+    stage2: RealDecimator,
+    stage1_out: Vec<f32>,
+    decimated: Vec<f32>,
+    ctcss: CtcssBank,
+    dcs: DcsDecoder,
+}
+
+impl ToneSquelch {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stage1: RealDecimator::new(
+                &design_lowpass(STAGE1_TAPS, TONE_CUTOFF_HZ / INPUT_RATE_HZ),
+                STAGE1_DECIM,
+            ),
+            stage2: RealDecimator::new(
+                &design_lowpass(
+                    STAGE2_TAPS,
+                    TONE_CUTOFF_HZ / (INPUT_RATE_HZ / STAGE1_DECIM as f64),
+                ),
+                STAGE2_DECIM,
+            ),
+            stage1_out: Vec::new(),
+            decimated: Vec::new(),
+            ctcss: CtcssBank::new(),
+            dcs: DcsDecoder::new(),
+        }
+    }
+
+    /// Feed one block of discriminator output and report what is under it now.
+    pub fn process(&mut self, demodulated: &[f32]) -> Subaudible {
+        self.stage1.process(demodulated, &mut self.stage1_out);
+        self.stage2.process(&self.stage1_out, &mut self.decimated);
+        for &s in &self.decimated {
+            self.ctcss.push(s);
+        }
+        self.dcs.process(&mut self.decimated);
+        Subaudible {
+            ctcss_hz: self.ctcss.detected(),
+            dcs_code: self.dcs.detected(),
+        }
+    }
+
+    /// Forget everything: the channel moved, and what was accreted describes the frequency it
+    /// left.
+    pub fn reset(&mut self) {
+        self.ctcss = CtcssBank::new();
+        self.dcs = DcsDecoder::new();
+    }
+}
+
+impl Default for ToneSquelch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Correlator window, in seconds. The closest pair of standard tones is 2.3 Hz apart, so the
+/// window has to resolve better than that: half a second puts the neighbour 18 dB down in the
+/// winner's bin. It is also the acquisition time — half a second before a tone is named, which
+/// is the same order as the 250 ms a radio takes.
+const CTCSS_WINDOW_S: f64 = 0.5;
+/// How often the bank picks a winner. Every sample would be fifty comparisons per sample for
+/// an answer that cannot change faster than the window slides.
+const CTCSS_DECISION_SAMPLES: usize = (TONE_RATE * 0.05) as usize;
+/// Amplitude the winner must reach, as a fraction of full deviation. A CTCSS tone is keyed at
+/// 10–15 % of deviation and this is well under the weakest of them.
+const CTCSS_MIN_LEVEL: f32 = 0.02;
+/// How far the winner must be above the runner-up. Voice energy leaking into the band is
+/// broadband and lifts every bin together, so a clear winner is the evidence that a *tone* is
+/// there rather than noise.
+const CTCSS_MARGIN: f32 = 3.0;
+/// Decisions agreeing before a tone is named, and disagreeing before it is dropped. Naming
+/// takes two (100 ms) and losing takes four (200 ms), so the gate does not chatter through a
+/// syllable that briefly swamps the bank.
+const CTCSS_ACQUIRE: u32 = 2;
+const CTCSS_RELEASE: u32 = 4;
+
+struct CtcssBank {
+    tones: Vec<ToneCorrelator>,
+    /// Latest magnitude per tone, refreshed every sample and read at each decision.
+    levels: Vec<f32>,
+    since_decision: usize,
+    /// Winner of the last decisions, and how many in a row have agreed.
+    candidate: Option<usize>,
+    agreements: u32,
+    held: Option<usize>,
+    misses: u32,
+}
+
+impl CtcssBank {
+    fn new() -> Self {
+        let window = (TONE_RATE * CTCSS_WINDOW_S) as usize;
+        Self {
+            tones: CTCSS_TONES_HZ
+                .iter()
+                .map(|&hz| ToneCorrelator::new(TONE_RATE, hz, window))
+                .collect(),
+            levels: vec![0.0; CTCSS_TONES_HZ.len()],
+            since_decision: 0,
+            candidate: None,
+            agreements: 0,
+            held: None,
+            misses: 0,
+        }
+    }
+
+    fn push(&mut self, sample: f32) {
+        for (tone, level) in self.tones.iter_mut().zip(self.levels.iter_mut()) {
+            *level = tone.push(sample);
+        }
+        self.since_decision += 1;
+        if self.since_decision >= CTCSS_DECISION_SAMPLES {
+            self.since_decision = 0;
+            self.decide();
+        }
+    }
+
+    /// The strongest bin, if it is strong enough and alone enough to be a tone.
+    fn winner(&self) -> Option<usize> {
+        let mut best = (0usize, 0.0f32);
+        let mut runner_up = 0.0f32;
+        for (index, &level) in self.levels.iter().enumerate() {
+            if level > best.1 {
+                runner_up = best.1;
+                best = (index, level);
+            } else if level > runner_up {
+                runner_up = level;
+            }
+        }
+        (best.1 >= CTCSS_MIN_LEVEL && best.1 >= runner_up * CTCSS_MARGIN).then_some(best.0)
+    }
+
+    fn decide(&mut self) {
+        let winner = self.winner();
+        if winner.is_some() && winner == self.candidate {
+            self.agreements += 1;
+        } else {
+            self.candidate = winner;
+            self.agreements = 1;
+        }
+        if winner.is_none() || winner != self.held {
+            self.misses += 1;
+        } else {
+            self.misses = 0;
+        }
+        if self.agreements >= CTCSS_ACQUIRE && winner.is_some() {
+            self.held = winner;
+            self.misses = 0;
+        } else if self.misses >= CTCSS_RELEASE {
+            self.held = None;
+        }
+    }
+
+    fn detected(&self) -> Option<f64> {
+        self.held.and_then(|i| CTCSS_TONES_HZ.get(i).copied())
+    }
+}
+
+/// DCS bit rate. The literature quotes both 134.4 and 134.3 bit/s; they differ by 0.07 %, far
+/// inside what a zero-crossing bit sync tracks over a 23-bit word.
+const DCS_BAUD: f64 = 134.4;
+const DCS_WORD_BITS: u32 = 23;
+/// The 3 data bits above the code, fixed by the standard. They are what tells a receiver it
+/// has the word the right way round: an inverted transmission presents `011` here instead, and
+/// the rotation that *does* present `100` reads out the code's inverse-pair partner — which is
+/// why there is no polarity switch anywhere in this module.
+const DCS_SIGNATURE: u32 = 0b100;
+/// Words that must agree before a code is named. The word repeats six times a second, so this
+/// costs 170 ms and buys a second independent 23-bit agreement against a chance parity match.
+const DCS_CONFIRMATIONS: u32 = 2;
+/// Word times without a standard code before the detector forgets what it had.
+const DCS_TIMEOUT_WORDS: f64 = 3.0;
+
+struct DcsDecoder {
+    /// The discriminator's DC is the receiver's tuning error, not the signal. The word's own
+    /// lowest component is its 5.84 Hz repetition rate, six times the blocker's ~0.95 Hz
+    /// corner at this rate, so removing one does not touch the other.
+    dc: DcBlocker,
+    sync: BitSync,
+    /// The 23 most recent bits, assembled back into the word's own bit order: transmission is
+    /// least-significant bit first, so each arrival enters at the top and shifts down.
+    register: u32,
+    bits: u32,
+    pending: Option<u16>,
+    confirmations: u32,
+    held: Option<u16>,
+    /// Samples since the last standard code was read.
+    quiet: usize,
+    timeout: usize,
+}
+
+impl DcsDecoder {
+    fn new() -> Self {
+        Self {
+            dc: DcBlocker::new(),
+            sync: BitSync::new(TONE_RATE, DCS_BAUD),
+            register: 0,
+            bits: 0,
+            pending: None,
+            confirmations: 0,
+            held: None,
+            quiet: 0,
+            timeout: (TONE_RATE * DCS_TIMEOUT_WORDS * f64::from(DCS_WORD_BITS) / DCS_BAUD) as usize,
+        }
+    }
+
+    fn process(&mut self, decimated: &mut [f32]) {
+        self.dc.process(decimated);
+        for &s in decimated.iter() {
+            let Some(bit) = self.sync.push(s) else {
+                self.quiet += 1;
+                self.forget_if_stale();
+                continue;
+            };
+            self.register = self.register >> 1 | u32::from(bit) << (DCS_WORD_BITS - 1);
+            self.bits = (self.bits + 1).min(DCS_WORD_BITS);
+            self.quiet += 1;
+            if self.bits >= DCS_WORD_BITS {
+                self.inspect();
+            }
+            self.forget_if_stale();
+        }
+    }
+
+    /// Test the window as it stands. Most alignments fail, which is not evidence of anything —
+    /// only a standard code read out of a valid word restarts the clock.
+    fn inspect(&mut self) {
+        if !golay23_ok(self.register) || self.register >> 20 != DCS_SIGNATURE {
+            return;
+        }
+        let code = octal_digits(self.register >> 11 & 0x1FF);
+        if !is_standard_dcs(code) {
+            return;
+        }
+        self.quiet = 0;
+        if self.pending == Some(code) {
+            self.confirmations += 1;
+        } else {
+            self.pending = Some(code);
+            self.confirmations = 1;
+        }
+        if self.confirmations >= DCS_CONFIRMATIONS {
+            self.held = Some(code);
+        }
+    }
+
+    fn forget_if_stale(&mut self) {
+        if self.quiet > self.timeout {
+            self.quiet = 0;
+            self.pending = None;
+            self.confirmations = 0;
+            self.held = None;
+        }
+    }
+
+    fn detected(&self) -> Option<u16> {
+        self.held
+    }
+}
+
+/// A 9-bit code as the three octal digits it is written with: `0b000_010_011` is `23`.
+fn octal_digits(code: u32) -> u16 {
+    ((code >> 6 & 7) * 100 + (code >> 3 & 7) * 10 + (code & 7)) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use sdrmm_dsp::golay23_encode;
+
+    use super::*;
+
+    /// The 83 standard codes are exactly the set that survives the code being cyclic. For each
+    /// one, every rotation of its word and of its complement is checked: the *only* standard
+    /// code any of them ever reads out is the code itself. Without that property the detector
+    /// would report a different code depending on where it happened to lock, and the whole
+    /// "confirm the same code twice" rule would ping-pong instead of converging.
+    #[test]
+    fn no_standard_dcs_code_can_be_read_out_of_another_ones_word() {
+        for &code in &DCS_CODES {
+            assert_eq!(
+                readouts(dcs_word(code)),
+                vec![code],
+                "{code:03} does not read out uniquely"
+            );
+        }
+    }
+
+    /// A radio has no polarity switch for DCS and neither does this: an inverted transmission
+    /// simply reads out the code's inverse-pair partner, which is another standard code.
+    /// 023 through an inverted discriminator is 047, and 047's own word is not 023's.
+    #[test]
+    fn an_inverted_transmission_reads_as_the_inverse_pair_partner() {
+        let mut paired = 0;
+        for &code in &DCS_CODES {
+            let read = readouts(dcs_word(code) ^ MASK);
+            assert!(read.len() <= 1, "{code:03} inverted reads as {read:?}");
+            let Some(&partner) = read.first() else {
+                continue;
+            };
+            paired += 1;
+            assert_ne!(partner, code, "{code:03} cannot be its own inverse");
+            // The relation is symmetric, as an inverse pair on a radio's code list is.
+            assert_eq!(
+                readouts(dcs_word(partner) ^ MASK),
+                vec![code],
+                "{code:03} <-> {partner:03} is not a pair"
+            );
+        }
+        assert_eq!(paired, 82, "41 inverse pairs, and 172 alone without one");
+        // The pair the literature names: 023 heard through an inverted discriminator is 047.
+        assert_eq!(readouts(dcs_word(23) ^ MASK), vec![47]);
+    }
+
+    #[test]
+    fn no_code_outside_the_standard_set_reads_as_one_inside_it() {
+        for raw in 0..512u32 {
+            let code = octal_digits(raw);
+            if is_standard_dcs(code) {
+                continue;
+            }
+            assert_eq!(
+                standard_readout(golay23_encode((DCS_SIGNATURE << 9 | raw) as u16)),
+                None,
+                "{code:03} masquerades as a standard code"
+            );
+        }
+    }
+
+    #[test]
+    fn octal_digits_are_the_digits_a_radio_shows() {
+        assert_eq!(octal_digits(0b000_010_011), 23);
+        assert_eq!(octal_digits(0b111_101_100), 754);
+        assert_eq!(octal_digits(0), 0);
+        assert_eq!(octal_digits(0b111_111_111), 777);
+    }
+
+    #[test]
+    fn the_standard_tables_are_what_they_claim() {
+        assert!(is_standard_ctcss(88.5) && is_standard_ctcss(254.1));
+        assert!(!is_standard_ctcss(88.0) && !is_standard_ctcss(300.0));
+        // A client that rounded 103.5 to a float a hair off must still be accepted.
+        assert!(is_standard_ctcss(103.500_000_1));
+        assert!(is_standard_dcs(23) && is_standard_dcs(754));
+        assert!(!is_standard_dcs(24) && !is_standard_dcs(999));
+        // Sorted and unique, so a client rendering the table in order gets a sane list.
+        assert!(CTCSS_TONES_HZ.windows(2).all(|w| w[0] < w[1]));
+        assert!(DCS_CODES.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    const MASK: u32 = (1 << DCS_WORD_BITS) - 1;
+
+    /// The transmitted word for a code, in the bit order the decoder assembles.
+    pub(super) fn dcs_word(code: u16) -> u32 {
+        let digits = u32::from(code);
+        let raw = (digits / 100 % 10) << 6 | (digits / 10 % 10) << 3 | (digits % 10);
+        golay23_encode((DCS_SIGNATURE << 9 | raw) as u16)
+    }
+
+    fn rotate(word: u32, by: u32) -> u32 {
+        (word << by | word >> (DCS_WORD_BITS - by)) & MASK
+    }
+
+    /// What [`DcsDecoder::inspect`] would make of a candidate window.
+    fn standard_readout(word: u32) -> Option<u16> {
+        if !golay23_ok(word) || word >> 20 != DCS_SIGNATURE {
+            return None;
+        }
+        let code = octal_digits(word >> 11 & 0x1FF);
+        is_standard_dcs(code).then_some(code)
+    }
+
+    /// Every standard code a sliding window over this repeating word can read out.
+    fn readouts(word: u32) -> Vec<u16> {
+        (0..DCS_WORD_BITS)
+            .filter_map(|r| standard_readout(rotate(word, r)))
+            .collect()
+    }
+}

--- a/crates/dsp/src/fec.rs
+++ b/crates/dsp/src/fec.rs
@@ -164,6 +164,48 @@ pub fn mode_s_fix_single_bit(frame: &mut [u8]) -> Option<usize> {
     None
 }
 
+/// Golay(23,12) generator x^11+x^10+x^6+x^5+x^4+x^2+1 — the one DCS / CDCSS keys its
+/// subaudible word with. The code is *cyclic*, which is the fact its users have to design
+/// around: every rotation of a codeword is another codeword, so a receiver sliding a 23-bit
+/// window over a repeating word finds a valid one at 23 alignments and needs something
+/// outside the code to pick the right one.
+const GOLAY23_POLY: u32 = 0xC75;
+const GOLAY23_CODE_BITS: u32 = 23;
+const GOLAY23_DATA_BITS: u32 = 12;
+const GOLAY23_CHECK_BITS: u32 = GOLAY23_CODE_BITS - GOLAY23_DATA_BITS;
+
+/// Remainder of a 23-bit word modulo the generator; 0 for a valid codeword.
+const fn golay23_remainder(word: u32) -> u32 {
+    let mut rem = word & ((1 << GOLAY23_CODE_BITS) - 1);
+    let mut shift = GOLAY23_CODE_BITS;
+    while shift > GOLAY23_CHECK_BITS {
+        shift -= 1;
+        if rem & (1 << shift) != 0 {
+            rem ^= GOLAY23_POLY << (shift - GOLAY23_CHECK_BITS);
+        }
+    }
+    rem
+}
+
+/// Systematic Golay(23,12): the 12 data bits followed by the 11 check bits they imply.
+/// Bits above the twelfth are ignored.
+#[must_use]
+pub const fn golay23_encode(data: u16) -> u32 {
+    let payload = (data as u32 & 0x0FFF) << GOLAY23_CHECK_BITS;
+    payload | golay23_remainder(payload)
+}
+
+/// Whether a 23-bit word's check bits match its data bits.
+///
+/// Detection only: the code corrects up to 3 errors, but a DCS receiver has no use for that.
+/// The word repeats about six times a second, so waiting for a clean copy costs nothing —
+/// while correcting one, over 23 alignments and both signal polarities, would turn noise into
+/// a plausible code far more often than it would rescue a real one.
+#[must_use]
+pub const fn golay23_ok(word: u32) -> bool {
+    golay23_remainder(word) == 0
+}
+
 /// POCSAG BCH(31,21) generator x^10+x^9+x^8+x^6+x^5+x^3+1.
 const POCSAG_GEN: u32 = 0x769;
 /// Codeword bits covered by the BCH code — everything but the trailing parity bit.
@@ -471,6 +513,45 @@ mod tests {
                 // The syndrome is *not* the address, which is why this function exists.
                 assert_ne!(mode_s_syndrome(&frame), overlay);
             }
+        }
+    }
+
+    /// The published DCS 023 word, which anchors the generator, the bit layout and the
+    /// systematic ordering all at once: data `100` + `000010011` (023 octal), check
+    /// `11101100011`.
+    #[test]
+    fn golay23_matches_the_published_dcs_word() {
+        let data = 0b1000_0001_0011;
+        let word = golay23_encode(data);
+        assert_eq!(format!("{word:023b}"), "10000001001111101100011");
+        assert!(golay23_ok(word));
+        assert_eq!(word >> GOLAY23_CHECK_BITS, u32::from(data));
+    }
+
+    #[test]
+    fn golay23_accepts_what_it_encodes_and_nothing_one_bit_away() {
+        for data in 0..1u16 << GOLAY23_DATA_BITS {
+            let word = golay23_encode(data);
+            assert!(golay23_ok(word), "data {data:#05x}");
+            for bit in 0..GOLAY23_CODE_BITS {
+                assert!(!golay23_ok(word ^ 1 << bit), "data {data:#05x} bit {bit}");
+            }
+        }
+    }
+
+    /// The property a DCS receiver has to design around: the code is cyclic, so sliding a
+    /// window over a repeating word finds a valid codeword at every one of 23 alignments, and
+    /// the complement of a codeword is one too. Neither is a defect — but a decoder that
+    /// assumed "parity checks out" meant "this is the word" would read a different code out
+    /// of the same transmission depending on where it happened to lock.
+    #[test]
+    fn every_rotation_and_the_complement_of_a_golay_word_is_also_one() {
+        let word = golay23_encode(0b1000_0001_0011);
+        for k in 0..GOLAY23_CODE_BITS {
+            let mask = (1 << GOLAY23_CODE_BITS) - 1;
+            let rotated = (word << k | word >> (GOLAY23_CODE_BITS - k)) & mask;
+            assert!(golay23_ok(rotated), "rotation {k}");
+            assert!(golay23_ok(rotated ^ mask), "complement of rotation {k}");
         }
     }
 

--- a/crates/dsp/src/fec.rs
+++ b/crates/dsp/src/fec.rs
@@ -90,18 +90,51 @@ pub fn mode_s_syndrome(frame: &[u8]) -> u32 {
     mode_s_crc(frame)
 }
 
+/// The value a frame's parity field was keyed with (ICAO Annex 10 Vol IV §3.1.2.3.3.2).
+///
+/// Most downlink formats do not transmit their parity bare: DF4/5/20/21 overlay the aircraft
+/// address on it (the AP field) and DF11 overlays the interrogator identifier (PI), so the
+/// receiver recovers the overlay by XOR-ing the field with the parity it computed itself. A
+/// frame whose parity really is bare — DF17/18 — returns 0, which is [`mode_s_syndrome`]'s
+/// zero by another name.
+///
+/// This is *not* the syndrome: the syndrome runs the recovered value on through the register
+/// and comes out as `value·x^24 mod g`, which is a fine "is it zero" test and a useless
+/// address.
+///
+/// `None` for anything that is not a 7- or 14-byte transmission.
+#[must_use]
+pub fn mode_s_overlay(frame: &[u8]) -> Option<u32> {
+    if frame.len() != MODE_S_SHORT_LEN && frame.len() != MODE_S_LONG_LEN {
+        return None;
+    }
+    let (body, field) = frame.split_at(frame.len() - MODE_S_PARITY_LEN);
+    let &[hi, mid, lo] = field else { return None };
+    let parity = u32::from(hi) << 16 | u32::from(mid) << 8 | u32::from(lo);
+    Some(mode_s_crc(body) ^ parity)
+}
+
 /// Append the 3 Mode S parity bytes to a 4- or 11-byte message body (used by test signals).
 ///
 /// # Panics
 /// If `body` is not a valid Mode S message body.
 pub fn mode_s_append_parity(body: &mut Vec<u8>) {
+    mode_s_append_overlaid_parity(body, 0);
+}
+
+/// [`mode_s_append_parity`] with `overlay` (an aircraft address or an interrogator identifier)
+/// keyed onto the parity field, which is what every downlink format but DF17/18 transmits.
+///
+/// # Panics
+/// If `body` is not a valid Mode S message body.
+pub fn mode_s_append_overlaid_parity(body: &mut Vec<u8>, overlay: u32) {
     assert!(
         body.len() == MODE_S_SHORT_LEN - MODE_S_PARITY_LEN
             || body.len() == MODE_S_LONG_LEN - MODE_S_PARITY_LEN,
         "mode s message body must be 4 or 11 bytes, got {}",
         body.len()
     );
-    let parity = mode_s_crc(body);
+    let parity = mode_s_crc(body) ^ (overlay & MODE_S_MASK);
     body.extend_from_slice(&[(parity >> 16) as u8, (parity >> 8) as u8, parity as u8]);
 }
 
@@ -422,6 +455,35 @@ mod tests {
         assert_ne!(mode_s_syndrome(&[0; 8]), 0);
         assert_ne!(mode_s_syndrome(&[]), 0);
         assert_eq!(mode_s_fix_single_bit(&mut [0; 8]), None);
+        assert_eq!(mode_s_overlay(&[0; 8]), None);
+        assert_eq!(mode_s_overlay(&[]), None);
+    }
+
+    /// The whole basis on which a DF4/5/20/21 reply can be attributed to an aircraft: the
+    /// address the transmitter keyed onto the parity comes back out of it exactly.
+    #[test]
+    fn an_overlaid_address_comes_back_out_of_the_parity() {
+        for overlay in [0x00_0001, 0x3C_6444, 0x48_40D6, 0xFF_FFFF] {
+            for body in [vec![0x20, 0x00, 0x19, 0x10], squitter_body()] {
+                let mut frame = body;
+                mode_s_append_overlaid_parity(&mut frame, overlay);
+                assert_eq!(mode_s_overlay(&frame), Some(overlay));
+                // The syndrome is *not* the address, which is why this function exists.
+                assert_ne!(mode_s_syndrome(&frame), overlay);
+            }
+        }
+    }
+
+    /// A bare-parity frame is the zero overlay, so one function answers both questions.
+    #[test]
+    fn a_bare_parity_frame_reads_as_a_zero_overlay() {
+        let mut frame = squitter_body();
+        mode_s_append_parity(&mut frame);
+        assert_eq!(mode_s_overlay(&frame), Some(0));
+        assert_eq!(mode_s_syndrome(&frame), 0);
+
+        flip(&mut frame, 42);
+        assert_ne!(mode_s_overlay(&frame), Some(0));
     }
 
     #[test]

--- a/crates/dsp/src/iir.rs
+++ b/crates/dsp/src/iir.rs
@@ -70,6 +70,57 @@ impl DcBlocker {
     }
 }
 
+/// Cascaded single-pole sections in [`Highpass`]. Three is what makes a 300 Hz corner reach
+/// −33 dB at 88.5 Hz — enough to take a CTCSS tone out of the audio — while still passing the
+/// bottom of the voice band.
+const HIGHPASS_SECTIONS: usize = 3;
+
+/// Highpass at `corner_hz`, 6 dB/octave per section, built as `x − lowpass(x)` three times.
+///
+/// This is an IIR because the job cannot be done any other way at audio rates: taking a
+/// subaudible tone out from under speech means a stopband at 250 Hz and a passband at 300,
+/// which is a transition of 0.001 of the sample rate at 48 kHz and thousands of FIR taps. A
+/// radio does not do that either — it cascades gentle sections and accepts that the highest
+/// CTCSS tones are only damped, not removed.
+#[derive(Clone, Debug)]
+pub struct Highpass {
+    lows: [f32; HIGHPASS_SECTIONS],
+    coeff: f32,
+}
+
+impl Highpass {
+    /// # Panics
+    /// If `rate` or `corner_hz` is not positive.
+    #[must_use]
+    pub fn new(rate: f64, corner_hz: f64) -> Self {
+        assert!(
+            rate > 0.0 && corner_hz > 0.0,
+            "rate and corner must be positive"
+        );
+        Self {
+            lows: [0.0; HIGHPASS_SECTIONS],
+            coeff: one_pole_coeff(rate, 1.0 / (std::f64::consts::TAU * corner_hz)),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.lows = [0.0; HIGHPASS_SECTIONS];
+    }
+
+    pub fn process(&mut self, samples: &mut [f32]) {
+        // Same per-block healing as the filters above: one non-finite sample would latch.
+        if !self.lows.iter().all(|v| v.is_finite()) {
+            self.reset();
+        }
+        for s in samples {
+            for low in &mut self.lows {
+                *low += self.coeff * (*s - *low);
+                *s -= *low;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::f32::consts::FRAC_1_SQRT_2;
@@ -133,6 +184,51 @@ mod tests {
         assert!(tone.iter().all(|v| v.is_finite()), "state still poisoned");
         let gain = rms_r(&tone[4_800..]) / FRAC_1_SQRT_2;
         assert!((0.891..1.122).contains(&gain), "post-recovery gain {gain}");
+    }
+
+    fn highpass_gain(corner_hz: f64, freq_hz: f64) -> f32 {
+        let rate = 48_000.0;
+        let mut filter = Highpass::new(rate, corner_hz);
+        let n = (rate * 2.0) as usize;
+        let mut x = real_tone(freq_hz / rate, n);
+        filter.process(&mut x);
+        rms_r(&x[n / 2..]) / FRAC_1_SQRT_2
+    }
+
+    /// The numbers the audio path depends on: a CTCSS tone damped out of audibility, the
+    /// voice band left where it was.
+    #[test]
+    fn highpass_takes_the_subaudible_band_out_and_keeps_the_voice_band() {
+        // Three cascaded 6 dB/octave sections: (f / √(f² + fc²))³.
+        let analytic = |f: f64| (f / f.hypot(300.0)).powi(3) as f32;
+        for freq_hz in [67.0f64, 88.5, 254.1, 300.0, 1_000.0] {
+            let gain = highpass_gain(300.0, freq_hz);
+            let want = analytic(freq_hz);
+            assert!(
+                (gain / want - 1.0).abs() < 0.1,
+                "{freq_hz} Hz: gain {gain}, expected {want}"
+            );
+        }
+        // The two ends of the trade: a CTCSS tone is gone from the audio, the voice is not.
+        // The discrete sections shed a little more than the analog form at the top of the
+        // voice band — ~0.7 dB at 3 kHz — which is the price of doing this at 48 kHz at all.
+        assert!(highpass_gain(300.0, 88.5) < 0.03);
+        assert!(highpass_gain(300.0, 3_000.0) > 0.9);
+    }
+
+    #[test]
+    fn highpass_removes_a_dc_offset_and_recovers_from_a_non_finite_sample() {
+        let mut filter = Highpass::new(48_000.0, 300.0);
+        let mut dc = vec![1.0f32; 48_000];
+        filter.process(&mut dc);
+        assert!(dc[dc.len() - 1].abs() < 0.01, "dc residue {}", dc[47_999]);
+
+        let mut poisoned = vec![0.5f32; 480];
+        poisoned[7] = f32::NAN;
+        filter.process(&mut poisoned);
+        let mut tone = real_tone(1_000.0 / 48_000.0, 48_000);
+        filter.process(&mut tone);
+        assert!(tone.iter().all(|v| v.is_finite()), "state still poisoned");
     }
 
     #[test]

--- a/crates/dsp/src/lib.rs
+++ b/crates/dsp/src/lib.rs
@@ -30,9 +30,9 @@ pub use bits::{
 pub use ddc::{Ddc, DdcError, flat_bandwidth_hz, resamplable_bandwidth_hz};
 pub use decim::{Decimator, RealDecimator};
 pub use fec::{
-    RdsOffset, crc16_ccitt, crc16_x25, hdlc_fcs_ok, mode_s_append_parity, mode_s_fix_single_bit,
-    mode_s_syndrome, pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block,
-    rds_syndrome,
+    RdsOffset, crc16_ccitt, crc16_x25, hdlc_fcs_ok, mode_s_append_overlaid_parity,
+    mode_s_append_parity, mode_s_fix_single_bit, mode_s_overlay, mode_s_syndrome,
+    pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block, rds_syndrome,
 };
 pub use fir::{design_bandpass, design_gaussian, design_lowpass};
 pub use firc::FirC;

--- a/crates/dsp/src/lib.rs
+++ b/crates/dsp/src/lib.rs
@@ -30,14 +30,15 @@ pub use bits::{
 pub use ddc::{Ddc, DdcError, flat_bandwidth_hz, resamplable_bandwidth_hz};
 pub use decim::{Decimator, RealDecimator};
 pub use fec::{
-    RdsOffset, crc16_ccitt, crc16_x25, hdlc_fcs_ok, mode_s_append_overlaid_parity,
-    mode_s_append_parity, mode_s_fix_single_bit, mode_s_overlay, mode_s_syndrome,
-    pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block, rds_syndrome,
+    RdsOffset, crc16_ccitt, crc16_x25, golay23_encode, golay23_ok, hdlc_fcs_ok,
+    mode_s_append_overlaid_parity, mode_s_append_parity, mode_s_fix_single_bit, mode_s_overlay,
+    mode_s_syndrome, pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block,
+    rds_syndrome,
 };
 pub use fir::{design_bandpass, design_gaussian, design_lowpass};
 pub use firc::FirC;
 pub use fm::FmDemod;
-pub use iir::{DcBlocker, Deemphasis, one_pole_coeff};
+pub use iir::{DcBlocker, Deemphasis, Highpass, one_pole_coeff};
 pub use nco::Nco;
 pub use pll::{Costas, LoopFilter, Pll};
 pub use resamp::FracResampler;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3640,6 +3640,7 @@ mod tests {
             squelch_db: None,
             params: ChannelParams::Nfm(NfmParams {
                 bandwidth_hz: 25_000.0,
+                ..NfmParams::default()
             }),
         };
 

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -158,8 +158,10 @@ pub(crate) struct ChannelHost {
     /// stamped with the absolute frequency they were heard on.
     offset_hz: f64,
     decoded: DecodedSink,
-    /// Whether this channel emits decoder frames, which decides what a closed squelch may do
-    /// to it (see [`ChannelHost::process`]).
+    /// Whether the type emits decoder frames at all; `emits_events` is this narrowed by what
+    /// the channel says it needs, and is recomputed whenever its settings change.
+    decodes: bool,
+    /// Whether a closed squelch must still feed this channel (see [`ChannelHost::process`]).
     emits_events: bool,
     /// Zero-filled stand-in handed to a decoder while the gate is closed; reused, so the
     /// substitution costs no allocation in steady state.
@@ -190,6 +192,8 @@ impl ChannelHost {
             .map_err(|e| ChannelError::InvalidSettings(e.to_string()))?;
         let filter = sdrmm_channels::channel_filter(&settings.params)?;
         let rx = sdrmm_channels::create(ChannelCtx { input_rate }, settings)?;
+        let decodes = descriptor.decoder_kind.is_some();
+        let emits_events = decodes && rx.needs_gated_input();
         Ok(Box::new(Self {
             ddc,
             filter,
@@ -211,7 +215,8 @@ impl ChannelHost {
             pcm_tx,
             offset_hz: settings.offset_hz,
             decoded,
-            emits_events: descriptor.decoder_kind.is_some(),
+            decodes,
+            emits_events,
             gated: Vec::new(),
         }))
     }
@@ -310,6 +315,9 @@ impl ChannelHost {
         if let Err(e) = self.rx.apply(settings) {
             tracing::error!(error = %e, "validated channel settings rejected on dsp thread");
         }
+        // Settings decide it: an NFM channel needs the gated span only once it has been given
+        // a tone mode, and stops needing it again when that is turned off.
+        self.emits_events = self.decodes && self.rx.needs_gated_input();
     }
 }
 

--- a/crates/engine/tests/decode.rs
+++ b/crates/engine/tests/decode.rs
@@ -19,15 +19,16 @@
 use std::{path::Path, sync::Arc, time::Duration};
 
 use num_complex::Complex;
-use sdrmm_channels::{AprsTx, ChannelCtx, ChannelTx, TxPayload, testgen};
+use sdrmm_channels::{AprsTx, ChannelCtx, ChannelTx, MicE, MicEBit, TxPayload, testgen};
 use sdrmm_device::DeviceRegistry;
 use sdrmm_device_virtual::VirtualDriver;
 use sdrmm_engine::Engine;
 use sdrmm_recorder::SigmfWriter;
 use sdrmm_wire::{
     AcarsParams, AdsbParams, AisChannel, AisParams, AprsMode, AprsParams, ChannelParams,
-    ChannelSettings, DecodedRecord, DecoderEvent, MorseParams, NavtexParams, PocsagBaud,
-    PocsagParams, RdsUpdate, RttyParams, SubghzEncoding, SubghzParams, WfmParams,
+    ChannelSettings, DecodedRecord, DecoderEvent, MorseParams, NavtexParams, NfmParams,
+    NfmToneMode, PocsagBaud, PocsagParams, RdsUpdate, RttyParams, SubghzEncoding, SubghzParams,
+    WfmParams,
 };
 use tempfile::TempDir;
 
@@ -276,6 +277,105 @@ async fn ais_position_survives_the_ddc_and_reaches_the_decoded_stream() {
     );
 }
 
+/// Mic-E's position is split between the destination callsign and a binary information field,
+/// so the whole pipeline has to carry both halves for either to mean anything.
+#[tokio::test]
+async fn a_mic_e_packet_survives_the_ddc_and_reaches_the_decoded_stream() {
+    let dir = TempDir::new().unwrap();
+    let engine = engine_for(dir.path());
+    let offset_hz = 40_000.0;
+
+    let report = MicE {
+        lat: 52.5,
+        lon: 13.4,
+        speed_kt: 42,
+        course_deg: 251,
+        symbol: "/j",
+        bits: [MicEBit::Standard; 3],
+        ..MicE::default()
+    };
+    let frame = AprsTx::ui_frame(
+        "DL1ABC-7",
+        &report.destination(),
+        &["WIDE2-2"],
+        &report.info(),
+    );
+    let mut iq = testgen::resample(
+        &aprs_burst(frame),
+        AprsTx::descriptor().input_rate_hz,
+        NARROW_DEVICE_RATE,
+    );
+    testgen::shift(&mut iq, offset_hz, NARROW_DEVICE_RATE);
+
+    let device = plant(dir.path(), "mice", iq, NARROW_DEVICE_RATE);
+    let record = decode_first(
+        &engine,
+        &device,
+        ChannelSettings {
+            offset_hz,
+            squelch_db: None,
+            params: ChannelParams::Aprs(AprsParams::default()),
+        },
+        |event| matches!(event, DecoderEvent::Aprs(p) if p.mic_e_message.is_some()),
+    )
+    .await;
+
+    let DecoderEvent::Aprs(packet) = record.event else {
+        unreachable!("filtered above")
+    };
+    assert_eq!(packet.source, "DL1ABC-7");
+    assert_eq!(packet.mic_e_message.as_deref(), Some("Off Duty"));
+    assert_eq!(packet.speed_kt, Some(42.0));
+    assert_eq!(packet.course_deg, Some(251.0));
+    assert_eq!(packet.symbol.as_deref(), Some("/j"));
+    let (lat, lon) = (packet.lat.unwrap(), packet.lon.unwrap());
+    assert!((lat - 52.5).abs() < 1e-3, "lat {lat}");
+    assert!((lon - 13.4).abs() < 1e-3, "lon {lon}");
+}
+
+/// Subaudible signalling is the one decoder whose events describe a channel rather than a
+/// message, and the one that shares a channel with audio — so the plumbing worth proving is
+/// that it reaches the decoded stream at all while the NFM audio path goes on working.
+#[tokio::test]
+async fn a_ctcss_tone_survives_the_ddc_and_reaches_the_decoded_stream() {
+    let dir = TempDir::new().unwrap();
+    let engine = engine_for(dir.path());
+    let offset_hz = -30_000.0;
+
+    // Two seconds: the correlator bank names a tone after half of one.
+    let len = (NARROW_DEVICE_RATE * 2.0) as usize;
+    let audio = testgen::nfm::mix(
+        &testgen::nfm::ctcss_audio(88.5, 0.15, NARROW_DEVICE_RATE, len),
+        &testgen::tone_audio(1_000.0, 0.6, NARROW_DEVICE_RATE, len),
+    );
+    let mut iq = testgen::fm_modulate(&audio, 2_500.0, NARROW_DEVICE_RATE);
+    testgen::shift(&mut iq, offset_hz, NARROW_DEVICE_RATE);
+
+    let device = plant(dir.path(), "ctcss", iq, NARROW_DEVICE_RATE);
+    let record = decode_first(
+        &engine,
+        &device,
+        ChannelSettings {
+            offset_hz,
+            squelch_db: None,
+            params: ChannelParams::Nfm(NfmParams {
+                tone_mode: NfmToneMode::Ctcss,
+                ctcss_hz: Some(88.5),
+                ..NfmParams::default()
+            }),
+        },
+        |event| matches!(event, DecoderEvent::Tone(t) if t.ctcss_hz.is_some()),
+    )
+    .await;
+
+    let DecoderEvent::Tone(status) = record.event else {
+        unreachable!("filtered above")
+    };
+    assert_eq!(status.ctcss_hz, Some(88.5));
+    assert_eq!(status.dcs_code, None);
+    assert!(status.open, "the tone the channel was set to must open it");
+}
+
 /// ADS-B end to end at 2 Msps, the lowest rate that carries it — one sample per half-chip.
 #[tokio::test]
 async fn adsb_squitter_survives_the_ddc_and_reaches_the_decoded_stream() {
@@ -322,6 +422,46 @@ async fn adsb_squitter_survives_the_ddc_and_reaches_the_decoded_stream() {
     let (lat, lon) = (message.lat.unwrap(), message.lon.unwrap());
     assert!((lat - 52.2657).abs() < 0.02, "lat {lat}");
     assert!((lon - 3.9184).abs() < 0.02, "lon {lon}");
+}
+
+/// A roll-call reply carries its address only on the parity, so it is decodable only in the
+/// company of the frames that proved that address. The whole transmission has to reach the
+/// decoder in order for the last frame in it to mean anything.
+#[tokio::test]
+async fn a_mode_s_identity_reply_survives_the_ddc_and_reaches_the_decoded_stream() {
+    let dir = TempDir::new().unwrap();
+    let engine = engine_for(dir.path());
+    let icao = 0x40_621D;
+
+    let frames = vec![
+        testgen::adsb::all_call_reply(icao, 5, 0),
+        testgen::adsb::identity_reply(icao, "7421", 0),
+        testgen::adsb::altitude_reply(icao, 24_000, 0),
+    ];
+    // A generous gap: a short frame is only scanned once a long frame's worth of samples sits
+    // behind it, so the transmission must not end on one.
+    let iq = testgen::adsb::transmission(&frames, 500.0, 0.8, ADSB_DEVICE_RATE);
+
+    let device = plant(dir.path(), "modes", iq, ADSB_DEVICE_RATE);
+    let record = decode_first(
+        &engine,
+        &device,
+        ChannelSettings {
+            offset_hz: 0.0,
+            squelch_db: None,
+            params: ChannelParams::Adsb(AdsbParams::default()),
+        },
+        |event| matches!(event, DecoderEvent::Adsb(a) if a.df == 5),
+    )
+    .await;
+
+    let DecoderEvent::Adsb(message) = record.event else {
+        unreachable!("filtered above")
+    };
+    assert_eq!(message.icao, "40621D");
+    assert_eq!(message.squawk.as_deref(), Some("7421"));
+    // An identity reply has no ME field, so it has no type code either.
+    assert_eq!(message.type_code, None);
 }
 
 #[tokio::test]

--- a/crates/wire/src/channel.rs
+++ b/crates/wire/src/channel.rs
@@ -100,16 +100,55 @@ fn default_deemphasis_us() -> f32 {
     50.0
 }
 
+/// What an NFM channel does about the subaudible signalling under the voice (PLAN §8).
+/// CTCSS is a continuous tone below the voice band; DCS is a 23-bit Golay word repeating
+/// under it at 134.4 bit/s. Both are how a repeater tells its own users apart from the
+/// co-channel traffic 50 km away.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NfmToneMode {
+    /// Nothing is detected and nothing is gated — the audio path a channel had before this
+    /// setting existed, including its flat response down to DC.
+    #[default]
+    Off,
+    /// Report whatever tone or code is present without acting on it: what a listener wants
+    /// when the question is "what does this repeater use?".
+    Detect,
+    /// Pass audio only while [`NfmParams::ctcss_hz`] is present.
+    Ctcss,
+    /// Pass audio only while [`NfmParams::dcs_code`] is present.
+    Dcs,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct NfmParams {
     #[serde(default = "default_nfm_bandwidth_hz")]
     pub bandwidth_hz: f64,
+    #[serde(default)]
+    pub tone_mode: NfmToneMode,
+    /// The CTCSS tone to open on, in Hz. One of the 50 standard tones (EIA/TIA-603); anything
+    /// else is refused, because the detector only searches those.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ctcss_hz: Option<f64>,
+    /// The DCS code to open on, as the three octal digits a radio displays — `23` for 023,
+    /// `754` for 754. One of the 83 standard codes.
+    ///
+    /// The standard list is not a convenience: the Golay code DCS is built on is cyclic, so
+    /// only a set with no rotation aliasing between its members can be read back unambiguously
+    /// from a continuously repeating word. A code's *inverse* is another code in the list —
+    /// 023 received through an inverted discriminator is 047 — so there is no polarity switch
+    /// here, and none on a radio either.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcs_code: Option<u16>,
 }
 
 impl Default for NfmParams {
     fn default() -> Self {
         Self {
             bandwidth_hz: default_nfm_bandwidth_hz(),
+            tone_mode: NfmToneMode::default(),
+            ctcss_hz: None,
+            dcs_code: None,
         }
     }
 }

--- a/crates/wire/src/decode.rs
+++ b/crates/wire/src/decode.rs
@@ -327,6 +327,23 @@ pub struct SubghzFrame {
     pub timings_us: Vec<u32>,
 }
 
+/// Subaudible signalling heard under an NFM channel's voice (PLAN §8).
+///
+/// Emitted only when the picture changes. Both CTCSS and DCS run for the whole of a
+/// transmission, so an event per block would be the same event forty times a second.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ToneSquelchStatus {
+    /// The CTCSS tone present, in Hz.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ctcss_hz: Option<f64>,
+    /// The DCS code present, as the three octal digits a radio displays.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dcs_code: Option<u16>,
+    /// Whether audio is passing. Always true unless the channel was told to gate on a tone:
+    /// [`crate::NfmToneMode::Detect`] reports what is there without acting on it.
+    pub open: bool,
+}
+
 /// Typed decoder output (PLAN §5). Adjacently tagged so the generated TypeScript is a
 /// discriminated union on `kind` that panels can exhaustively `switch` on, and so the log
 /// database can index on `kind` without parsing the blob.
@@ -343,6 +360,7 @@ pub enum DecoderEvent {
     Navtex(NavtexMessage),
     Acars(AcarsMessage),
     Subghz(SubghzFrame),
+    Tone(ToneSquelchStatus),
 }
 
 impl DecoderEvent {
@@ -360,6 +378,7 @@ impl DecoderEvent {
             Self::Navtex(_) => "navtex",
             Self::Acars(_) => "acars",
             Self::Subghz(_) => "subghz",
+            Self::Tone(_) => "tone",
         }
     }
 
@@ -447,6 +466,20 @@ impl DecoderEvent {
                 }
                 parts.join(" · ")
             }
+            Self::Tone(t) => {
+                let mut parts = Vec::new();
+                if let Some(hz) = t.ctcss_hz {
+                    parts.push(format!("CTCSS {hz:.1} Hz"));
+                }
+                if let Some(code) = t.dcs_code {
+                    parts.push(format!("DCS {code:03}"));
+                }
+                if parts.is_empty() {
+                    parts.push("no tone".to_owned());
+                }
+                parts.push(if t.open { "open" } else { "muted" }.to_owned());
+                parts.join(" · ")
+            }
             Self::Subghz(f) => {
                 let mut parts = vec![if f.bits == 0 {
                     format!("raw, {} edges", f.timings_us.len())
@@ -500,7 +533,7 @@ impl DecoderEvent {
                 .address
                 .map(|a| format!("{a:05X}"))
                 .or_else(|| (!f.data.is_empty()).then(|| f.data.clone())),
-            Self::Rtty(_) | Self::Morse(_) => None,
+            Self::Rtty(_) | Self::Morse(_) | Self::Tone(_) => None,
         }
     }
 }
@@ -572,6 +605,7 @@ mod tests {
             DecoderEvent::Navtex(NavtexMessage::default()),
             DecoderEvent::Acars(AcarsMessage::default()),
             DecoderEvent::Subghz(SubghzFrame::default()),
+            DecoderEvent::Tone(ToneSquelchStatus::default()),
         ] {
             let json = serde_json::to_value(&ev).unwrap();
             assert_eq!(json["kind"], ev.kind());

--- a/crates/wire/src/decode.rs
+++ b/crates/wire/src/decode.rs
@@ -170,6 +170,12 @@ pub struct AprsPacket {
     pub speed_kt: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub altitude_ft: Option<i32>,
+    /// The Mic-E message the operator selected, named (APRS 1.0.1 ch. 10): one of the 7
+    /// standard messages, one of the 7 custom ones, or `Emergency`. `Unknown` is the spec's
+    /// own word for a packet whose three message bits mix the standard and custom tables.
+    /// Absent on every packet that is not Mic-E.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mic_e_message: Option<String>,
     /// TNC2 monitor line (`SRC>DEST,PATH:info`) — the interop format.
     pub tnc2: String,
 }
@@ -408,7 +414,12 @@ impl DecoderEvent {
                 }
                 parts.join(" · ")
             }
-            Self::Aprs(p) => p.tnc2.clone(),
+            // A Mic-E monitor line is packed binary, so the message named beside it is the
+            // only part of the row a reader can act on.
+            Self::Aprs(p) => match &p.mic_e_message {
+                Some(message) => format!("{} · {message}", p.tnc2),
+                None => p.tnc2.clone(),
+            },
             Self::Rtty(t) => t.text.clone(),
             Self::Morse(m) => m.text.clone(),
             Self::Navtex(n) => {
@@ -643,6 +654,25 @@ mod tests {
         });
         assert_eq!(decoded.summary(), "24 bit A1B2C3 · addr 0A1B2 · btn 3 · ×4");
         assert_eq!(decoded.station().as_deref(), Some("0A1B2"));
+    }
+
+    /// A Mic-E packet's TNC2 line is the packed binary it was sent as, so the log row names
+    /// the message; every other APRS packet's line is already readable and is left alone.
+    #[test]
+    fn a_mic_e_summary_names_the_message_beside_the_monitor_line() {
+        let mut packet = AprsPacket {
+            tnc2: "DL1ABC-9>S32U6T:`(_fn\"Oj/".to_owned(),
+            ..AprsPacket::default()
+        };
+        assert_eq!(
+            DecoderEvent::Aprs(packet.clone()).summary(),
+            "DL1ABC-9>S32U6T:`(_fn\"Oj/"
+        );
+        packet.mic_e_message = Some("Returning".to_owned());
+        assert_eq!(
+            DecoderEvent::Aprs(packet).summary(),
+            "DL1ABC-9>S32U6T:`(_fn\"Oj/ · Returning"
+        );
     }
 
     #[test]

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -22,12 +22,13 @@ pub mod ws;
 pub use channel::{
     AcarsParams, AdsbParams, AisChannel, AisParams, AmParams, AprsMode, AprsParams,
     ChannelDescriptor, ChannelInfo, ChannelParams, ChannelSettings, MorseParams, NavtexParams,
-    NfmParams, PocsagBaud, PocsagParams, RttyParams, RttyStopBits, Sideband, SsbParams,
-    SubghzModulation, SubghzParams, WfmParams,
+    NfmParams, NfmToneMode, PocsagBaud, PocsagParams, RttyParams, RttyStopBits, Sideband,
+    SsbParams, SubghzModulation, SubghzParams, WfmParams,
 };
 pub use decode::{
     AcarsMessage, AdsbMessage, AisMessage, AprsPacket, DecodedRecord, DecoderEvent, MorseText,
     NavtexMessage, PocsagMessage, PocsagPayload, RdsUpdate, RttyText, SubghzEncoding, SubghzFrame,
+    ToneSquelchStatus,
 };
 pub use device::{
     Capabilities, DeviceInfo, DeviceSettings, Direction, Duplex, ExtraSetting, ExtraValue,
@@ -209,7 +210,10 @@ mod contract_tests {
         assert_eq!(
             nfm,
             ChannelParams::Nfm(NfmParams {
-                bandwidth_hz: 12_500.0
+                bandwidth_hz: 12_500.0,
+                tone_mode: NfmToneMode::Off,
+                ctcss_hz: None,
+                dcs_code: None,
             })
         );
         let ssb: ChannelParams = serde_json::from_str(r#"{"type":"ssb","settings":{}}"#).unwrap();

--- a/openapi.json
+++ b/openapi.json
@@ -3145,6 +3145,24 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "data",
+              "kind"
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/ToneSquelchStatus"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "tone"
+                ]
+              }
+            }
           }
         ],
         "description": "Typed decoder output (PLAN §5). Adjacently tagged so the generated TypeScript is a\ndiscriminated union on `kind` that panels can exhaustively `switch` on, and so the log\ndatabase can index on `kind` without parsing the blob."
@@ -3860,8 +3878,38 @@
           "bandwidth_hz": {
             "type": "number",
             "format": "double"
+          },
+          "ctcss_hz": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "The CTCSS tone to open on, in Hz. One of the 50 standard tones (EIA/TIA-603); anything\nelse is refused, because the detector only searches those."
+          },
+          "dcs_code": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The DCS code to open on, as the three octal digits a radio displays — `23` for 023,\n`754` for 754. One of the 83 standard codes.\n\nThe standard list is not a convenience: the Golay code DCS is built on is cyclic, so\nonly a set with no rotation aliasing between its members can be read back unambiguously\nfrom a continuously repeating word. A code's *inverse* is another code in the list —\n023 received through an inverted discriminator is 047 — so there is no polarity switch\nhere, and none on a radio either.",
+            "minimum": 0
+          },
+          "tone_mode": {
+            "$ref": "#/components/schemas/NfmToneMode"
           }
         }
+      },
+      "NfmToneMode": {
+        "type": "string",
+        "description": "What an NFM channel does about the subaudible signalling under the voice (PLAN §8).\nCTCSS is a continuous tone below the voice band; DCS is a 23-bit Golay word repeating\nunder it at 134.4 bit/s. Both are how a repeater tells its own users apart from the\nco-channel traffic 50 km away.",
+        "enum": [
+          "off",
+          "detect",
+          "ctcss",
+          "dcs"
+        ]
       },
       "NodeBody": {
         "oneOf": [
@@ -5822,6 +5870,36 @@
             "items": {
               "$ref": "#/components/schemas/TemplateInfo"
             }
+          }
+        }
+      },
+      "ToneSquelchStatus": {
+        "type": "object",
+        "description": "Subaudible signalling heard under an NFM channel's voice (PLAN §8).\n\nEmitted only when the picture changes. Both CTCSS and DCS run for the whole of a\ntransmission, so an event per block would be the same event forty times a second.",
+        "required": [
+          "open"
+        ],
+        "properties": {
+          "ctcss_hz": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "The CTCSS tone present, in Hz."
+          },
+          "dcs_code": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The DCS code present, as the three octal digits a radio displays.",
+            "minimum": 0
+          },
+          "open": {
+            "type": "boolean",
+            "description": "Whether audio is passing. Always true unless the channel was told to gate on a tone:\n[`crate::NfmToneMode::Detect`] reports what is there without acting on it."
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -2062,6 +2062,13 @@
             ],
             "format": "double"
           },
+          "mic_e_message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The Mic-E message the operator selected, named (APRS 1.0.1 ch. 10): one of the 7\nstandard messages, one of the 7 custom ones, or `Emergency`. `Unknown` is the spec's\nown word for a packet whose three message bits mix the standard and custom tables.\nAbsent on every packet that is not Mic-E."
+          },
           "path": {
             "type": "array",
             "items": {

--- a/web/src/components/ChannelControls.tsx
+++ b/web/src/components/ChannelControls.tsx
@@ -41,6 +41,40 @@ const APRS_MODES: Options<NonNullable<ChannelParamsOf<"aprs">["mode"]>> = [
   { value: "afsk1200", label: "AFSK 1200" },
   { value: "g3ruh9600", label: "G3RUH 9600" },
 ];
+const NFM_TONE_MODES: Options<NonNullable<ChannelParamsOf<"nfm">["tone_mode"]>> = [
+  { value: "off", label: "Off" },
+  { value: "detect", label: "Detect" },
+  { value: "ctcss", label: "CTCSS" },
+  { value: "dcs", label: "DCS" },
+];
+// The 50 standard CTCSS tones and the 83 standard DCS codes, as a radio's own code lists. The
+// server refuses anything outside them (it is what the detector searches), so an entry that
+// drifted from `channels::tone_squelch` fails loudly the first time it is picked.
+const CTCSS_TONES_HZ = [
+  67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5, 85.4, 88.5, 91.5, 94.8, 97.4, 100.0, 103.5, 107.2,
+  110.9, 114.8, 118.8, 123.0, 127.3, 131.8, 136.5, 141.3, 146.2, 151.4, 156.7, 159.8, 162.2, 165.5,
+  167.9, 171.3, 173.8, 177.3, 179.9, 183.5, 186.2, 189.9, 192.8, 196.6, 199.5, 203.5, 206.5, 210.7,
+  218.1, 225.7, 229.1, 233.6, 241.8, 250.3, 254.1,
+];
+const DCS_CODES = [
+  23, 25, 26, 31, 32, 43, 47, 51, 54, 65, 71, 72, 73, 74, 114, 115, 116, 125, 131, 132, 134, 143,
+  152, 155, 156, 162, 165, 172, 174, 205, 223, 226, 243, 244, 245, 251, 261, 263, 265, 271, 306,
+  311, 315, 331, 343, 346, 351, 364, 365, 371, 411, 412, 413, 423, 431, 432, 445, 464, 465, 466,
+  503, 506, 516, 532, 546, 565, 606, 612, 624, 627, 631, 632, 654, 662, 664, 703, 712, 723, 731,
+  732, 734, 743, 754,
+];
+// The tone and code a radio ships set to, so switching to a gating mode is one click rather
+// than two: 88.5 Hz and 023 are the most-used of each list.
+const CTCSS_DEFAULT_HZ = 88.5;
+const DCS_DEFAULT_CODE = 23;
+const CTCSS_OPTIONS: Options<number> = CTCSS_TONES_HZ.map((hz) => ({
+  value: hz,
+  label: `${hz.toFixed(1)} Hz`,
+}));
+const DCS_OPTIONS: Options<number> = DCS_CODES.map((code) => ({
+  value: code,
+  label: String(code).padStart(3, "0"),
+}));
 const RTTY_STOP_BITS: Options<NonNullable<ChannelParamsOf<"rtty">["stop_bits"]>> = [
   { value: "one", label: "1" },
   { value: "one_and_half", label: "1.5" },
@@ -172,19 +206,62 @@ function ModeControls({
   onParams: (params: ChannelParams) => void;
 }) {
   switch (params.type) {
-    case "nfm":
+    case "nfm": {
+      const mode = params.settings.tone_mode ?? "off";
+      const set = (settings: ChannelParamsOf<"nfm">) => onParams({ type: "nfm", settings });
       return (
-        <label className={LABEL}>
-          BW
-          <BandwidthSelect
-            valueHz={params.settings.bandwidth_hz ?? 12_500}
-            optionsHz={[12_500, 25_000]}
-            onCommit={(bandwidth_hz) =>
-              onParams({ type: "nfm", settings: { ...params.settings, bandwidth_hz } })
-            }
-          />
-        </label>
+        <>
+          <label className={LABEL}>
+            BW
+            <BandwidthSelect
+              valueHz={params.settings.bandwidth_hz ?? 12_500}
+              optionsHz={[12_500, 25_000]}
+              onCommit={(bandwidth_hz) => set({ ...params.settings, bandwidth_hz })}
+            />
+          </label>
+          <label className={LABEL}>
+            Tone
+            <Select
+              label="Tone squelch"
+              value={mode}
+              options={NFM_TONE_MODES}
+              // Switching to a gating mode without a tone chosen would be settings the server
+              // refuses, so the first standard tone and code stand in until one is picked.
+              onChange={(tone_mode) =>
+                set({
+                  ...params.settings,
+                  tone_mode,
+                  ctcss_hz: params.settings.ctcss_hz ?? CTCSS_DEFAULT_HZ,
+                  dcs_code: params.settings.dcs_code ?? DCS_DEFAULT_CODE,
+                })
+              }
+            />
+          </label>
+          {mode === "ctcss" && (
+            <label className={LABEL}>
+              CTCSS
+              <Select
+                label="CTCSS tone"
+                value={params.settings.ctcss_hz ?? CTCSS_DEFAULT_HZ}
+                options={CTCSS_OPTIONS}
+                onChange={(ctcss_hz) => set({ ...params.settings, ctcss_hz })}
+              />
+            </label>
+          )}
+          {mode === "dcs" && (
+            <label className={LABEL}>
+              DCS
+              <Select
+                label="DCS code"
+                value={params.settings.dcs_code ?? DCS_DEFAULT_CODE}
+                options={DCS_OPTIONS}
+                onChange={(dcs_code) => set({ ...params.settings, dcs_code })}
+              />
+            </label>
+          )}
+        </>
       );
+    }
     case "am":
       return (
         <>

--- a/web/src/components/DecoderPanels.tsx
+++ b/web/src/components/DecoderPanels.tsx
@@ -40,6 +40,7 @@ import {
   TARGET_MAX_AGE_MS,
   type TargetRow,
   type TargetSort,
+  toneLabel,
 } from "./decoderViews";
 
 const PANE = "flex flex-col gap-2 p-3";
@@ -583,6 +584,37 @@ export function SubghzView({ scope = {} }: { scope?: DecoderScope }) {
   );
 }
 
+/** Subaudible signalling is a property of the channel right now, not a stream of messages, so
+ * this is a status line rather than a list — the decoder log already holds the history. */
+export function ToneView({ scope = {} }: { scope?: DecoderScope }) {
+  const records = recordsInScope(useDecodedKind("tone"), scope);
+  const latest = records[0];
+
+  if (latest === undefined) {
+    return (
+      <div className={PANE}>
+        <span className={EMPTY}>No subaudible tone heard.</span>
+      </div>
+    );
+  }
+
+  const status = latest.event.data;
+  const label = toneLabel(status);
+  return (
+    <div className={PANE}>
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="font-mono text-xs tabular-nums text-ink-dim">
+          {formatClock(latest.at)}
+        </span>
+        <span className="font-mono text-xs tabular-nums text-accent">
+          {label === "" ? "no tone" : label}
+        </span>
+        <span className={CAPTION}>{status.open ? "open" : "muted"}</span>
+      </div>
+    </div>
+  );
+}
+
 /** The view each decoder kind is read in. Keyed on the generated `DecoderKind`, so a decoder
  * added to `wire` fails to compile here until it has somewhere to be read. */
 const VIEWS: Record<DecoderKind, (scope: DecoderScope) => ReactNode> = {
@@ -596,6 +628,7 @@ const VIEWS: Record<DecoderKind, (scope: DecoderScope) => ReactNode> = {
   navtex: (scope) => <NavtexView scope={scope} />,
   acars: (scope) => <AcarsView scope={scope} />,
   subghz: (scope) => <SubghzView scope={scope} />,
+  tone: (scope) => <ToneView scope={scope} />,
 };
 
 // `ChannelDescriptor.decoder_kind` is a bare string on the wire, so a server newer than this

--- a/web/src/components/decoderLog.test.ts
+++ b/web/src/components/decoderLog.test.ts
@@ -205,7 +205,28 @@ describe("eventSummary", () => {
         data: { source: "DL1ABC-9", destination: "APRS", info: "hi", tnc2: "DL1ABC-9>APRS:hi" },
       }),
     ).toBe("DL1ABC-9>APRS:hi");
+    // A Mic-E packet's monitor line is binary, so the message is named beside it.
+    expect(
+      eventSummary({
+        kind: "aprs",
+        data: {
+          source: "DL1ABC-7",
+          destination: "S32U6T",
+          info: '`(_fn"Oj/',
+          tnc2: 'DL1ABC-7>S32U6T:`(_fn"Oj/',
+          mic_e_message: "Returning",
+        },
+      }),
+    ).toBe('DL1ABC-7>S32U6T:`(_fn"Oj/ · Returning');
     expect(eventSummary({ kind: "rtty", data: { text: "CQ CQ" } })).toBe("CQ CQ");
+    expect(eventSummary({ kind: "tone", data: { ctcss_hz: 88.5, open: true } })).toBe(
+      "CTCSS 88.5 Hz · open",
+    );
+    expect(eventSummary({ kind: "tone", data: { dcs_code: 23, open: false } })).toBe(
+      "DCS 023 · muted",
+    );
+    // Nothing under the carrier still has something to say once a tone has gone.
+    expect(eventSummary({ kind: "tone", data: { open: false } })).toBe("no tone · muted");
     expect(eventSummary({ kind: "morse", data: { text: "SOS", wpm: 18 } })).toBe("SOS");
     expect(
       eventSummary({ kind: "rds", data: { block_errors: 0, groups: 10, pi: "D3C2", ps: "NDR2" } }),

--- a/web/src/components/decoderLog.ts
+++ b/web/src/components/decoderLog.ts
@@ -25,6 +25,7 @@ export const KIND_LABELS: Record<DecoderKind, string> = {
   navtex: "NAVTEX",
   acars: "ACARS",
   subghz: "Sub-GHz",
+  tone: "Tone",
 };
 
 export const DECODER_KINDS = Object.keys(KIND_LABELS) as DecoderKind[];
@@ -246,6 +247,14 @@ export function eventSummary(event: DecoderEvent): string {
         f.repeats > 1 ? `\u00d7${f.repeats}` : null,
       ]);
     }
+    case "tone": {
+      const t = event.data;
+      const heard = join([
+        t.ctcss_hz == null ? null : `CTCSS ${t.ctcss_hz.toFixed(1)} Hz`,
+        t.dcs_code == null ? null : `DCS ${String(t.dcs_code).padStart(3, "0")}`,
+      ]);
+      return join([heard === "" ? "no tone" : heard, t.open ? "open" : "muted"]);
+    }
   }
 }
 
@@ -275,6 +284,8 @@ export function eventStation(event: DecoderEvent): string | null {
     }
     case "rtty":
     case "morse":
+    // Subaudible signalling names the channel's state, not whoever is keying up.
+    case "tone":
       return null;
   }
 }

--- a/web/src/components/decoderLog.ts
+++ b/web/src/components/decoderLog.ts
@@ -220,8 +220,12 @@ export function eventSummary(event: DecoderEvent): string {
       const m = event.data;
       return join([String(m.mmsi), m.name?.trim() ?? null, position(m.lat, m.lon)]);
     }
-    case "aprs":
-      return event.data.tnc2;
+    case "aprs": {
+      const p = event.data;
+      // A Mic-E monitor line is packed binary, so the message named beside it is the only
+      // part of the row a reader can act on.
+      return p.mic_e_message == null ? p.tnc2 : join([p.tnc2, p.mic_e_message]);
+    }
     case "rtty":
     case "morse":
       return event.data.text;

--- a/web/src/components/decoderViews.test.ts
+++ b/web/src/components/decoderViews.test.ts
@@ -36,6 +36,7 @@ import {
   subghzTiming,
   TARGET_MAX_AGE_MS,
   TARGET_STALE_MS,
+  toneLabel,
 } from "./decoderViews";
 
 const NOW = Date.parse("2026-08-09T12:00:00Z");
@@ -342,6 +343,19 @@ describe("aprsMotion", () => {
       "En Route · 251° · 20 kt",
     );
     expect(aprsMotion({ mic_e_message: "Emergency" })).toBe("Emergency");
+  });
+});
+
+describe("toneLabel", () => {
+  it("names what is under the carrier the way a radio does", () => {
+    expect(toneLabel({})).toBe("");
+    expect(toneLabel({ ctcss_hz: 88.5 })).toBe("CTCSS 88.5 Hz");
+    expect(toneLabel({ ctcss_hz: 100 })).toBe("CTCSS 100.0 Hz");
+    // Octal codes are three digits, and 023 is not 23.
+    expect(toneLabel({ dcs_code: 23 })).toBe("DCS 023");
+    expect(toneLabel({ dcs_code: 754 })).toBe("DCS 754");
+    // A channel set to one and hearing the other is exactly what Detect is for.
+    expect(toneLabel({ ctcss_hz: 88.5, dcs_code: 23 })).toBe("CTCSS 88.5 Hz · DCS 023");
   });
 });
 

--- a/web/src/components/decoderViews.test.ts
+++ b/web/src/components/decoderViews.test.ts
@@ -336,6 +336,13 @@ describe("aprsMotion", () => {
       "90° · 10 kt · 1,500 ft",
     );
   });
+
+  it("leads with the Mic-E message when the packet carried one", () => {
+    expect(aprsMotion({ mic_e_message: "En Route", speed_kt: 20, course_deg: 251 })).toBe(
+      "En Route · 251° · 20 kt",
+    );
+    expect(aprsMotion({ mic_e_message: "Emergency" })).toBe("Emergency");
+  });
 });
 
 describe("NAVTEX", () => {

--- a/web/src/components/decoderViews.ts
+++ b/web/src/components/decoderViews.ts
@@ -304,6 +304,17 @@ export function aprsMotion(packet: {
   );
 }
 
+// ── subaudible signalling ─────────────────────────────────────────────────────────────────
+
+/** What is under the carrier, named the way a radio names it: a CTCSS tone in Hz to one
+ * decimal, a DCS code as its three octal digits. Empty when there is nothing under it. */
+export function toneLabel(status: { ctcss_hz?: number | null; dcs_code?: number | null }): string {
+  return joinFields(
+    status.ctcss_hz == null ? "" : `CTCSS ${status.ctcss_hz.toFixed(1)} Hz`,
+    status.dcs_code == null ? "" : `DCS ${String(status.dcs_code).padStart(3, "0")}`,
+  );
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────────────────
 
 function compareIds(a: string, b: string): number {

--- a/web/src/components/decoderViews.ts
+++ b/web/src/components/decoderViews.ts
@@ -287,13 +287,17 @@ export function matchesAddress(address: number, filter: string): boolean {
 
 // ── APRS ──────────────────────────────────────────────────────────────────────────────────
 
-/** Course/speed/altitude as one trailing line; empty when the packet carried none of them. */
+/** The Mic-E message and course/speed/altitude as one trailing line; empty when the packet
+ * carried none of them. The message leads because it is what the operator chose to say —
+ * "Emergency" is the one thing on this line that is not a measurement. */
 export function aprsMotion(packet: {
   course_deg?: number | null;
   speed_kt?: number | null;
   altitude_ft?: number | null;
+  mic_e_message?: string | null;
 }): string {
   return joinFields(
+    packet.mic_e_message ?? "",
     formatBearing(packet.course_deg),
     packet.speed_kt == null ? "" : formatSpeedKt(packet.speed_kt),
     packet.altitude_ft == null ? "" : formatAltitudeFt(packet.altitude_ft),

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -1066,6 +1066,10 @@ export interface components {
             data: components["schemas"]["SubghzFrame"];
             /** @enum {string} */
             kind: "subghz";
+        } | {
+            data: components["schemas"]["ToneSquelchStatus"];
+            /** @enum {string} */
+            kind: "tone";
         };
         /**
          * @description One stored decoder frame (PLAN §11: decoder logs are queryable and exportable, not
@@ -1367,7 +1371,34 @@ export interface components {
         NfmParams: {
             /** Format: double */
             bandwidth_hz?: number;
+            /**
+             * Format: double
+             * @description The CTCSS tone to open on, in Hz. One of the 50 standard tones (EIA/TIA-603); anything
+             *     else is refused, because the detector only searches those.
+             */
+            ctcss_hz?: number | null;
+            /**
+             * Format: int32
+             * @description The DCS code to open on, as the three octal digits a radio displays — `23` for 023,
+             *     `754` for 754. One of the 83 standard codes.
+             *
+             *     The standard list is not a convenience: the Golay code DCS is built on is cyclic, so
+             *     only a set with no rotation aliasing between its members can be read back unambiguously
+             *     from a continuously repeating word. A code's *inverse* is another code in the list —
+             *     023 received through an inverted discriminator is 047 — so there is no polarity switch
+             *     here, and none on a radio either.
+             */
+            dcs_code?: number | null;
+            tone_mode?: components["schemas"]["NfmToneMode"];
         };
+        /**
+         * @description What an NFM channel does about the subaudible signalling under the voice (PLAN §8).
+         *     CTCSS is a continuous tone below the voice band; DCS is a 23-bit Golay word repeating
+         *     under it at 134.4 bit/s. Both are how a repeater tells its own users apart from the
+         *     co-channel traffic 50 km away.
+         * @enum {string}
+         */
+        NfmToneMode: "off" | "detect" | "ctcss" | "dcs";
         /**
          * @description What a node is. Adjacently tagged like [`crate::ChannelParams`], so the generated TypeScript
          *     is a union the client can exhaustively switch on.
@@ -2282,6 +2313,29 @@ export interface components {
         /** @description `GET /api/templates`. */
         TemplatesResponse: {
             templates: components["schemas"]["TemplateInfo"][];
+        };
+        /**
+         * @description Subaudible signalling heard under an NFM channel's voice (PLAN §8).
+         *
+         *     Emitted only when the picture changes. Both CTCSS and DCS run for the whole of a
+         *     transmission, so an event per block would be the same event forty times a second.
+         */
+        ToneSquelchStatus: {
+            /**
+             * Format: double
+             * @description The CTCSS tone present, in Hz.
+             */
+            ctcss_hz?: number | null;
+            /**
+             * Format: int32
+             * @description The DCS code present, as the three octal digits a radio displays.
+             */
+            dcs_code?: number | null;
+            /**
+             * @description Whether audio is passing. Always true unless the channel was told to gate on a tone:
+             *     [`crate::NfmToneMode::Detect`] reports what is there without acting on it.
+             */
+            open: boolean;
         };
         /** @description `PUT /api/workspaces/{id}` — rename, re-patch, or both. */
         UpdateWorkspaceRequest: {

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -646,6 +646,13 @@ export interface components {
             lat?: number | null;
             /** Format: double */
             lon?: number | null;
+            /**
+             * @description The Mic-E message the operator selected, named (APRS 1.0.1 ch. 10): one of the 7
+             *     standard messages, one of the 7 custom ones, or `Emergency`. `Unknown` is the spec's
+             *     own word for a packet whose three message bits mix the standard and custom tables.
+             *     Absent on every packet that is not Mic-E.
+             */
+            mic_e_message?: string | null;
             /** @description Digipeater path, in order. */
             path?: string[];
             /** @description Source callsign with SSID, e.g. `DL1ABC-9`. */

--- a/web/src/lib/decoded.ts
+++ b/web/src/lib/decoded.ts
@@ -298,6 +298,9 @@ function stationId(event: DecoderEvent): string | null {
     case "subghz":
     case "rtty":
     case "morse":
+    // Subaudible signalling describes the channel, not a station on it — the transmitter it
+    // belongs to is whoever is keying up right now, and nothing in the event names them.
+    case "tone":
       return null;
   }
 }

--- a/web/src/lib/map/layers.ts
+++ b/web/src/lib/map/layers.ts
@@ -265,6 +265,7 @@ function detailRows(station: Target): (readonly [string, string])[] {
         ["Speed", scalar(d.speed_kt, 0, " kt")],
         ["Course", scalar(d.course_deg, 0, "°")],
         ["Altitude", scalar(d.altitude_ft, 0, " ft")],
+        ["Message", trimmed(d.mic_e_message)],
         ["Comment", trimmed(d.comment)],
       ]);
     }


### PR DESCRIPTION
Three `[planned]` decoder entries from FEATURES.md, one commit each. Each turned out to hinge on a single question about what the receiver is entitled to *claim*, so that is what each section leads with.

## Mode S DF4/5/11/20/21

Altitude and identity replies, all-call replies, and the BDS 2,0 callsign a Comm-B reply may carry.

DF4/5/20/21 key the aircraft address onto the parity instead of transmitting it, so **every** 24-bit value reads as a valid frame — decoding one unconditionally would mean inventing aircraft out of noise. So a reply is decoded only when the address recovered from its parity was proved in the clear (DF11/17/18) within the last minute. Single-bit CRC repair stays confined to the bare-parity formats, where it cannot "fix" one aircraft's frame into another's.

One deliberate divergence from dump1090: a roll-call reply refreshes the cache entry but never the *proof*. dump1090 lets any frame refresh; here proof of identity does not decay into hearsay, so one lucky parity match cannot keep a bogus address alive. It costs nothing in practice — an aircraft in range squitters twice a second.

`mode_s_overlay` is new in `dsp`: the syndrome is *not* the address (our register runs the overlay on through it as `value·x^24 mod g`), so the address is recovered as `crc(body) ^ parity`.

## Mic-E

The one APRS form that is not a text format. Six latitude digits and three indicator bits ride in the AX.25 destination *callsign*; longitude, course, speed and symbol ride in an information field offset by 28. Neither half decodes without the other.

Written against APRS 1.0.1 ch. 10 rather than from memory, and both of the chapter's worked examples are tests. Their destination example sets no longitude offset while their information-field example is written up with one, so the same bytes decode to 12°07.74'W and need one changed character to become the chapter's 112° — worth two tests rather than a guess.

All 15 message codes are named; the standard/custom mixture the spec calls "unknown" stays unnamed. Position ambiguity is declared in the latitude and applies to the longitude, which never mentions it. The `xxx}` altitude is read only at the head of the status text — a `}` in free text would otherwise put a station 700 km up.

The reference encoder (`MicE`) sits beside `AprsTx::ui_frame`, and shares no code with the decoder: its tables are written forwards from the spec rather than inverted from the thing under test.

## CTCSS / DCS on NFM

The subaudible band is decimated off the discriminator in two stages; fifty sliding correlators name a CTCSS tone (half a second of window, because the closest pair of standard tones is 2.3 Hz apart), and a Golay(23,12) reader at 134.4 bit/s names a DCS code, sliced against a tracked baseline so a carrier offset is not a decision threshold.

**The 83 standard DCS codes are part of the decoder, not a dropdown.** Golay(23,12) is cyclic: every rotation of a word is another word, so a sliding window over a continuously repeating transmission finds a valid one at all 23 alignments and reads a *different* code at each. The standard set is the one no two of whose members alias — a test walks every code, every rotation and both polarities to prove it. The same fact removes a setting: an inverted transmission reads out the code's inverse-pair partner (023 → 047), so there is no polarity switch here, and none on a radio either.

`Detect` names what a repeater uses without gating; `Ctcss`/`Dcs` gate on it, muting rather than skipping so a client's jitter buffer keeps its samples. A three-section 300 Hz highpass keeps the tone out of the audio it passes — no FIR makes that transition at 48 kHz, and a radio does not try either.

## API and behaviour notes for review

- **`ChannelRx::needs_gated_input`** is new, defaulting to `true`. The engine already feeds decoders silence rather than skipping them under a closed squelch, so their bit clocks keep time. NFM now emits events, and without this every squelched NFM channel would start paying for a feature that is off by default. With a tone mode on it answers `true` (the gated span is what lets the detector *lose* a tone); off, `false`, and the host goes back to skipping the channel entirely. **With tone mode off, nothing about NFM changed.**
- `NfmParams` gains `tone_mode`, `ctcss_hz`, `dcs_code`, all `#[serde(default)]`, so existing presets deserialize unchanged.
- New `DecoderEvent::Tone` variant; NFM's `decoder_kind` becomes `Some("tone")`, making it the second type that is both audio and decoder.
- `AprsPacket` gains `mic_e_message`.

## Tests

Unit tests per decoder, exhaustive table tests where a table is load-bearing (every DCS code × rotation × polarity; every squawk in the 4096-code space; every Golay data word), reference modulators for all three, and three new end-to-end cases in `crates/engine/tests/decode.rs` replaying through `device-virtual`.

## Known bound, documented not fixed

A short Mode S frame (DF4/5/11) is only scanned once a long frame's worth of samples — 232 µs — sits behind it, because the scan window is sized for the longest candidate. On a live stream that is latency and nothing else; a capture that *ends* inside those 232 µs loses its last short frame. Decoding earlier needs a scan watermark this decoder does not carry, so it is noted at the site rather than half-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)