### PR TITLE
WFM stereo: two-channel audio end to end

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -138,11 +138,11 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 
 ## 8. Voice & analog channels
 
-- **[shipped]** AM, NFM, SSB (USB/LSB), WFM mono — DDC → mode-aware complex channel filter → squelch → demod → 48 kHz PCM
+- **[shipped]** AM, NFM, SSB (USB/LSB), WFM — DDC → mode-aware complex channel filter → squelch → demod → 48 kHz PCM
 - **[shipped]** Squelch (power + hysteresis + hold, measured on the filtered channel so a threshold means the same thing across modes), AGC, de-emphasis, DC blocking
 - **[shipped]** Mode changed in place on a live channel, keeping audio subscribers
 - **[shipped]** RDS — 19 kHz pilot PLL → 3rd harmonic → symbol sync → differential decode → offset-word block sync; groups 0A/0B (PS, TP/TA/MS, AF), 2A/2B (RadioText), PTY; emitted only when a field changes. **It decodes the synthesized fixture completely and has never decoded off air** — six real stations on two radios produced nothing, reproduced deterministically from a committed-out 8 s capture; the leading (untested) hypothesis is the stereo L−R subcarrier sitting against 57 kHz
-- **[planned]** WFM **stereo** — the audio path becomes two-channel end to end (PCM, Opus, frame layout, worklet)
+- **[shipped]** WFM **stereo** — 19 kHz pilot PLL → 38 kHz difference demod → L/R matrix, with the whole audio path two-channel end to end (interleaved PCM, stereo Opus, per-frame `ch_layout`, two-channel worklet); a station without a pilot falls back to the same programme on both channels, and the toggle switches layout under a live stream
 - **[planned]** ATV (analog TV)
 - **[planned]** Notch and audio filters per channel
 - **[planned]** CTCSS/DCS detection on NFM; Selcall (CCIR/ZVEI)
@@ -225,7 +225,7 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 
 ## 17. Audio processing
 
-- **[shipped]** Opus audio to the browser and desktop — per-channel encoder threads, WebCodecs fast path with a WASM fallback, AudioWorklet jitter buffer (100 ms target, underrun rebuffer, 400 ms drop-oldest), per-channel gain, gesture-unlocked context, auto-resubscribe on reconnect, timestamp-gap loss detection
+- **[shipped]** Opus audio to the browser and desktop — per-channel encoder threads that follow the channel's layout (mono 64 kbit/s, stereo 96 kbit/s) mid-stream, WebCodecs fast path with a WASM fallback, AudioWorklet jitter buffer (100 ms target, underrun rebuffer, 400 ms drop-oldest), per-channel gain, gesture-unlocked context, auto-resubscribe on reconnect, timestamp-gap loss detection
 - **[shipped]** Speaker node — client-side mixing across every channel wired into it
 - **[planned]** Spectral noise reduction, noise blanker, auto-notch, AGC as advanced processing inside **every** voice channel rather than a separate channel type
 - **[planned]** Adaptive/auto DSP — auto-notch, auto-squelch, auto-gain, per-mode click and noise removal

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -1,6 +1,6 @@
 //! `sdrmm-channels` — the `ChannelRx` plugin surface (PLAN §8). Depends only on `dsp` + `wire`.
 //! Phase-1 analog demodulators plus the wave-1 and wave-2 data decoders (PLAN §13): NFM, AM,
-//! SSB, WFM mono (+RDS), POCSAG, ADS-B, AIS, APRS/AX.25, RTTY, Morse, NAVTEX, ACARS, sub-GHz. Each mode is one module whose
+//! SSB, WFM (stereo + RDS), POCSAG, ADS-B, AIS, APRS/AX.25, RTTY, Morse, NAVTEX, ACARS, sub-GHz. Each mode is one module whose
 //! descriptor and constructor sit in the same [`REGISTRY`] row, so the "add channel" UI and
 //! `create` dispatch cannot drift apart.
 
@@ -46,8 +46,20 @@ pub use ssb::{SsbChannel, SsbTx};
 pub use subghz::SubghzChannel;
 pub use wfm::WfmChannel;
 
-/// Every channel emits mono PCM at this rate; the engine's audio path is sized against it.
+/// Every channel emits PCM at this rate; the engine's audio path is sized against it.
 pub const AUDIO_RATE: u32 = 48_000;
+
+/// How many interleaved channels this mode's audio comes out as — WFM in stereo is the one
+/// two-channel mode. The engine builds its Opus encoder from this rather than from what a
+/// block happens to contain, so a squelched channel emits silence in the right layout; a mode
+/// whose `process` disagreed with it would interleave garbage.
+#[must_use]
+pub fn audio_channels(params: &ChannelParams) -> u8 {
+    match params {
+        ChannelParams::Wfm(p) if p.stereo => 2,
+        _ => 1,
+    }
+}
 
 /// Opus integer-API decoders (and the browser DAC) hard-clip PCM beyond ±1.0, so every demod
 /// bounds its final output here — overshoot (open-squelch FM noise, over-deviated carriers)
@@ -160,7 +172,8 @@ pub struct ChannelCtx {
 /// low-rate IQ taps for the analyzer (PLAN §8). Buffers are reused across calls by the host.
 #[derive(Default)]
 pub struct ChannelOutputs {
-    /// Interleaved/mono PCM plus its sample rate, when the channel produced audio this block.
+    /// PCM plus its sample rate, when the channel produced audio this block. Interleaved at
+    /// [`audio_channels`] for the channel's params — a whole number of sample frames.
     pub audio_pcm: Vec<f32>,
     pub audio_rate: u32,
     /// Typed decoder frames produced this block (PLAN §5). The host stamps them with time and
@@ -533,6 +546,42 @@ mod tests {
                 d.has_audio,
                 matches!(d.type_id.as_str(), "nfm" | "am" | "ssb" | "wfm"),
                 "{} audio flag does not match its mode class",
+                d.type_id
+            );
+        }
+    }
+
+    /// [`audio_channels`] is what the engine sizes its Opus encoder and its squelched
+    /// zero-fill from, so it has to be what the demodulator actually writes: a mode whose
+    /// interleave disagreed would show up here as half — or double — the frames its rate
+    /// implies, and would reach a listener as chipmunk audio, not as a wrong channel count.
+    #[test]
+    fn audio_channels_matches_the_frames_each_mode_produces() {
+        const LEN: usize = 96_000;
+        for d in descriptors().into_iter().filter(|d| d.has_audio) {
+            let params = default_params(&d.type_id);
+            let channels = usize::from(audio_channels(&params));
+            let ctx = ChannelCtx {
+                input_rate: d.input_rate_hz,
+            };
+            let mut chan = create(ctx, &settings(params)).expect("builds");
+            let audio = crate::testutil::run_ragged(
+                chan.as_mut(),
+                &crate::testutil::complex_noise(7, 0.5, LEN),
+            );
+            assert_eq!(
+                audio.len() % channels,
+                0,
+                "{} emitted a partial sample frame",
+                d.type_id
+            );
+            let frames = audio.len() / channels;
+            // Filter warm-up is the only shortfall allowed: no mode's group delay reaches
+            // 200 output frames at these tap counts.
+            let expected = (LEN as f64 * f64::from(AUDIO_RATE) / d.input_rate_hz) as usize;
+            assert!(
+                frames <= expected && expected - frames < 200,
+                "{} produced {frames} frames of {channels}-channel audio, expected ~{expected}",
                 d.type_id
             );
         }

--- a/crates/channels/src/testgen/mod.rs
+++ b/crates/channels/src/testgen/mod.rs
@@ -30,6 +30,7 @@ pub mod pocsag;
 pub mod rds;
 pub mod rtty;
 pub mod subghz;
+pub mod wfm;
 
 use std::f64::consts::TAU;
 

--- a/crates/channels/src/testgen/wfm.rs
+++ b/crates/channels/src/testgen/wfm.rs
@@ -1,0 +1,150 @@
+//! FM broadcast stereo reference modulator (PLAN §14): the pilot-tone multiplex a stereo
+//! station transmits, per ITU-R BS.450 / 47 CFR §73.322.
+//!
+//! `MPX = 0.45·[(L+R)/2 + (L−R)/2·sub] + 0.09·pilot`, the deviation shares of a typical
+//! broadcast multiplex — the same audio/pilot split [`super::rds`] uses, so one composite could
+//! carry both. The pilot is written as a cosine to match that module; the subcarrier is then
+//! `−sin(2ωt)`, which is what the standard's rule — pilot zero crossings coincide with
+//! positive-going subcarrier zero crossings — comes to for a cosine pilot. Getting that sign
+//! wrong swaps the channels rather than breaking them, which is exactly why it is generated
+//! here from the rule rather than copied from the demodulator.
+//!
+//! No pre-emphasis: a receiver's de-emphasis then shows up as the plain analog roll-off at the
+//! test tone's frequency, which is what the WFM tests measure against.
+
+use std::f64::consts::TAU;
+
+use num_complex::Complex;
+
+use super::fm_modulate;
+
+/// Stereo pilot; the difference subcarrier is its second harmonic.
+const PILOT_HZ: f64 = 19_000.0;
+/// Peak deviation of a fully modulated broadcast carrier; [`composite`] returns ±1 for it.
+const DEVIATION_HZ: f64 = 75_000.0;
+const AUDIO_LEVEL: f64 = 0.45;
+const PILOT_LEVEL: f64 = 0.09;
+
+/// The stereo multiplex for `left`/`right` (both in ±1, same length) as a real signal in ±1.
+/// `pilot` false makes it a mono station: no pilot, no difference subcarrier, so a stereo
+/// receiver must fall back to the sum signal on both channels.
+#[must_use]
+pub fn composite(left: &[f32], right: &[f32], pilot: bool, rate: f64) -> Vec<f32> {
+    assert_eq!(
+        left.len(),
+        right.len(),
+        "left and right must be the same length"
+    );
+    left.iter()
+        .zip(right)
+        .enumerate()
+        .map(|(n, (&l, &r))| {
+            let (l, r) = (f64::from(l), f64::from(r));
+            let phase = TAU * PILOT_HZ * n as f64 / rate;
+            let sum = AUDIO_LEVEL * (l + r) / 2.0;
+            if !pilot {
+                return sum as f32;
+            }
+            let difference = AUDIO_LEVEL * (l - r) / 2.0 * -(2.0 * phase).sin();
+            (sum + difference + PILOT_LEVEL * phase.cos()) as f32
+        })
+        .collect()
+}
+
+/// The same multiplex frequency-modulated onto a carrier as complex baseband IQ — what a WFM
+/// channel receives off the air.
+#[must_use]
+pub fn transmission(left: &[f32], right: &[f32], pilot: bool, rate: f64) -> Vec<Complex<f32>> {
+    fm_modulate(&composite(left, right, pilot, rate), DEVIATION_HZ, rate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::tone_audio, *};
+
+    const RATE: f64 = 240_000.0;
+
+    fn program(len: usize) -> (Vec<f32>, Vec<f32>) {
+        (
+            tone_audio(1_000.0, 1.0, RATE, len),
+            tone_audio(3_000.0, 1.0, RATE, len),
+        )
+    }
+
+    /// Correlating against a reference recovers its share only if that component is present at
+    /// that phase: the pilot at its nominal level, and the difference signal on `−sin(2ωt)`
+    /// rather than the `+sin` or `cos` a sign or quadrature slip would put it on.
+    fn correlate(mpx: &[f32], reference: impl Fn(f64) -> f64) -> f64 {
+        mpx.iter()
+            .enumerate()
+            .map(|(n, &s)| f64::from(s) * reference(TAU * PILOT_HZ * n as f64 / RATE))
+            .sum::<f64>()
+            / mpx.len() as f64
+    }
+
+    #[test]
+    fn composite_carries_the_pilot_and_the_difference_signal_in_the_standard_phase() {
+        // One channel silent, so (L−R)/2 is a plain 1 kHz tone rather than a two-tone mix.
+        let len = 24_000;
+        let (left, _) = program(len);
+        let silent = vec![0.0f32; len];
+        let mpx = composite(&left, &silent, true, RATE);
+
+        for (n, &s) in mpx.iter().enumerate() {
+            assert!((-1.0..=1.0).contains(&s), "sample {n} out of range: {s}");
+        }
+        assert!(
+            (correlate(&mpx, f64::cos) - PILOT_LEVEL / 2.0).abs() < 0.005,
+            "pilot level {}",
+            correlate(&mpx, f64::cos)
+        );
+        // The difference signal rides on −sin(2ωt); correlating the multiplex against that
+        // subcarrier leaves the 1 kHz tone, which averages to zero — so demodulate first and
+        // measure what lands at baseband.
+        let demodulated: Vec<f32> = mpx
+            .iter()
+            .enumerate()
+            .map(|(n, &s)| {
+                let phase = TAU * PILOT_HZ * n as f64 / RATE;
+                (f64::from(s) * -2.0 * (2.0 * phase).sin()) as f32
+            })
+            .collect();
+        let recovered: f64 = demodulated
+            .iter()
+            .zip(&left)
+            .map(|(&d, &l)| f64::from(d) * f64::from(l))
+            .sum::<f64>()
+            / demodulated.len() as f64;
+        // (L−R)/2 = L/2 at 0.45 deviation share, correlated against L (mean square 1/2).
+        assert!(
+            (recovered - AUDIO_LEVEL / 4.0).abs() < 0.01,
+            "difference level {recovered}"
+        );
+    }
+
+    #[test]
+    fn a_mono_station_carries_neither_pilot_nor_subcarrier() {
+        let len = 24_000;
+        let (left, right) = program(len);
+        let mpx = composite(&left, &right, false, RATE);
+        assert!(correlate(&mpx, f64::cos).abs() < 0.002, "pilot present");
+        assert!(
+            correlate(&mpx, |p| -(2.0 * p).sin()).abs() < 0.002,
+            "subcarrier present"
+        );
+    }
+
+    #[test]
+    fn transmission_is_a_unit_magnitude_carrier() {
+        let (left, right) = program(2_400);
+        let iq = transmission(&left, &right, true, RATE);
+        assert_eq!(iq.len(), 2_400);
+        for (n, s) in iq.iter().enumerate() {
+            assert!(
+                (s.norm() - 1.0).abs() < 1e-3,
+                "sample {n} magnitude {}",
+                s.norm()
+            );
+        }
+    }
+}

--- a/crates/channels/src/testutil.rs
+++ b/crates/channels/src/testutil.rs
@@ -87,6 +87,15 @@ pub(crate) fn run_ragged(chan: &mut dyn ChannelRx, iq: &[Complex<f32>]) -> Vec<f
     audio
 }
 
+/// Split interleaved two-channel PCM into its left and right halves.
+pub(crate) fn split_stereo(pcm: &[f32]) -> (Vec<f32>, Vec<f32>) {
+    assert_eq!(pcm.len() % 2, 0, "interleaved stereo needs whole frames");
+    (
+        pcm.iter().step_by(2).copied().collect(),
+        pcm.iter().skip(1).step_by(2).copied().collect(),
+    )
+}
+
 /// Deterministic uniform complex noise in roughly `±amp` (xorshift32, like `sdrmm-dsp`'s).
 pub(crate) fn complex_noise(seed: u32, amp: f32, len: usize) -> Vec<Complex<f32>> {
     let mut state = seed | 1;

--- a/crates/channels/src/wfm.rs
+++ b/crates/channels/src/wfm.rs
@@ -1,11 +1,20 @@
-//! WFM mono: 240 kHz IQ → quadrature discriminator → de-emphasis → 5:1 decimate to 48 kHz.
-//! With `rds` set, the discriminator's composite is also tapped off — ahead of de-emphasis and
-//! the audio decimation, both of which destroy the 57 kHz subcarrier — into [`RdsDecoder`].
+//! WFM: 240 kHz IQ → quadrature discriminator → 5:1 decimate to 48 kHz → de-emphasis.
+//! With `stereo` set, the composite is also demultiplexed against the 19 kHz pilot into the
+//! L−R difference signal, and the channel's audio leaves as interleaved L/R.
+//! With `rds` set, the composite is tapped off into [`RdsDecoder`] as well.
+//!
+//! De-emphasis runs *after* the audio decimation, not on the composite: at 240 kHz it would
+//! flatten the 38 kHz difference subcarrier (−15 dB and rotated) before the stereo demux ever
+//! saw it. Being linear and time-invariant, it may equivalently be applied to the sum and
+//! difference signals separately, which is what keeps it off the interleaved output.
 
-use std::sync::LazyLock;
+use std::{f64::consts::FRAC_1_SQRT_2, sync::LazyLock};
 
 use num_complex::Complex;
-use sdrmm_dsp::{Decimator, Deemphasis, FmDemod, RealDecimator, design_lowpass};
+use sdrmm_dsp::{
+    ComplexOnePole, Decimator, Deemphasis, FmDemod, Nco, Pll, RealDecimator, design_lowpass,
+    one_pole_coeff,
+};
 use sdrmm_wire::{ChannelDescriptor, ChannelParams, ChannelSettings, WfmParams};
 
 use crate::{
@@ -14,17 +23,42 @@ use crate::{
 };
 
 const DEVIATION_HZ: f64 = 75_000.0;
-/// Mono audio ends at 15 kHz; everything above (pilot, stereo subcarrier, RDS) is cut.
+/// Audio ends at 15 kHz; everything above (pilot, stereo subcarrier, RDS) is cut.
 const AUDIO_CUTOFF_HZ: f64 = 15_000.0;
 const DECIM_FACTOR: usize = 5;
-const DECIM_TAPS: usize = 127;
+/// A Blackman lowpass's transition half-width is 2.75/taps (see `dsp::fir`), so 199 taps put
+/// the stopband edge at 18.3 kHz — below the pilot. Fewer taps leave 19 kHz in the transition
+/// band, and with de-emphasis no longer damping the composite ahead of this filter, that is
+/// audible pilot whine in the mono sum.
+const DECIM_TAPS: usize = 199;
 /// The ±100 kHz channel edge sits at 0.417 of the 240 kHz rate; 65 taps put the stopband
 /// just inside Nyquist while keeping the per-sample cost sane at this rate.
 const CHANNEL_TAPS: usize = 65;
 
+/// Stereo pilot; the difference subcarrier is its second harmonic (ITU-R BS.450).
+const PILOT_HZ: f64 = 19_000.0;
+/// Per-stage corner of the cascade that isolates the mixed-down pilot. Its nearest composite
+/// neighbours are 4 kHz away (audio ends at 15 kHz, the difference subcarrier starts at
+/// 23 kHz), which three stages at this corner put ~55 dB down.
+const PILOT_CUTOFF_HZ: f64 = 400.0;
+const PILOT_STAGES: usize = 3;
+/// Pilot loop bandwidth and pull-in range, in Hz. The pilot is transmitter-locked to the
+/// subcarrier, so the loop only has to track the receiver's own clock error — narrow enough to
+/// ignore what leaks past the pilot filter, wide enough to acquire in a few tens of ms.
+const PILOT_LOOP_BW_HZ: f64 = 30.0;
+const PILOT_RANGE_HZ: f64 = 120.0;
+/// Lock quality that turns the difference signal on, and the lower one that turns it off
+/// again. Hysteresis, so a pilot flickering at the threshold cannot toggle the matrix.
+const LOCK_ON: f32 = 0.6;
+const LOCK_OFF: f32 = 0.4;
+/// Time constant of the ramp between mono and stereo, in seconds. Long enough that neither
+/// transition clicks, short enough that a station change does not leave the difference signal
+/// misapplied for audibly long.
+const BLEND_TAU_S: f64 = 0.05;
+
 static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
     type_id: "wfm".to_owned(),
-    name: "WFM (mono)".to_owned(),
+    name: "WFM (broadcast)".to_owned(),
     bandwidth_hz: 200_000.0,
     input_rate_hz: 240_000.0,
     has_audio: true,
@@ -38,8 +72,40 @@ pub struct WfmChannel {
     deemphasis: Deemphasis,
     decim: RealDecimator,
     demod_buf: Vec<f32>,
+    /// Sum signal at 48 kHz; only the stereo path needs it out of line, because the mono path
+    /// decimates straight into the channel's output.
+    sum: Vec<f32>,
+    /// Present only while `stereo` is set. Holds the pilot loop and the difference path.
+    stereo: Option<StereoDemux>,
     /// Present only while `rds` is set — a disabled decoder costs neither state nor cycles.
     rds: Option<RdsDecoder>,
+}
+
+/// Pilot recovery and L−R demodulation (ITU-R BS.450 pilot-tone system).
+///
+/// The pilot is mixed to DC and isolated there — a 400 Hz-wide filter at 19 kHz would need
+/// thousands of FIR taps, while at DC three complex one-pole sections do it — and a PLL tracks
+/// what is left. Rebuilding the analytic pilot as `conj(mix)·reference` puts its phase back at
+/// 19 kHz sample-accurately, and squaring it lands on the subcarrier: the multiplex's pilot is
+/// `cos(θ)`, so the difference subcarrier the standard's zero-crossing rule prescribes is
+/// `−sin(2θ) = −Im(P²)`. A quadrature slip there collapses the separation; a sign slip swaps
+/// the channels.
+struct StereoDemux {
+    pilot: Nco,
+    filter: ComplexOnePole,
+    pll: Pll,
+    /// L−R at the composite rate, before the audio decimation, and at 48 kHz after it.
+    difference: Vec<f32>,
+    side: Vec<f32>,
+    decim: RealDecimator,
+    /// Same de-emphasis as the sum path: applying it to sum and difference separately is
+    /// identical to applying it to L and R, and keeps both filters on contiguous buffers.
+    deemphasis: Deemphasis,
+    /// How much of the difference signal reaches the matrix, ramped rather than switched.
+    blend: f32,
+    blend_coeff: f32,
+    /// What `blend` is ramping towards: the hysteretic verdict on the pilot lock.
+    target: f32,
 }
 
 fn params(settings: &ChannelSettings) -> Result<&WfmParams, ChannelError> {
@@ -65,7 +131,82 @@ fn deemphasis(p: &WfmParams) -> Result<Deemphasis, ChannelError> {
             p.deemphasis_us
         )));
     }
-    Ok(Deemphasis::new(DESCRIPTOR.input_rate_hz, p.deemphasis_us))
+    Ok(Deemphasis::new(f64::from(AUDIO_RATE), p.deemphasis_us))
+}
+
+/// The 240 kHz → 48 kHz audio decimation, built the same way for the sum and the difference
+/// signal: identical filters fed identical block lengths stay sample-aligned, which is what
+/// lets the matrix pair them.
+fn audio_decimator(rate: f64) -> RealDecimator {
+    RealDecimator::new(
+        &design_lowpass(DECIM_TAPS, AUDIO_CUTOFF_HZ / rate),
+        DECIM_FACTOR,
+    )
+}
+
+impl StereoDemux {
+    fn new(rate: f64, deemphasis: Deemphasis) -> Self {
+        Self {
+            pilot: Nco::new(PILOT_HZ as f32, rate as f32),
+            filter: ComplexOnePole::new(rate, PILOT_CUTOFF_HZ, PILOT_STAGES),
+            pll: Pll::new(
+                PILOT_LOOP_BW_HZ / rate,
+                FRAC_1_SQRT_2,
+                0.0,
+                PILOT_RANGE_HZ / rate,
+            ),
+            difference: Vec::new(),
+            side: Vec::new(),
+            decim: audio_decimator(rate),
+            deemphasis,
+            blend: 0.0,
+            blend_coeff: one_pole_coeff(f64::from(AUDIO_RATE), BLEND_TAU_S),
+            target: 0.0,
+        }
+    }
+
+    /// Interleave L/R into `out` from this block's composite and the sum path's 48 kHz output.
+    fn process(&mut self, composite: &[f32], sum: &[f32], out: &mut Vec<f32>) {
+        self.demodulate(composite);
+        self.decim.process(&self.difference, &mut self.side);
+        self.deemphasis.process(&mut self.side);
+
+        let lock = self.pll.lock();
+        if lock > LOCK_ON {
+            self.target = 1.0;
+        } else if lock < LOCK_OFF {
+            self.target = 0.0;
+        }
+        // Both decimators are the same filter fed the same block, so they emit the same count.
+        debug_assert_eq!(sum.len(), self.side.len(), "stereo paths drifted apart");
+        out.clear();
+        out.reserve(2 * sum.len());
+        for (&mid, &side) in sum.iter().zip(&self.side) {
+            self.blend += self.blend_coeff * (self.target - self.blend);
+            let side = side * self.blend;
+            out.push(mid + side);
+            out.push(mid - side);
+        }
+    }
+
+    /// L−R at the composite rate: the multiplex times the recovered 38 kHz subcarrier.
+    fn demodulate(&mut self, composite: &[f32]) {
+        self.difference.clear();
+        self.difference.reserve(composite.len());
+        for &sample in composite {
+            let carrier = self.pilot.next_sample();
+            let baseband = self
+                .filter
+                .process(Complex::new(sample, 0.0) * carrier.conj());
+            let reference = self.pll.process(baseband);
+            // The loop tracks the pilot at DC; multiplying its reference back by the mixer's
+            // own phasor is what returns the analytic pilot to 19 kHz without a second loop.
+            let analytic = carrier * reference;
+            let subcarrier = analytic * analytic;
+            // ×2 because the product of two unit sinusoids halves the amplitude.
+            self.difference.push(-2.0 * subcarrier.im * sample);
+        }
+    }
 }
 
 impl ChannelRx for WfmChannel {
@@ -79,23 +220,35 @@ impl ChannelRx for WfmChannel {
         let deemphasis = deemphasis(p)?;
         Ok(Self {
             demod: FmDemod::new(ctx.input_rate, DEVIATION_HZ),
-            deemphasis,
-            decim: RealDecimator::new(
-                &design_lowpass(DECIM_TAPS, AUDIO_CUTOFF_HZ / ctx.input_rate),
-                DECIM_FACTOR,
-            ),
+            decim: audio_decimator(ctx.input_rate),
             demod_buf: Vec::new(),
+            sum: Vec::new(),
+            stereo: p
+                .stereo
+                .then(|| StereoDemux::new(ctx.input_rate, deemphasis.clone())),
+            deemphasis,
             rds: p.rds.then(|| RdsDecoder::new(ctx.input_rate)),
         })
     }
 
     fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
         let p = params(&settings)?;
-        self.deemphasis = deemphasis(p)?;
+        let deemphasis = deemphasis(p)?;
+        self.deemphasis = deemphasis.clone();
+        let rate = DESCRIPTOR.input_rate_hz;
+        if p.stereo != self.stereo.is_some() {
+            // A freshly built decimator has no history, so it would emit fewer samples for the
+            // first block than the running one: restart both together, or the matrix pairs
+            // sum and difference samples from different instants for the rest of the stream.
+            self.decim = audio_decimator(rate);
+            self.stereo = p.stereo.then(|| StereoDemux::new(rate, deemphasis));
+        } else if let Some(stereo) = &mut self.stereo {
+            stereo.deemphasis = deemphasis;
+        }
         if !p.rds {
             self.rds = None;
         } else if self.rds.is_none() {
-            self.rds = Some(RdsDecoder::new(DESCRIPTOR.input_rate_hz));
+            self.rds = Some(RdsDecoder::new(rate));
         }
         Ok(())
     }
@@ -111,8 +264,17 @@ impl ChannelRx for WfmChannel {
         if let Some(rds) = &mut self.rds {
             rds.process(&self.demod_buf, &mut out.events);
         }
-        self.deemphasis.process(&mut self.demod_buf);
-        self.decim.process(&self.demod_buf, &mut out.audio_pcm);
+        match &mut self.stereo {
+            None => {
+                self.decim.process(&self.demod_buf, &mut out.audio_pcm);
+                self.deemphasis.process(&mut out.audio_pcm);
+            }
+            Some(stereo) => {
+                self.decim.process(&self.demod_buf, &mut self.sum);
+                self.deemphasis.process(&mut self.sum);
+                stereo.process(&self.demod_buf, &self.sum, &mut out.audio_pcm);
+            }
+        }
         clamp_full_scale(&mut out.audio_pcm);
         if !out.audio_pcm.is_empty() {
             out.audio_rate = AUDIO_RATE;
@@ -126,19 +288,41 @@ mod tests {
 
     use super::*;
     use crate::{
-        testgen::rds::{Station, transmission},
-        testutil::{dominant_tone, fm_iq, rms, run_ragged, settings},
+        testgen::{
+            rds::{Station, transmission},
+            tone_audio,
+            wfm::transmission as stereo_transmission,
+        },
+        testutil::{dominant_tone, fm_iq, rms, run_ragged, settings, split_stereo, tone_power},
     };
 
     const RATE: f64 = 240_000.0;
+    /// One second of programme: long enough for the pilot loop to lock and the stereo blend to
+    /// ramp in, with half a second of settled audio left to measure.
+    const RUN_SAMPLES: usize = 240_000;
+    const LEFT_HZ: f64 = 1_000.0;
+    const RIGHT_HZ: f64 = 3_000.0;
+
+    fn wfm_params(deemphasis_us: f32, rds: bool, stereo: bool) -> ChannelParams {
+        ChannelParams::Wfm(WfmParams {
+            deemphasis_us,
+            rds,
+            stereo,
+        })
+    }
 
     fn channel(deemphasis_us: f32) -> WfmChannel {
         WfmChannel::new(
             ChannelCtx { input_rate: RATE },
-            settings(ChannelParams::Wfm(WfmParams {
-                deemphasis_us,
-                rds: false,
-            })),
+            settings(wfm_params(deemphasis_us, false, false)),
+        )
+        .unwrap()
+    }
+
+    fn stereo_channel() -> WfmChannel {
+        WfmChannel::new(
+            ChannelCtx { input_rate: RATE },
+            settings(wfm_params(50.0, false, true)),
         )
         .unwrap()
     }
@@ -147,11 +331,22 @@ mod tests {
         ChannelSettings {
             offset_hz,
             squelch_db: None,
-            params: ChannelParams::Wfm(WfmParams {
-                deemphasis_us: 50.0,
-                rds,
-            }),
+            params: wfm_params(50.0, rds, false),
         }
+    }
+
+    /// A station carrying a different tone on each channel, `pilot` false making it mono.
+    fn two_tone_station(pilot: bool) -> Vec<Complex<f32>> {
+        let left = tone_audio(LEFT_HZ, 1.0, RATE, RUN_SAMPLES);
+        let right = tone_audio(RIGHT_HZ, 1.0, RATE, RUN_SAMPLES);
+        stereo_transmission(&left, &right, pilot, RATE)
+    }
+
+    /// The settled half of each channel of an interleaved run.
+    fn settled_channels(audio: &[f32]) -> (Vec<f32>, Vec<f32>) {
+        let (left, right) = split_stereo(audio);
+        let from = left.len() / 2;
+        (left[from..].to_vec(), right[from..].to_vec())
     }
 
     fn station() -> Station {
@@ -217,11 +412,8 @@ mod tests {
     #[test]
     fn apply_75_us_deemphasis_keeps_demodulating() {
         let mut chan = channel(50.0);
-        chan.apply(settings(ChannelParams::Wfm(WfmParams {
-            deemphasis_us: 75.0,
-            rds: false,
-        })))
-        .unwrap();
+        chan.apply(settings(wfm_params(75.0, false, false)))
+            .unwrap();
         let audio = run_ragged(&mut chan, &fm_iq(RATE, 1_000.0, DEVIATION_HZ, 240_000));
         let (freq, ratio) = dominant_tone(&audio[2_000..14_000], f64::from(AUDIO_RATE));
         assert!((995.0..1_005.0).contains(&freq), "dominant {freq} Hz");
@@ -338,5 +530,133 @@ mod tests {
             first.groups >= 1,
             "an update was emitted before any group was decoded"
         );
+    }
+
+    #[test]
+    fn stereo_output_is_two_interleaved_channels() {
+        let mut chan = stereo_channel();
+        let iq = two_tone_station(true);
+        let audio = run_ragged(&mut chan, &iq);
+        assert_eq!(audio.len(), 2 * (iq.len() / DECIM_FACTOR));
+    }
+
+    /// The separation test: each channel must carry its own tone and almost none of the
+    /// other's. A quadrature slip in the recovered subcarrier collapses this to ~0 dB; a sign
+    /// slip swaps which tone lands where, which is why both are named.
+    #[test]
+    fn stereo_separates_the_two_programme_channels() {
+        let mut chan = stereo_channel();
+        let audio = run_ragged(&mut chan, &two_tone_station(true));
+        let (left, right) = settled_channels(&audio);
+
+        for (channel, own, other) in [(&left, LEFT_HZ, RIGHT_HZ), (&right, RIGHT_HZ, LEFT_HZ)] {
+            let (freq, ratio) = dominant_tone(channel, f64::from(AUDIO_RATE));
+            assert!((own - 5.0..own + 5.0).contains(&freq), "dominant {freq} Hz");
+            assert!(ratio > 10.0, "tone-to-rest ratio {ratio}");
+            let separation = tone_power(channel, own, f64::from(AUDIO_RATE))
+                / tone_power(channel, other, f64::from(AUDIO_RATE));
+            assert!(
+                separation > 100.0,
+                "{own} Hz channel carries {other} Hz only {} dB down",
+                10.0 * separation.log10()
+            );
+        }
+        // 45 % deviation through 50 µs de-emphasis: |H(1 kHz)| ≈ 0.954, |H(3 kHz)| ≈ 0.728.
+        assert!(
+            (0.27..0.34).contains(&rms(&left)),
+            "left rms {}",
+            rms(&left)
+        );
+        assert!(
+            (0.20..0.26).contains(&rms(&right)),
+            "right rms {}",
+            rms(&right)
+        );
+    }
+
+    /// A station with no pilot still plays: the difference signal is gated off, so both
+    /// channels carry the mono sum — bit for bit, not merely close.
+    #[test]
+    fn a_mono_station_plays_the_same_audio_on_both_channels() {
+        let mut chan = stereo_channel();
+        let audio = run_ragged(&mut chan, &two_tone_station(false));
+        let (left, right) = split_stereo(&audio);
+        assert_eq!(left, right, "unlocked pilot leaked into the matrix");
+        // The sum of the two tones is what a mono station transmits: both are in it, and
+        // between them they are essentially all of it (de-emphasis leaves 3 kHz the quieter).
+        let settled = &left[left.len() / 2..];
+        let shares: Vec<f64> = [LEFT_HZ, RIGHT_HZ]
+            .iter()
+            .map(|&freq| tone_power(settled, freq, f64::from(AUDIO_RATE)))
+            .collect();
+        assert!(
+            shares.iter().all(|&s| s > 0.3) && shares.iter().sum::<f64>() > 0.9,
+            "tone shares of the sum signal {shares:?}"
+        );
+    }
+
+    /// The pilot sits 4 kHz above the audio band and must not survive the decimation filter:
+    /// nothing de-emphasizes the composite ahead of it any more.
+    #[test]
+    fn the_pilot_does_not_reach_the_audio() {
+        let mut chan = channel(50.0);
+        let audio = run_ragged(&mut chan, &two_tone_station(true));
+        let settled = &audio[audio.len() / 2..];
+        let pilot = tone_power(settled, PILOT_HZ, f64::from(AUDIO_RATE));
+        assert!(pilot < 1e-6, "pilot share of the mono audio {pilot}");
+    }
+
+    /// Toggling stereo is a params patch, not a pipeline rebuild, so the switch happens inside
+    /// a running channel — and both layouts must come out intact on either side of it.
+    #[test]
+    fn stereo_can_be_switched_on_and_off_while_running() {
+        let iq = two_tone_station(true);
+        let mut chan = channel(50.0);
+        let mono = run_ragged(&mut chan, &iq);
+        assert_eq!(mono.len(), iq.len() / DECIM_FACTOR);
+
+        chan.apply(settings(wfm_params(50.0, false, true))).unwrap();
+        let audio = run_ragged(&mut chan, &iq);
+        assert_eq!(audio.len(), 2 * (iq.len() / DECIM_FACTOR));
+        let (left, _) = settled_channels(&audio);
+        let separation = tone_power(&left, LEFT_HZ, f64::from(AUDIO_RATE))
+            / tone_power(&left, RIGHT_HZ, f64::from(AUDIO_RATE));
+        assert!(separation > 100.0, "separation after switching on");
+
+        chan.apply(settings(wfm_params(50.0, false, false)))
+            .unwrap();
+        let audio = run_ragged(&mut chan, &iq);
+        assert_eq!(audio.len(), iq.len() / DECIM_FACTOR);
+        let (freq, _) = dominant_tone(&audio[audio.len() / 2..], f64::from(AUDIO_RATE));
+        assert!((995.0..1_005.0).contains(&freq), "mono dominant {freq} Hz");
+    }
+
+    /// RDS rides on the third harmonic of the same pilot the stereo matrix locks to. Running
+    /// both at once must leave each intact — and an RDS station's composite carries a pilot
+    /// but no difference signal, so its two channels are the same programme.
+    #[test]
+    fn rds_and_stereo_run_on_the_same_pilot() {
+        let mut chan = WfmChannel::new(
+            ChannelCtx { input_rate: RATE },
+            settings(wfm_params(50.0, true, true)),
+        )
+        .unwrap();
+        let (audio, events) = run_collecting(
+            &mut chan,
+            &transmission(&station(), 3.5, Some(1_000.0), RATE),
+        );
+
+        let update = last_update(&events);
+        assert_eq!(update.ps.as_deref(), Some("WFM+RDS"));
+        assert_eq!(update.block_errors, 0);
+
+        let (left, right) = settled_channels(&audio);
+        let (freq, ratio) = dominant_tone(&left, f64::from(AUDIO_RATE));
+        assert!((995.0..1_005.0).contains(&freq), "dominant {freq} Hz");
+        assert!(ratio > 10.0, "tone-to-rest ratio {ratio}");
+        // No difference signal on the air, so what the matrix adds and subtracts is only what
+        // leaked into it: the two channels must stay within a fraction of a dB of each other.
+        let imbalance = (rms(&left) - rms(&right)).abs() / rms(&left);
+        assert!(imbalance < 0.05, "channel imbalance {imbalance}");
     }
 }

--- a/crates/dsp/src/iir.rs
+++ b/crates/dsp/src/iir.rs
@@ -1,4 +1,9 @@
-//! Single-pole audio IIR helpers (PLAN §7): FM deemphasis and DC removal.
+//! Single-pole IIR helpers (PLAN §7): FM deemphasis, DC removal, and the complex baseband
+//! smoother a mixed-down carrier is extracted with.
+
+use std::f64::consts::TAU;
+
+use num_complex::Complex;
 
 /// Smoothing coefficient for `y += c·(x − y)` matching the analog RC time constant `tau_s`
 /// at `rate` (matched-z pole `e^(−1/(rate·tau))`). Public because decoders that track a
@@ -39,6 +44,57 @@ impl Deemphasis {
     }
 }
 
+/// Cascaded single-pole complex lowpass, one `y += c·(x − y)` section per stage. The
+/// coefficients are real, so the response is symmetric about DC: a carrier mixed exactly to
+/// baseband passes with no phase shift at all — which is what a phase detector reading the
+/// output depends on — while its neighbours roll off `stages`·6 dB per octave.
+///
+/// This is the cheap alternative to an FIR for a *very* narrow band at a high rate: the FM
+/// pilot needs a ~400 Hz corner at 240 kHz, which no realisable FIR reaches without decimating
+/// first, and decimating would cost the sample-accurate phase the reference is rebuilt from.
+#[derive(Clone, Debug)]
+pub struct ComplexOnePole {
+    stages: Vec<Complex<f32>>,
+    coeff: f32,
+}
+
+impl ComplexOnePole {
+    /// `cutoff_hz` is the −3 dB corner of a single stage; the cascade's own corner is lower.
+    #[must_use]
+    pub fn new(rate: f64, cutoff_hz: f64, stages: usize) -> Self {
+        assert!(
+            rate > 0.0 && cutoff_hz > 0.0 && stages > 0,
+            "rate, cutoff and stage count must be positive"
+        );
+        Self {
+            stages: vec![Complex::new(0.0, 0.0); stages],
+            coeff: one_pole_coeff(rate, 1.0 / (TAU * cutoff_hz)),
+        }
+    }
+
+    /// Advance one sample. A non-finite input is dropped rather than latched into the
+    /// recursion — the per-sample counterpart of the per-block healing above.
+    #[must_use]
+    pub fn process(&mut self, sample: Complex<f32>) -> Complex<f32> {
+        let mut v = if sample.re.is_finite() && sample.im.is_finite() {
+            sample
+        } else {
+            Complex::new(0.0, 0.0)
+        };
+        for stage in &mut self.stages {
+            *stage += (v - *stage) * self.coeff;
+            v = *stage;
+        }
+        v
+    }
+
+    pub fn reset(&mut self) {
+        for stage in &mut self.stages {
+            *stage = Complex::new(0.0, 0.0);
+        }
+    }
+}
+
 /// DC blocker `y[n] = x[n] − x[n−1] + a·y[n−1]`. The 0.995 pole puts the corner near
 /// fs/1500 (~32 Hz at 48 kHz) — inaudible, but it kills demodulator DC offsets.
 #[derive(Clone, Debug, Default)]
@@ -75,7 +131,7 @@ mod tests {
     use std::f32::consts::FRAC_1_SQRT_2;
 
     use super::*;
-    use crate::testutil::{real_tone, rms_r};
+    use crate::testutil::{complex_tone, real_tone, rms_c, rms_r};
 
     fn deemphasis_gain(rate: f64, tau_us: f32, freq_hz: f64) -> f32 {
         let mut filter = Deemphasis::new(rate, tau_us);
@@ -133,6 +189,64 @@ mod tests {
         assert!(tone.iter().all(|v| v.is_finite()), "state still poisoned");
         let gain = rms_r(&tone[4_800..]) / FRAC_1_SQRT_2;
         assert!((0.891..1.122).contains(&gain), "post-recovery gain {gain}");
+    }
+
+    /// Settled response of a `stages`-deep cascade to a complex tone at `freq_norm`.
+    fn cascade_gain(freq_norm: f64, stages: usize) -> f32 {
+        let mut filter = ComplexOnePole::new(1.0, CUTOFF_NORM, stages);
+        let input = complex_tone(freq_norm, 200_000);
+        let out: Vec<Complex<f32>> = input.iter().map(|&s| filter.process(s)).collect();
+        rms_c(&out[out.len() / 2..])
+    }
+
+    /// −3 dB corner of one stage, normalized to the sample rate.
+    const CUTOFF_NORM: f64 = 0.001;
+
+    #[test]
+    fn complex_one_pole_matches_the_analytic_single_pole_response() {
+        // |H(f)| = (1 + (f/fc)²)^(−stages/2), the cascade of identical RC sections.
+        for (freq_norm, stages) in [(CUTOFF_NORM, 1), (10.0 * CUTOFF_NORM, 1), (0.01, 3)] {
+            let ratio = freq_norm / CUTOFF_NORM;
+            let expected = (1.0 + ratio * ratio).powf(-(stages as f64) / 2.0) as f32;
+            let gain = cascade_gain(freq_norm, stages);
+            assert!(
+                (gain - expected).abs() < 0.1 * expected.max(1e-3),
+                "{stages} stages at {ratio}·fc: gain {gain}, expected {expected}"
+            );
+        }
+    }
+
+    /// Real coefficients ⇒ a mirror-image tone is treated identically, and DC passes untouched
+    /// in both magnitude *and* phase — the stereo pilot reference is rebuilt from that phase.
+    #[test]
+    fn complex_one_pole_is_symmetric_about_dc_and_passes_it_unrotated() {
+        let above = cascade_gain(0.005, 3);
+        let below = cascade_gain(-0.005, 3);
+        assert!((above - below).abs() < 1e-4, "{above} vs {below}");
+
+        let mut filter = ComplexOnePole::new(1.0, CUTOFF_NORM, 3);
+        let dc = Complex::new(0.6f32, -0.8);
+        let mut out = Complex::new(0.0, 0.0);
+        for _ in 0..20_000 {
+            out = filter.process(dc);
+        }
+        assert!(
+            (out - dc).norm() < 1e-3,
+            "dc settled to {out}, expected {dc}"
+        );
+    }
+
+    #[test]
+    fn complex_one_pole_recovers_after_non_finite_sample() {
+        let mut filter = ComplexOnePole::new(1.0, CUTOFF_NORM, 2);
+        let _ = filter.process(Complex::new(f32::NAN, 0.0));
+        let _ = filter.process(Complex::new(0.0, f32::INFINITY));
+        let mut out = Complex::new(0.0, 0.0);
+        for _ in 0..20_000 {
+            out = filter.process(Complex::new(1.0, 0.0));
+        }
+        assert!(out.re.is_finite() && out.im.is_finite(), "state poisoned");
+        assert!((out.re - 1.0).abs() < 1e-3, "post-recovery gain {}", out.re);
     }
 
     #[test]

--- a/crates/dsp/src/lib.rs
+++ b/crates/dsp/src/lib.rs
@@ -37,7 +37,7 @@ pub use fec::{
 pub use fir::{design_bandpass, design_gaussian, design_lowpass};
 pub use firc::FirC;
 pub use fm::FmDemod;
-pub use iir::{DcBlocker, Deemphasis, one_pole_coeff};
+pub use iir::{ComplexOnePole, DcBlocker, Deemphasis, one_pole_coeff};
 pub use nco::Nco;
 pub use pll::{Costas, LoopFilter, Pll};
 pub use resamp::FracResampler;

--- a/crates/engine/src/audio.rs
+++ b/crates/engine/src/audio.rs
@@ -1,6 +1,10 @@
 //! Per-channel Opus encode (PLAN §9): a dedicated thread per channel turns the gated 48 kHz
-//! mono PCM broadcast into 20 ms Opus packets on its own broadcast stream. The thread exits
+//! PCM broadcast into 20 ms Opus packets on its own broadcast stream. The thread exits
 //! when every PCM sender is gone (channel removed / set stopped); removal joins it.
+//!
+//! Channel layout travels with the PCM rather than being fixed at construction: WFM stereo is
+//! a params patch, which reaches the live pipeline as a settings command and not as a rebuild,
+//! so the encoder has to be able to change layout under a running stream.
 
 use std::{sync::Arc, thread::JoinHandle};
 
@@ -9,9 +13,13 @@ use tokio::sync::broadcast::{self, error::RecvError};
 
 use crate::EngineError;
 
-/// 20 ms at the fixed 48 kHz channel audio rate (PLAN §9).
+/// 20 ms at the fixed 48 kHz channel audio rate (PLAN §9), counted in sample frames — a
+/// stereo frame holds twice as many `f32`s.
 pub const OPUS_FRAME_SAMPLES: usize = 960;
-const OPUS_BITRATE_BPS: i32 = 64_000;
+const MONO_BITRATE_BPS: i32 = 64_000;
+/// Stereo carries a second, largely correlated channel: half again the mono rate is what
+/// libopus needs to keep the same quality once it couples them.
+const STEREO_BITRATE_BPS: i32 = 96_000;
 /// libopus's recommended packet buffer; any single 20 ms frame fits.
 const MAX_PACKET_BYTES: usize = 4000;
 /// PCM blocks arrive at drain cadence (~25 ms each); 32 buffers ~0.8 s of encoder stall
@@ -19,44 +27,65 @@ const MAX_PACKET_BYTES: usize = 4000;
 pub(crate) const PCM_CHANNEL_CAP: usize = 32;
 pub(crate) const AUDIO_CHANNEL_CAP: usize = 64;
 
-/// One DSP-thread PCM hand-off, stamped with where it starts in the channel's 48 kHz sample
+/// One DSP-thread PCM hand-off, stamped with where it starts in the channel's 48 kHz frame
 /// stream. The stamps are what keep packet timestamps honest: blocks dropped between DSP and
 /// encoder surface as a stamp discontinuity instead of splicing seamlessly.
 #[derive(Clone, Debug)]
 pub(crate) struct PcmBlock {
-    pub(crate) start_sample: u64,
+    pub(crate) start_frame: u64,
+    /// Interleave of `payload`; 1 = mono, 2 = stereo (see `sdrmm_channels::audio_channels`).
+    pub(crate) channels: u8,
     pub(crate) payload: PcmPayload,
 }
 
-/// Squelched fill travels as a bare length — the DSP thread must not allocate for silence.
+/// Squelched fill travels as a bare frame count — the DSP thread must not allocate for silence.
 #[derive(Clone, Debug)]
 pub(crate) enum PcmPayload {
     Samples(Arc<[f32]>),
     Silence(usize),
 }
 
-/// One encoded audio frame. `timestamp` is the position of the frame's first sample in the
-/// channel's 48 kHz audio stream (PLAN §5 sample-count timestamps); a jump beyond the frame
-/// size marks PCM lost upstream while `seq` stays a contiguous packet counter.
+/// One encoded audio frame. `timestamp` is the position of the frame's first sample frame in
+/// the channel's 48 kHz audio stream (PLAN §5 sample-count timestamps); a jump beyond the
+/// frame size marks PCM lost upstream while `seq` stays a contiguous packet counter. The
+/// clock is in frames, so a layout change does not disturb it.
 #[derive(Clone, Debug)]
 pub struct AudioPacket {
     pub seq: u32,
     pub timestamp: u64,
+    /// Channel count this packet was encoded with; travels to the client in the frame header.
+    pub channels: u8,
     pub opus: Arc<[u8]>,
+}
+
+/// The Opus encoder plus the layout it was built for, so a change of layout is one swap.
+struct Encoder {
+    opus: opus::Encoder,
+    channels: u8,
+}
+
+impl Encoder {
+    fn new(channels: u8) -> Result<Self, opus::Error> {
+        let (layout, bitrate) = match channels {
+            2 => (opus::Channels::Stereo, STEREO_BITRATE_BPS),
+            _ => (opus::Channels::Mono, MONO_BITRATE_BPS),
+        };
+        let mut opus = opus::Encoder::new(AUDIO_RATE, layout, opus::Application::Audio)?;
+        opus.set_bitrate(opus::Bitrate::Bits(bitrate))?;
+        Ok(Self { opus, channels })
+    }
 }
 
 /// Build the encoder control-side so construction errors surface to the caller, then hand it
 /// to a dedicated thread — Opus encode must never run on the DSP thread (PLAN §7).
+/// `channels` is the layout the channel starts in; the thread follows it from there.
 pub(crate) fn spawn_encoder(
+    channels: u8,
     pcm_rx: broadcast::Receiver<PcmBlock>,
     audio_tx: broadcast::Sender<AudioPacket>,
 ) -> Result<JoinHandle<()>, EngineError> {
-    let mut encoder =
-        opus::Encoder::new(AUDIO_RATE, opus::Channels::Mono, opus::Application::Audio)
-            .map_err(|e| EngineError::Audio(format!("create opus encoder: {e}")))?;
-    encoder
-        .set_bitrate(opus::Bitrate::Bits(OPUS_BITRATE_BPS))
-        .map_err(|e| EngineError::Audio(format!("set opus bitrate: {e}")))?;
+    let mut encoder = Encoder::new(channels)
+        .map_err(|e| EngineError::Audio(format!("create opus encoder: {e}")))?;
     std::thread::Builder::new()
         .name("sdrmm-opus".to_string())
         .spawn(move || encode_loop(pcm_rx, &audio_tx, &mut encoder))
@@ -66,34 +95,68 @@ pub(crate) fn spawn_encoder(
 fn encode_loop(
     mut pcm_rx: broadcast::Receiver<PcmBlock>,
     audio_tx: &broadcast::Sender<AudioPacket>,
-    encoder: &mut opus::Encoder,
+    encoder: &mut Encoder,
 ) {
     let mut pending: Vec<f32> = Vec::new();
-    // Stream position of `pending[0]`; every packet timestamp derives from it.
+    // Stream position of `pending[0]`, in sample frames; every packet timestamp derives from it.
     let mut pending_start: u64 = 0;
     let mut packet = [0u8; MAX_PACKET_BYTES];
     let mut seq: u32 = 0;
+    // The layout an encoder rebuild last failed on, so a layout nothing can encode is
+    // reported once instead of at block cadence.
+    let mut rejected: Option<u8> = None;
     loop {
         match pcm_rx.blocking_recv() {
             Ok(block) => {
+                let mut channels = usize::from(encoder.channels);
                 // A stamp that is not where `pending` ends means PCM was dropped upstream:
                 // discard the stale partial frame instead of splicing across the gap, and
                 // resync — the loss then shows downstream as a timestamp jump.
-                if block.start_sample != pending_start + pending.len() as u64 {
+                if block.start_frame != pending_start + (pending.len() / channels) as u64 {
                     pending.clear();
-                    pending_start = block.start_sample;
+                    pending_start = block.start_frame;
                 }
+                if block.channels != encoder.channels {
+                    // The pending tail is in the old interleave and cannot be spliced onto
+                    // the new one; the client re-reads the layout from the frame header.
+                    pending.clear();
+                    pending_start = block.start_frame;
+                    match Encoder::new(block.channels) {
+                        Ok(fresh) => {
+                            *encoder = fresh;
+                            channels = usize::from(encoder.channels);
+                            rejected = None;
+                        }
+                        Err(e) => {
+                            if rejected.replace(block.channels) != Some(block.channels) {
+                                tracing::error!(
+                                    error = %e,
+                                    channels = block.channels,
+                                    "opus encoder rebuild failed; audio dropped until the layout changes"
+                                );
+                            }
+                            continue;
+                        }
+                    }
+                }
+                let frame_samples = OPUS_FRAME_SAMPLES * channels;
                 match block.payload {
                     PcmPayload::Samples(samples) => pending.extend_from_slice(&samples),
-                    PcmPayload::Silence(n) => pending.resize(pending.len() + n, 0.0),
+                    PcmPayload::Silence(frames) => {
+                        pending.resize(pending.len() + frames * channels, 0.0);
+                    }
                 }
-                while pending.len() >= OPUS_FRAME_SAMPLES {
-                    match encoder.encode_float(&pending[..OPUS_FRAME_SAMPLES], &mut packet) {
+                while pending.len() >= frame_samples {
+                    match encoder
+                        .opus
+                        .encode_float(&pending[..frame_samples], &mut packet)
+                    {
                         Ok(len) => {
                             // send() only errors with no subscribers — nobody listening is fine.
                             let _ = audio_tx.send(AudioPacket {
                                 seq,
                                 timestamp: pending_start,
+                                channels: encoder.channels,
                                 opus: Arc::from(&packet[..len]),
                             });
                             seq = seq.wrapping_add(1);
@@ -102,7 +165,7 @@ fn encode_loop(
                         // surfaces downstream as a timestamp gap, never a silent splice.
                         Err(e) => tracing::error!(error = %e, "opus encode failed; frame dropped"),
                     }
-                    pending.drain(..OPUS_FRAME_SAMPLES);
+                    pending.drain(..frame_samples);
                     pending_start += OPUS_FRAME_SAMPLES as u64;
                 }
             }
@@ -122,6 +185,22 @@ fn encode_loop(
 mod tests {
     use super::*;
 
+    fn samples(start_frame: u64, channels: u8, frames: usize) -> PcmBlock {
+        PcmBlock {
+            start_frame,
+            channels,
+            payload: PcmPayload::Samples(vec![0.25; frames * usize::from(channels)].into()),
+        }
+    }
+
+    fn silence(start_frame: u64, channels: u8, frames: usize) -> PcmBlock {
+        PcmBlock {
+            start_frame,
+            channels,
+            payload: PcmPayload::Silence(frames),
+        }
+    }
+
     /// A cap-1 PCM channel with blocks queued before the encoder starts makes the broadcast
     /// lag deterministic: the receiver sees `Lagged`, then only the newest block. The stale
     /// partial frame from before the gap must not be spliced into the first packet, and
@@ -130,15 +209,10 @@ mod tests {
     fn lag_drops_stale_pending_and_resyncs_timestamps() {
         let (pcm_tx, pcm_rx) = broadcast::channel(1);
         let (audio_tx, mut audio_rx) = broadcast::channel(8);
-        for (start, n) in [(0u64, 480usize), (480, 480), (960, 960)] {
-            pcm_tx
-                .send(PcmBlock {
-                    start_sample: start,
-                    payload: PcmPayload::Samples(vec![0.25; n].into()),
-                })
-                .unwrap();
+        for (start, frames) in [(0u64, 480usize), (480, 480), (960, 960)] {
+            pcm_tx.send(samples(start, 1, frames)).unwrap();
         }
-        let encoder = spawn_encoder(pcm_rx, audio_tx).unwrap();
+        let encoder = spawn_encoder(1, pcm_rx, audio_tx).unwrap();
 
         let first = audio_rx.blocking_recv().unwrap();
         assert_eq!(first.seq, 0);
@@ -148,12 +222,7 @@ mod tests {
         );
 
         // The first packet proves the 960-block was consumed, so this send cannot lag.
-        pcm_tx
-            .send(PcmBlock {
-                start_sample: 1_920,
-                payload: PcmPayload::Silence(960),
-            })
-            .unwrap();
+        pcm_tx.send(silence(1_920, 1, 960)).unwrap();
         let second = audio_rx.blocking_recv().unwrap();
         assert_eq!(second.seq, 1);
         assert_eq!(second.timestamp, 1_920);
@@ -168,25 +237,58 @@ mod tests {
     fn contiguous_stamps_yield_contiguous_timestamps() {
         let (pcm_tx, pcm_rx) = broadcast::channel(PCM_CHANNEL_CAP);
         let (audio_tx, mut audio_rx) = broadcast::channel(8);
-        pcm_tx
-            .send(PcmBlock {
-                start_sample: 0,
-                payload: PcmPayload::Samples(vec![0.1; 1_440].into()),
-            })
-            .unwrap();
-        pcm_tx
-            .send(PcmBlock {
-                start_sample: 1_440,
-                payload: PcmPayload::Silence(480),
-            })
-            .unwrap();
-        let encoder = spawn_encoder(pcm_rx, audio_tx).unwrap();
+        pcm_tx.send(samples(0, 1, 1_440)).unwrap();
+        pcm_tx.send(silence(1_440, 1, 480)).unwrap();
+        let encoder = spawn_encoder(1, pcm_rx, audio_tx).unwrap();
         drop(pcm_tx);
 
         let first = audio_rx.blocking_recv().unwrap();
         let second = audio_rx.blocking_recv().unwrap();
         assert_eq!((first.seq, first.timestamp), (0, 0));
         assert_eq!((second.seq, second.timestamp), (1, 960));
+        encoder.join().unwrap();
+    }
+
+    /// A stereo channel's blocks hold two samples per frame: the packet cadence must follow
+    /// the *frame* clock, not the buffer length, or every timestamp doubles.
+    #[test]
+    fn stereo_blocks_are_timestamped_in_frames() {
+        let (pcm_tx, pcm_rx) = broadcast::channel(PCM_CHANNEL_CAP);
+        let (audio_tx, mut audio_rx) = broadcast::channel(8);
+        pcm_tx.send(samples(0, 2, 1_440)).unwrap();
+        pcm_tx.send(silence(1_440, 2, 480)).unwrap();
+        let encoder = spawn_encoder(2, pcm_rx, audio_tx).unwrap();
+        drop(pcm_tx);
+
+        let first = audio_rx.blocking_recv().unwrap();
+        let second = audio_rx.blocking_recv().unwrap();
+        assert_eq!((first.seq, first.timestamp, first.channels), (0, 0, 2));
+        assert_eq!((second.seq, second.timestamp, second.channels), (1, 960, 2));
+        encoder.join().unwrap();
+    }
+
+    /// Toggling WFM stereo reaches a live channel as a settings command, so the layout changes
+    /// under the running encoder: the packets after it must be stereo, keep the frame clock,
+    /// and carry no spliced tail from the mono side of the switch.
+    #[test]
+    fn a_layout_change_swaps_the_encoder_mid_stream() {
+        let (pcm_tx, pcm_rx) = broadcast::channel(PCM_CHANNEL_CAP);
+        let (audio_tx, mut audio_rx) = broadcast::channel(8);
+        let encoder = spawn_encoder(1, pcm_rx, audio_tx).unwrap();
+
+        pcm_tx.send(samples(0, 1, 960)).unwrap();
+        let mono = audio_rx.blocking_recv().unwrap();
+        assert_eq!((mono.timestamp, mono.channels), (0, 1));
+
+        // Half a frame of mono, then the switch: the partial mono tail must not be encoded
+        // as the head of the first stereo packet.
+        pcm_tx.send(samples(960, 1, 480)).unwrap();
+        pcm_tx.send(samples(1_440, 2, 960)).unwrap();
+        let stereo = audio_rx.blocking_recv().unwrap();
+        assert_eq!((stereo.timestamp, stereo.channels), (1_440, 2));
+        assert_eq!(stereo.seq, 1, "seq stays a contiguous packet counter");
+
+        drop(pcm_tx);
         encoder.join().unwrap();
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -298,10 +298,12 @@ struct ChannelAudio {
 }
 
 impl ChannelAudio {
-    fn new() -> Result<Self, EngineError> {
+    /// `channels` is the layout the channel starts in; the encoder follows the PCM from there,
+    /// so a later stereo toggle needs no new identity.
+    fn new(channels: u8) -> Result<Self, EngineError> {
         let (pcm_tx, pcm_rx) = broadcast::channel(audio::PCM_CHANNEL_CAP);
         let (audio_tx, _) = broadcast::channel(audio::AUDIO_CHANNEL_CAP);
-        let encoder = audio::spawn_encoder(pcm_rx, audio_tx.clone())?;
+        let encoder = audio::spawn_encoder(channels, pcm_rx, audio_tx.clone())?;
         Ok(Self {
             pcm_tx,
             pcm_pos: Arc::new(AtomicU64::new(0)),
@@ -1503,7 +1505,7 @@ impl Engine {
             state.next_channel_id += 1;
             (sample_rate_of(&state.settings), id)
         };
-        let created = ChannelAudio::new()?;
+        let created = ChannelAudio::new(sdrmm_channels::audio_channels(&settings.params))?;
         let pcm_tx = created.pcm_tx.clone();
         let pcm_pos = created.pcm_pos.clone();
         let mut audio = Some(created);

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -144,11 +144,14 @@ pub(crate) struct ChannelHost {
     outputs: ChannelOutputs,
     scratch: Vec<Complex<f32>>,
     filtered: Vec<Complex<f32>>,
-    /// Audio samples per channel-rate IQ sample, with a running remainder so squelched
+    /// Audio frames per channel-rate IQ sample, with a running remainder so squelched
     /// zero-fill stays duration-accurate (WFM decimates 5:1 inside the demod).
     pcm_per_input: f64,
     zero_carry: f64,
-    /// 48 kHz-domain position of the channel's next PCM sample. Shared through the
+    /// Interleave of the channel's audio, from its params: what the demod writes when it runs
+    /// and what the squelched zero-fill has to match.
+    audio_channels: u8,
+    /// 48 kHz-domain position of the channel's next PCM *frame*. Shared through the
     /// channel's audio identity so stamps stay continuous across pipeline rebuilds; only
     /// the DSP thread advances it (hosts are swapped, never concurrent), so `Relaxed`
     /// suffices — the stamps consumers act on travel inside the messages themselves.
@@ -207,6 +210,7 @@ impl ChannelHost {
             filtered: Vec::new(),
             pcm_per_input: f64::from(AUDIO_RATE) / input_rate,
             zero_carry: 0.0,
+            audio_channels: sdrmm_channels::audio_channels(&settings.params),
             pcm_pos,
             pcm_tx,
             offset_hz: settings.offset_hz,
@@ -245,11 +249,11 @@ impl ChannelHost {
                 // (short internal critical section, bounded channel, no syscalls) per
                 // ~25 ms block, and no other thread ever holds that lock across blocking
                 // work — the DSP thread cannot stall on it.
-                let stamp = self
-                    .pcm_pos
-                    .fetch_add(self.outputs.audio_pcm.len() as u64, Ordering::Relaxed);
+                let frames = self.outputs.audio_pcm.len() / usize::from(self.audio_channels);
+                let stamp = self.pcm_pos.fetch_add(frames as u64, Ordering::Relaxed);
                 let _ = self.pcm_tx.send(PcmBlock {
-                    start_sample: stamp,
+                    start_frame: stamp,
+                    channels: self.audio_channels,
                     payload: PcmPayload::Samples(Arc::from(self.outputs.audio_pcm.as_slice())),
                 });
             }
@@ -274,14 +278,15 @@ impl ChannelHost {
                 }
             }
             // A closed gate still emits (zeroed) audio so client jitter buffers stay alive;
-            // silence travels as a bare length, so this path allocates nothing.
+            // silence travels as a bare frame count, so this path allocates nothing.
             self.zero_carry += self.filtered.len() as f64 * self.pcm_per_input;
             let zeros = self.zero_carry as usize;
             if zeros > 0 {
                 self.zero_carry -= zeros as f64;
                 let stamp = self.pcm_pos.fetch_add(zeros as u64, Ordering::Relaxed);
                 let _ = self.pcm_tx.send(PcmBlock {
-                    start_sample: stamp,
+                    start_frame: stamp,
+                    channels: self.audio_channels,
                     payload: PcmPayload::Silence(zeros),
                 });
             }
@@ -307,8 +312,13 @@ impl ChannelHost {
                 }
             }
         }
+        let channels = sdrmm_channels::audio_channels(&settings.params);
         if let Err(e) = self.rx.apply(settings) {
             tracing::error!(error = %e, "validated channel settings rejected on dsp thread");
+        } else {
+            // Only once the demod has taken the settings: the interleave the squelched
+            // zero-fill claims must be the one the channel is now actually producing.
+            self.audio_channels = channels;
         }
     }
 }
@@ -772,14 +782,14 @@ mod tests {
             !blocks.is_empty(),
             "closed gate must still emit keep-alive fill"
         );
-        let settled = blocks.iter().filter(|b| b.start_sample >= settle);
+        let settled = blocks.iter().filter(|b| b.start_frame >= settle);
         let mut seen = 0usize;
         for block in settled {
             seen += 1;
             assert!(
                 matches!(block.payload, PcmPayload::Silence(_)),
                 "{what}: gate open on out-of-channel energy at stamp {}",
-                block.start_sample
+                block.start_frame
             );
         }
         assert!(seen > 0, "no settled blocks to judge");
@@ -877,12 +887,12 @@ mod tests {
         let mut expected = 0u64;
         let mut seen = 0usize;
         while let Ok(block) = rx.try_recv() {
-            assert_eq!(block.start_sample, expected, "stamp gap at block {seen}");
-            let len = match &block.payload {
-                PcmPayload::Samples(s) => s.len(),
+            assert_eq!(block.start_frame, expected, "stamp gap at block {seen}");
+            let frames = match &block.payload {
+                PcmPayload::Samples(s) => s.len() / usize::from(block.channels),
                 PcmPayload::Silence(n) => *n,
             };
-            expected += len as u64;
+            expected += frames as u64;
             seen += 1;
         }
         assert_eq!(

--- a/crates/engine/tests/common/mod.rs
+++ b/crates/engine/tests/common/mod.rs
@@ -34,15 +34,31 @@ pub async fn collect_packets(
     out
 }
 
-fn decode(packets: &[AudioPacket]) -> Vec<f32> {
-    let mut decoder = opus::Decoder::new(48_000, opus::Channels::Mono).expect("decoder");
-    let mut out = Vec::with_capacity(packets.len() * OPUS_FRAME_SAMPLES);
-    let mut frame = [0.0f32; OPUS_FRAME_SAMPLES];
+/// One vector per audio channel, deinterleaved. The layout comes from the packets themselves;
+/// a run whose layout changes part-way through would need two decoders, so it is a test bug
+/// here rather than something to paper over.
+fn decode(packets: &[AudioPacket]) -> Vec<Vec<f32>> {
+    let channels = usize::from(packets.first().map_or(1, |p| p.channels));
+    assert!(
+        packets.iter().all(|p| usize::from(p.channels) == channels),
+        "channel layout changed inside one collection"
+    );
+    let layout = if channels == 2 {
+        opus::Channels::Stereo
+    } else {
+        opus::Channels::Mono
+    };
+    let mut decoder = opus::Decoder::new(48_000, layout).expect("decoder");
+    let mut out = vec![Vec::with_capacity(packets.len() * OPUS_FRAME_SAMPLES); channels];
+    let mut frame = vec![0.0f32; OPUS_FRAME_SAMPLES * channels];
     for packet in packets {
-        let n = decoder
+        // Opus counts what it decoded in sample frames, whatever the layout.
+        let frames = decoder
             .decode_float(&packet.opus, &mut frame, false)
             .expect("opus decode");
-        out.extend_from_slice(&frame[..n]);
+        for (i, sample) in frame[..frames * channels].iter().enumerate() {
+            out[i % channels].push(*sample);
+        }
     }
     out
 }
@@ -59,17 +75,26 @@ fn goertzel_power(samples: &[f32], freq_hz: f64) -> f64 {
     coeff.mul_add(-(s1 * s2), s1 * s1 + s2 * s2)
 }
 
-pub fn assert_tone_dominates(audio: &[f32]) {
-    let tone = goertzel_power(audio, MOD_TONE_HZ);
-    let probes = [700.0, 1_500.0, 2_300.0].map(|f| goertzel_power(audio, f));
-    let mean = probes.iter().sum::<f64>() / probes.len() as f64;
-    assert!(
-        tone > 10.0 * mean,
-        "1 kHz tone does not dominate: tone {tone:.3e}, probe mean {mean:.3e} ({probes:?})"
-    );
+/// Every channel of the decoded audio must carry the virtual device's tone — a stereo mode
+/// that filled only one of them would still pass a check on the first.
+pub fn assert_tone_dominates(channels: &[Vec<f32>]) {
+    assert!(!channels.is_empty(), "no audio channels decoded");
+    for (index, audio) in channels.iter().enumerate() {
+        let tone = goertzel_power(audio, MOD_TONE_HZ);
+        let probes = [700.0, 1_500.0, 2_300.0].map(|f| goertzel_power(audio, f));
+        let mean = probes.iter().sum::<f64>() / probes.len() as f64;
+        assert!(
+            tone > 10.0 * mean,
+            "channel {index}: 1 kHz tone does not dominate: tone {tone:.3e}, \
+             probe mean {mean:.3e} ({probes:?})"
+        );
+    }
 }
 
-pub async fn settle_then_collect_second(rx: &mut broadcast::Receiver<AudioPacket>) -> Vec<f32> {
+/// One second of settled audio, deinterleaved: one vector per channel of the stream's layout.
+pub async fn settle_then_collect_second(
+    rx: &mut broadcast::Receiver<AudioPacket>,
+) -> Vec<Vec<f32>> {
     collect_packets(rx, SETTLE_PACKETS).await;
     decode(&collect_packets(rx, ONE_SECOND_PACKETS).await)
 }

--- a/crates/engine/tests/decode.rs
+++ b/crates/engine/tests/decode.rs
@@ -632,6 +632,7 @@ async fn rds_station_survives_the_ddc_and_reaches_the_decoded_stream() {
             params: ChannelParams::Wfm(WfmParams {
                 deemphasis_us: 50.0,
                 rds: true,
+                stereo: false,
             }),
         },
         |event| matches!(event, DecoderEvent::Rds(u) if u.ps.is_some()),
@@ -692,6 +693,7 @@ async fn retuning_resets_the_decoder_through_the_engine_path() {
         params: ChannelParams::Wfm(WfmParams {
             deemphasis_us: 50.0,
             rds: true,
+            stereo: false,
         }),
     };
 

--- a/crates/engine/tests/listen.rs
+++ b/crates/engine/tests/listen.rs
@@ -97,8 +97,12 @@ async fn am_channel_demodulates_the_test_carrier() {
     engine.remove_device_set(ds).unwrap();
 }
 
+/// WFM defaults to stereo, so this also drives the whole two-channel path end to end: PCM
+/// interleave, a stereo Opus encoder, and the frame clock staying in sample frames. The
+/// virtual device transmits no 19 kHz pilot, so it is the unlocked-pilot fallback that must
+/// come out — the same programme on both channels, sample for sample.
 #[tokio::test]
-async fn wfm_channel_demodulates_the_test_carrier() {
+async fn wfm_channel_demodulates_the_test_carrier_in_stereo() {
     let engine = engine();
     let ds = set_at_test_rate(&engine);
     let ch = engine
@@ -113,7 +117,68 @@ async fn wfm_channel_demodulates_the_test_carrier() {
         )
         .unwrap();
     let mut rx = engine.subscribe_audio(ds, ch).unwrap();
-    assert_tone_dominates(&settle_then_collect_second(&mut rx).await);
+    let channels = settle_then_collect_second(&mut rx).await;
+    assert_eq!(channels.len(), 2, "wfm defaults to a two-channel stream");
+    assert_tone_dominates(&channels);
+    // Opus is lossy and codes the two channels jointly, so "the same programme" is a level
+    // match, not bit equality: anything above a fraction of a percent is a real difference.
+    let difference: Vec<f32> = channels[0]
+        .iter()
+        .zip(&channels[1])
+        .map(|(l, r)| l - r)
+        .collect();
+    let (left, delta) = (rms(&channels[0]), rms(&difference));
+    assert!(
+        delta < 0.05 * left,
+        "no pilot on air, yet the channels differ: rms {delta} against {left}"
+    );
+    engine.remove_device_set(ds).unwrap();
+}
+
+/// Toggling stereo is a params patch, so it reaches the live pipeline as a settings command
+/// and never as a rebuild: the encoder has to change layout under a running stream, and the
+/// stream's timestamps have to keep counting sample frames on the far side of the switch.
+#[tokio::test]
+async fn wfm_stereo_toggle_changes_the_layout_of_the_live_stream() {
+    let engine = engine();
+    let ds = set_at_test_rate(&engine);
+    let wfm = |stereo: bool| {
+        settings(
+            ChannelParams::Wfm(WfmParams {
+                deemphasis_us: 50.0,
+                rds: false,
+                stereo,
+            }),
+            WFM_CARRIER_OFFSET_HZ,
+            None,
+        )
+    };
+    let ch = engine.add_channel(ds, 0, wfm(true)).unwrap();
+    let mut rx = engine.subscribe_audio(ds, ch).unwrap();
+    let stereo = collect_packets(&mut rx, SETTLE_PACKETS).await;
+    assert!(
+        stereo.iter().all(|p| p.channels == 2),
+        "stream did not start stereo"
+    );
+
+    engine.patch_channel(ds, ch, wfm(false)).unwrap();
+    // The command applies between blocks, so a few stereo packets are still in flight.
+    let mut waited = 0;
+    while collect_packets(&mut rx, 1).await[0].channels != 1 {
+        waited += 1;
+        assert!(waited < SETTLE_PACKETS, "layout never followed the patch");
+    }
+
+    let mono = collect_packets(&mut rx, SETTLE_PACKETS).await;
+    assert!(mono.iter().all(|p| p.channels == 1), "layout flapped back");
+    for pair in mono.windows(2) {
+        assert_eq!(pair[1].seq, pair[0].seq.wrapping_add(1), "seq gap");
+        assert_eq!(
+            pair[1].timestamp,
+            pair[0].timestamp + OPUS_FRAME_SAMPLES as u64,
+            "the frame clock did not survive the layout change"
+        );
+    }
     engine.remove_device_set(ds).unwrap();
 }
 
@@ -128,7 +193,7 @@ async fn squelch_gates_empty_spectrum_and_patch_reopens() {
 
     // Closed gate: PCM keeps flowing (jitter-buffer contract) but carries silence.
     let silence = settle_then_collect_second(&mut rx).await;
-    let level = rms(&silence);
+    let level = rms(&silence[0]);
     assert!(level < 0.01, "squelched audio rms {level}");
 
     engine

--- a/crates/engine/tests/multistream.rs
+++ b/crates/engine/tests/multistream.rs
@@ -121,7 +121,7 @@ async fn a_channel_on_stream_2_hears_stream_2_and_not_stream_0() {
 
     let on_stream_0 = engine.add_channel(ds, 0, nfm(offset, Some(-20.0))).unwrap();
     let mut rx = engine.subscribe_audio(ds, on_stream_0).unwrap();
-    let level = rms(&settle_then_collect_second(&mut rx).await);
+    let level = rms(&settle_then_collect_second(&mut rx).await[0]);
     assert!(
         level < 0.01,
         "stream 0 carries no signal at stream 2's offset, yet audio rms is {level}"

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -29,8 +29,6 @@ const OUT_CHANNEL_CAP: usize = 256;
 const MIN_BINS: usize = 16;
 const MAX_BINS: usize = 4096;
 const MAX_FPS: u16 = 60;
-/// `ch_layout` header byte for mono audio frames (PLAN §5 frame layout).
-const CH_LAYOUT_MONO: u8 = 1;
 /// Audio stream ids live in `AUDIO_ID_BASE..=u16::MAX` and spectrum ids in `0..AUDIO_ID_BASE`, so
 /// the two can never collide on one connection.
 ///
@@ -572,7 +570,8 @@ fn spawn_spectrum(
 }
 
 /// Per-subscription task: forward the channel's Opus packets as binary [`AudioFrame`]s
-/// (mono, PLAN §9) with the same drop-oldest backpressure as [`spawn_spectrum`].
+/// (PLAN §9) with the same drop-oldest backpressure as [`spawn_spectrum`]. The channel layout
+/// comes from the packet: a channel may switch between mono and stereo mid-stream.
 fn spawn_audio(
     stream_id: u16,
     mut rx: broadcast::Receiver<AudioPacket>,
@@ -586,7 +585,7 @@ fn spawn_audio(
                         stream_id,
                         seq: packet.seq,
                         timestamp: packet.timestamp,
-                        ch_layout: CH_LAYOUT_MONO,
+                        ch_layout: packet.channels,
                         opus: &packet.opus,
                     }
                     .encode();
@@ -1081,6 +1080,7 @@ mod tests {
             tx.send(AudioPacket {
                 seq,
                 timestamp: u64::from(seq) * 960,
+                channels: 1,
                 opus: Arc::from(&[0u8; 4][..]),
             })
             .expect("send");
@@ -1131,6 +1131,36 @@ mod tests {
             seqs.len() < last_seq as usize + 1,
             "stale backlog was not shed: {seqs:?}"
         );
+    }
+
+    /// The layout byte is the packet's own, not a constant: a channel that switches to stereo
+    /// mid-stream (WFM's stereo toggle) has to be announced frame by frame, or the client
+    /// keeps decoding the new packets with the old channel count.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn audio_frames_carry_each_packets_channel_layout() {
+        let (tx, rx) = broadcast::channel::<AudioPacket>(4);
+        let (out_tx, mut out_rx) = mpsc::channel::<Message>(4);
+        let task = spawn_audio(AUDIO_ID_BASE, rx, out_tx);
+
+        for (seq, channels) in [(0u32, 1u8), (1, 2)] {
+            tx.send(AudioPacket {
+                seq,
+                timestamp: u64::from(seq) * 960,
+                channels,
+                opus: Arc::from(&[0u8; 4][..]),
+            })
+            .expect("send");
+            let Ok(Some(Message::Binary(buf))) = timeout(WAIT, out_rx.recv()).await else {
+                panic!("no audio frame for seq {seq}");
+            };
+            // Byte 16 is `ch_layout`, straight after the 16-byte header (wire::frame).
+            assert_eq!(buf[16], channels, "layout of packet {seq}");
+        }
+
+        drop(tx);
+        // Drain the StreamStopped the closed broadcast produces so the task can finish.
+        let _ = timeout(WAIT, out_rx.recv()).await;
+        task.await.expect("forwarder task");
     }
 
     /// Connections are counted for every client and released on disconnect, and each change

--- a/crates/wire/src/channel.rs
+++ b/crates/wire/src/channel.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 pub struct ChannelDescriptor {
     /// Stable type id, e.g. `"nfm"`, `"am"`, `"ssb"`, `"wfm"`.
     pub type_id: String,
-    /// Display name, e.g. `"NFM"`, `"WFM (mono)"`.
+    /// Display name, e.g. `"NFM"`, `"WFM (broadcast)"`.
     pub name: String,
     /// Nominal RF bandwidth the channel needs, in Hz.
     pub bandwidth_hz: f64,
@@ -100,6 +100,10 @@ fn default_deemphasis_us() -> f32 {
     50.0
 }
 
+fn default_stereo() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct NfmParams {
     #[serde(default = "default_nfm_bandwidth_hz")]
@@ -168,6 +172,10 @@ pub struct WfmParams {
     /// it costs a second demod chain on the same channel.
     #[serde(default)]
     pub rds: bool,
+    /// Recover the 38 kHz stereo difference signal, making the channel's audio two-channel.
+    /// A station without a 19 kHz pilot still plays: L and R carry the same mono programme.
+    #[serde(default = "default_stereo")]
+    pub stereo: bool,
 }
 
 impl Default for WfmParams {
@@ -175,6 +183,7 @@ impl Default for WfmParams {
         Self {
             deemphasis_us: default_deemphasis_us(),
             rds: false,
+            stereo: default_stereo(),
         }
     }
 }

--- a/crates/wire/src/frame.rs
+++ b/crates/wire/src/frame.rs
@@ -17,12 +17,14 @@
 //!   u16 n
 //!   u8[n] bins          (quantized magnitude over [db_min, db_max])
 //! AUDIO_OPUS payload:
-//!   u8  ch_layout       (1 = mono)
+//!   u8  ch_layout       (1 = mono, 2 = stereo — the packet's own Opus channel count)
 //!   u8[] opus           (one Opus packet, to end of frame)
 //! ```
 //!
-//! AUDIO_OPUS timestamps count 48 kHz-domain samples since the channel's audio started
-//! (PLAN §9: demods emit 48 kHz PCM before Opus encoding).
+//! AUDIO_OPUS timestamps count 48 kHz-domain sample *frames* since the channel's audio started
+//! (PLAN §9: demods emit 48 kHz PCM before Opus encoding), so a layout change does not disturb
+//! the clock a client detects loss on. `ch_layout` travels per frame because a channel may
+//! switch layout mid-stream (WFM stereo toggled on a live channel).
 
 /// Protocol version in every frame header. Bump on any layout change.
 pub const PROTOCOL_VERSION: u8 = 1;
@@ -98,9 +100,9 @@ impl SpectrumFrame<'_> {
 pub struct AudioFrame<'a> {
     pub stream_id: u16,
     pub seq: u32,
-    /// 48 kHz-domain sample count since the channel's audio started.
+    /// 48 kHz-domain sample-frame count since the channel's audio started.
     pub timestamp: u64,
-    /// Channel layout; 1 = mono.
+    /// Channel layout of this packet; 1 = mono, 2 = stereo (interleaved L, R).
     pub ch_layout: u8,
     pub opus: &'a [u8],
 }
@@ -190,26 +192,30 @@ mod tests {
         (ver, kind, stream_id, seq, timestamp, ch_layout, opus)
     }
 
+    /// Both layouts travel through the same fixed offsets: only the `ch_layout` byte differs,
+    /// so a stereo frame must not shift the opus payload by so much as a byte.
     #[test]
-    fn audio_roundtrip() {
+    fn audio_roundtrip_in_both_layouts() {
         let opus: Vec<u8> = (0..96u8).map(|i| i.wrapping_mul(3)).collect();
-        let frame = AudioFrame {
-            stream_id: 3,
-            seq: 512,
-            timestamp: 96_000,
-            ch_layout: 1,
-            opus: &opus,
-        };
-        let buf = frame.encode();
-        assert_eq!(buf.len(), frame.encoded_len());
+        for ch_layout in [1u8, 2] {
+            let frame = AudioFrame {
+                stream_id: 3,
+                seq: 512,
+                timestamp: 96_000,
+                ch_layout,
+                opus: &opus,
+            };
+            let buf = frame.encode();
+            assert_eq!(buf.len(), frame.encoded_len());
 
-        let (ver, kind, sid, seq, ts, layout, out) = decode_audio(&buf);
-        assert_eq!(ver, PROTOCOL_VERSION);
-        assert_eq!(kind, FrameKind::AudioOpus);
-        assert_eq!(sid, 3);
-        assert_eq!(seq, 512);
-        assert_eq!(ts, 96_000);
-        assert_eq!(layout, 1);
-        assert_eq!(out, opus);
+            let (ver, kind, sid, seq, ts, layout, out) = decode_audio(&buf);
+            assert_eq!(ver, PROTOCOL_VERSION);
+            assert_eq!(kind, FrameKind::AudioOpus);
+            assert_eq!(sid, 3);
+            assert_eq!(seq, 512);
+            assert_eq!(ts, 96_000);
+            assert_eq!(layout, ch_layout);
+            assert_eq!(out, opus);
+        }
     }
 }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -234,6 +234,7 @@ mod contract_tests {
             ChannelParams::Wfm(WfmParams {
                 deemphasis_us: 75.0,
                 rds: false,
+                stereo: true,
             })
         );
     }

--- a/openapi.json
+++ b/openapi.json
@@ -2277,7 +2277,7 @@
           },
           "name": {
             "type": "string",
-            "description": "Display name, e.g. `\"NFM\"`, `\"WFM (mono)\"`."
+            "description": "Display name, e.g. `\"NFM\"`, `\"WFM (broadcast)\"`."
           },
           "native_rate_max_hz": {
             "type": [
@@ -5860,6 +5860,10 @@
           "rds": {
             "type": "boolean",
             "description": "Decode the 57 kHz RDS subcarrier alongside the audio (PLAN §13 P2). Off by default:\nit costs a second demod chain on the same channel."
+          },
+          "stereo": {
+            "type": "boolean",
+            "description": "Recover the 38 kHz stereo difference signal, making the channel's audio two-channel.\nA station without a 19 kHz pilot still plays: L and R carry the same mono programme."
           }
         }
       },

--- a/web/src/components/ChannelControls.tsx
+++ b/web/src/components/ChannelControls.tsx
@@ -253,6 +253,13 @@ function ModeControls({
             />
           </label>
           <Toggle
+            label="Stereo"
+            checked={params.settings.stereo ?? true}
+            onChange={(stereo) =>
+              onParams({ type: "wfm", settings: { ...params.settings, stereo } })
+            }
+          />
+          <Toggle
             label="RDS"
             checked={params.settings.rds ?? false}
             onChange={(rds) => onParams({ type: "wfm", settings: { ...params.settings, rds } })}

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -759,7 +759,7 @@ export interface components {
              * @description IQ rate the demod expects from the DDC, in Hz.
              */
             input_rate_hz: number;
-            /** @description Display name, e.g. `"NFM"`, `"WFM (mono)"`. */
+            /** @description Display name, e.g. `"NFM"`, `"WFM (broadcast)"`. */
             name: string;
             /**
              * Format: double
@@ -2297,6 +2297,11 @@ export interface components {
              *     it costs a second demod chain on the same channel.
              */
             rds?: boolean;
+            /**
+             * @description Recover the 38 kHz stereo difference signal, making the channel's audio two-channel.
+             *     A station without a 19 kHz pilot still plays: L and R carry the same mono programme.
+             */
+            stereo?: boolean;
         };
         /** @description `GET /api/workspaces/{id}` — the row plus its workspace. */
         WorkspaceDetail: components["schemas"]["WorkspaceInfo"] & {

--- a/web/src/lib/audio/decoder.ts
+++ b/web/src/lib/audio/decoder.ts
@@ -1,59 +1,75 @@
 // Opus packet decoding (PLAN §9): WebCodecs `AudioDecoder` when the platform supports the
 // exact stream config, else the "opus-decoder" WASM build (the likely WKWebView/Tauri path).
-// Both paths emit Float32 PCM at 48 kHz mono.
+// Both paths emit interleaved Float32 PCM at 48 kHz, in the channel count they were built for.
 import { SAMPLE_RATE } from "./worklet";
 
 export interface OpusPacketDecoder {
+  /** Channel count this decoder was configured for; interleave of what it emits. */
+  readonly channels: number;
   decode(packet: Uint8Array, timestampUs: number): void;
   close(): void;
 }
-
-const OPUS_CONFIG: AudioDecoderConfig = {
-  codec: "opus",
-  sampleRate: SAMPLE_RATE,
-  numberOfChannels: 1,
-};
 
 // Opus decode is far faster than realtime, so a growing WebCodecs queue means the pipeline
 // is stuck; drop instead of queueing unboundedly (PLAN §5: UI streams are drop-oldest).
 const MAX_DECODE_QUEUE = 16;
 
-let webCodecsProbe: Promise<boolean> | null = null;
+function config(channels: number): AudioDecoderConfig {
+  return { codec: "opus", sampleRate: SAMPLE_RATE, numberOfChannels: channels };
+}
 
-function webCodecsSupported(): Promise<boolean> {
-  webCodecsProbe ??= (async () => {
-    if (typeof AudioDecoder === "undefined") {
-      return false;
-    }
-    try {
-      const support = await AudioDecoder.isConfigSupported(OPUS_CONFIG);
-      return support.supported === true;
-    } catch {
-      return false;
-    }
-  })();
-  return webCodecsProbe;
+// Support is per stream config, so the probe is keyed by channel count: a platform may do
+// mono and not stereo, and answering from a mono probe would configure a decoder that throws.
+const webCodecsProbes = new Map<number, Promise<boolean>>();
+
+function webCodecsSupported(channels: number): Promise<boolean> {
+  let probe = webCodecsProbes.get(channels);
+  if (!probe) {
+    probe = (async () => {
+      if (typeof AudioDecoder === "undefined") {
+        return false;
+      }
+      try {
+        const support = await AudioDecoder.isConfigSupported(config(channels));
+        return support.supported === true;
+      } catch {
+        return false;
+      }
+    })();
+    webCodecsProbes.set(channels, probe);
+  }
+  return probe;
 }
 
 export async function createOpusPacketDecoder(
+  channels: number,
   onPcm: (pcm: Float32Array) => void,
   onError: (err: unknown) => void,
 ): Promise<OpusPacketDecoder> {
-  if (await webCodecsSupported()) {
-    return createWebCodecsDecoder(onPcm, onError);
+  if (await webCodecsSupported(channels)) {
+    return createWebCodecsDecoder(channels, onPcm, onError);
   }
-  return createWasmDecoder(onPcm, onError);
+  return createWasmDecoder(channels, onPcm, onError);
 }
 
 function createWebCodecsDecoder(
+  channels: number,
   onPcm: (pcm: Float32Array) => void,
   onError: (err: unknown) => void,
 ): OpusPacketDecoder {
   const decoder = new AudioDecoder({
     output: (data) => {
       try {
-        const pcm = new Float32Array(data.numberOfFrames);
-        data.copyTo(pcm, { planeIndex: 0, format: "f32-planar" });
+        // Planar copy per plane, then interleave here: `copyTo`'s conversion to interleaved
+        // f32 is not implemented consistently across engines, planar always is.
+        const pcm = new Float32Array(data.numberOfFrames * channels);
+        const plane = new Float32Array(data.numberOfFrames);
+        for (let c = 0; c < channels; c++) {
+          data.copyTo(plane, { planeIndex: c, format: "f32-planar" });
+          for (let f = 0; f < plane.length; f++) {
+            pcm[f * channels + c] = plane[f] ?? 0;
+          }
+        }
         onPcm(pcm);
       } finally {
         data.close();
@@ -61,8 +77,9 @@ function createWebCodecsDecoder(
     },
     error: onError,
   });
-  decoder.configure(OPUS_CONFIG);
+  decoder.configure(config(channels));
   return {
+    channels,
     decode(packet, timestampUs) {
       if (decoder.state !== "configured" || decoder.decodeQueueSize > MAX_DECODE_QUEUE) {
         return;
@@ -79,21 +96,23 @@ function createWebCodecsDecoder(
 }
 
 async function createWasmDecoder(
+  channels: number,
   onPcm: (pcm: Float32Array) => void,
   onError: (err: unknown) => void,
 ): Promise<OpusPacketDecoder> {
   // Dynamic import so the WASM payload is only fetched when WebCodecs can't do Opus.
   const { OpusDecoder } = await import("opus-decoder");
-  // RFC 7845 §5.1.1 mono mapping: one uncoupled stream.
+  // RFC 7845 §5.1.1 channel mapping family 0: one stream, coupled for stereo.
   const decoder = new OpusDecoder({
-    channels: 1,
+    channels,
     streamCount: 1,
-    coupledStreamCount: 0,
-    channelMappingTable: [0],
+    coupledStreamCount: channels === 2 ? 1 : 0,
+    channelMappingTable: channels === 2 ? [0, 1] : [0],
   });
   await decoder.ready;
   let closed = false;
   return {
+    channels,
     decode(packet) {
       if (closed) {
         return;
@@ -104,11 +123,22 @@ async function createWasmDecoder(
           onError(new Error(errors.map((e) => e.message).join("; ")));
           return;
         }
-        const channel = channelData[0];
-        if (channel && samplesDecoded > 0) {
-          // Copy out of the decoder-owned buffer so the PCM can be transferred to the worklet.
-          onPcm(channel.slice(0, samplesDecoded));
+        if (samplesDecoded <= 0) {
+          return;
         }
+        // The decoder owns its planar buffers, so the interleave doubles as the copy the
+        // worklet transfer needs.
+        const pcm = new Float32Array(samplesDecoded * channels);
+        for (let c = 0; c < channels; c++) {
+          const plane = channelData[c];
+          if (!plane) {
+            return;
+          }
+          for (let f = 0; f < samplesDecoded; f++) {
+            pcm[f * channels + c] = plane[f] ?? 0;
+          }
+        }
+        onPcm(pcm);
       } catch (err) {
         onError(err);
       }

--- a/web/src/lib/audio/engine.test.ts
+++ b/web/src/lib/audio/engine.test.ts
@@ -43,7 +43,7 @@ class FakeSocket implements AudioSocket {
 }
 
 class FakeSink implements AudioSink {
-  pushed: { opus: number[]; timestampUs: number }[] = [];
+  pushed: { opus: number[]; timestampUs: number; channels: number }[] = [];
   conceals: number[] = [];
   volume: number;
   resets = 0;
@@ -55,11 +55,11 @@ class FakeSink implements AudioSink {
   ) {
     this.volume = volume;
   }
-  push(opus: Uint8Array, timestampUs: number): void {
-    this.pushed.push({ opus: Array.from(opus), timestampUs });
+  push(opus: Uint8Array, timestampUs: number, channels: number): void {
+    this.pushed.push({ opus: Array.from(opus), timestampUs, channels });
   }
-  conceal(samples: number): void {
-    this.conceals.push(samples);
+  conceal(frames: number): void {
+    this.conceals.push(frames);
   }
   setVolume(volume: number): void {
     this.volume = volume;
@@ -97,8 +97,13 @@ function stopped(streamId: number, kind: StreamKind = "audio"): ServerEvent {
   return { type: "StreamStopped", data: { stream_id: streamId, kind } };
 }
 
-function audioFrame(streamId: number, timestamp: bigint, bytes: number[]): AudioFrame {
-  return { streamId, seq: 0, timestamp, chLayout: 1, opus: Uint8Array.from(bytes) };
+function audioFrame(
+  streamId: number,
+  timestamp: bigint,
+  bytes: number[],
+  chLayout = 1,
+): AudioFrame {
+  return { streamId, seq: 0, timestamp, chLayout, opus: Uint8Array.from(bytes) };
 }
 
 describe("AudioEngine", () => {
@@ -141,8 +146,28 @@ describe("AudioEngine", () => {
     socket.onAudio(audioFrame(11, 24_000n, [3]));
     socket.onAudio(audioFrame(99, 0n, [4]));
 
-    expect(sinks[0]?.pushed).toEqual([{ opus: [1, 2], timestampUs: 1_000_000 }]);
-    expect(sinks[1]?.pushed).toEqual([{ opus: [3], timestampUs: 500_000 }]);
+    expect(sinks[0]?.pushed).toEqual([{ opus: [1, 2], timestampUs: 1_000_000, channels: 1 }]);
+    expect(sinks[1]?.pushed).toEqual([{ opus: [3], timestampUs: 500_000, channels: 1 }]);
+  });
+
+  // Layout is per frame, and the timestamps stay in sample frames across a change of it —
+  // so a stereo packet must not read as a loss gap on the frame clock.
+  it("hands each frame's channel layout to the sink without disturbing the clock", async () => {
+    engine.start(1, 2);
+    await flush();
+    socket.emit(started(1, 2, 10));
+
+    socket.onAudio(audioFrame(10, 0n, [1], 1));
+    socket.onAudio(audioFrame(10, 960n, [2], 2));
+    socket.onAudio(audioFrame(10, 1_920n, [3], 2));
+
+    expect(sinks[0]?.pushed).toEqual([
+      { opus: [1], timestampUs: 0, channels: 1 },
+      { opus: [2], timestampUs: 20_000, channels: 2 },
+      { opus: [3], timestampUs: 40_000, channels: 2 },
+    ]);
+    expect(sinks[0]?.conceals).toEqual([]);
+    expect(sinks[0]?.resets).toBe(1);
   });
 
   it("StreamStopped clears intent, closes the sink, and stops routing", async () => {
@@ -211,7 +236,7 @@ describe("AudioEngine", () => {
     expect(sinks[1]?.closed).toBe(false);
 
     socket.onAudio(audioFrame(0x8001, 0n, [7]));
-    expect(sinks[1]?.pushed).toEqual([{ opus: [7], timestampUs: 0 }]);
+    expect(sinks[1]?.pushed).toEqual([{ opus: [7], timestampUs: 0, channels: 1 }]);
     // The stale Stopped must not have cancelled the still-owed subscription.
     expect(socket.sent).toHaveLength(3);
   });
@@ -234,7 +259,7 @@ describe("AudioEngine", () => {
     // The rebind resets the sink: stale pre-disconnect audio must not play first.
     expect(sinks[0]?.resets).toBe(resetsAfterFirstBind + 1);
     socket.onAudio(audioFrame(20, 0n, [5]));
-    expect(sinks[0]?.pushed).toEqual([{ opus: [5], timestampUs: 0 }]);
+    expect(sinks[0]?.pushed).toEqual([{ opus: [5], timestampUs: 0, channels: 1 }]);
   });
 
   it("start while disconnected subscribes only once connected", async () => {

--- a/web/src/lib/audio/engine.ts
+++ b/web/src/lib/audio/engine.ts
@@ -4,12 +4,13 @@
 import type { AudioFrame } from "../frame";
 import type { ClientCommand, ServerEvent } from "../types";
 import { LossTracker } from "./loss";
-import { MAX_SAMPLES, SAMPLE_RATE } from "./worklet";
+import { MAX_FRAMES, SAMPLE_RATE } from "./worklet";
 
 export interface AudioSink {
-  push(opus: Uint8Array, timestampUs: number): void;
-  /** Insert `samples` of silence for a detected loss gap so depth and timing stay honest. */
-  conceal(samples: number): void;
+  /** `channels` is the packet's own layout (1 = mono, 2 = stereo); it may change mid-stream. */
+  push(opus: Uint8Array, timestampUs: number, channels: number): void;
+  /** Insert `frames` of silence for a detected loss gap so depth and timing stay honest. */
+  conceal(frames: number): void;
   setVolume(volume: number): void;
   /** Discard buffered/decoder state; called when a fresh stream id binds to this channel. */
   reset(): void;
@@ -47,7 +48,7 @@ interface ChannelEntry {
   loss: LossTracker;
 }
 
-const US_PER_SAMPLE = 1_000_000 / SAMPLE_RATE;
+const US_PER_FRAME = 1_000_000 / SAMPLE_RATE;
 
 function entryKey(deviceSet: number, channel: number): string {
   return `${deviceSet}:${channel}`;
@@ -282,9 +283,9 @@ export class AudioEngine {
     if (action.kind === "reset") {
       sink.reset();
     } else if (action.kind === "gap") {
-      sink.conceal(action.samples);
+      sink.conceal(action.frames);
     }
-    sink.push(frame.opus, Math.round(Number(frame.timestamp) * US_PER_SAMPLE));
+    sink.push(frame.opus, Math.round(Number(frame.timestamp) * US_PER_FRAME), frame.chLayout);
   };
 
   private ensureEntry(deviceSet: number, channel: number): ChannelEntry {
@@ -302,7 +303,7 @@ export class AudioEngine {
         generation: 0,
         volume: 1,
         lastError: null,
-        loss: new LossTracker(MAX_SAMPLES),
+        loss: new LossTracker(MAX_FRAMES),
       };
       this.entries.set(key, entry);
     }

--- a/web/src/lib/audio/jitter.test.ts
+++ b/web/src/lib/audio/jitter.test.ts
@@ -5,108 +5,166 @@ function ramp(start: number, length: number): Float32Array {
   return Float32Array.from({ length }, (_, i) => start + i);
 }
 
-function read(jb: JitterBuffer, n: number): { ok: boolean; out: number[] } {
-  const out = new Float32Array(n);
-  const ok = jb.read(out);
-  return { ok, out: Array.from(out) };
+/** Read `frames` into one output buffer per channel. */
+function read(
+  jb: JitterBuffer,
+  frames: number,
+  channels: number,
+): { ok: boolean; out: number[][] } {
+  const outputs = Array.from({ length: channels }, () => new Float32Array(frames));
+  const ok = jb.read(outputs);
+  return { ok, out: outputs.map((o) => Array.from(o)) };
+}
+
+function readMono(jb: JitterBuffer, frames: number): { ok: boolean; out: number[] } {
+  const { ok, out } = read(jb, frames, 1);
+  return { ok, out: out[0] ?? [] };
 }
 
 describe("JitterBuffer", () => {
   it("outputs silence until the target fill is reached", () => {
-    const jb = new JitterBuffer(4, 16);
+    const jb = new JitterBuffer(4, 16, 1);
     jb.push(ramp(1, 3));
-    expect(read(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
     expect(jb.buffered).toBe(3);
 
     jb.push(ramp(4, 2));
-    expect(read(jb, 4)).toEqual({ ok: true, out: [1, 2, 3, 4] });
+    expect(readMono(jb, 4)).toEqual({ ok: true, out: [1, 2, 3, 4] });
   });
 
   it("underruns to silence and rebuffers to target before resuming", () => {
-    const jb = new JitterBuffer(4, 16);
+    const jb = new JitterBuffer(4, 16, 1);
     jb.push(ramp(1, 5));
-    expect(read(jb, 4).out).toEqual([1, 2, 3, 4]);
+    expect(readMono(jb, 4).out).toEqual([1, 2, 3, 4]);
 
     // Partial fill: real samples then silence, then buffering until target again.
-    expect(read(jb, 4)).toEqual({ ok: true, out: [5, 0, 0, 0] });
-    expect(read(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: true, out: [5, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
 
     jb.push(ramp(6, 3));
-    expect(read(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
     jb.push(ramp(9, 1));
-    expect(read(jb, 4)).toEqual({ ok: true, out: [6, 7, 8, 9] });
+    expect(readMono(jb, 4)).toEqual({ ok: true, out: [6, 7, 8, 9] });
   });
 
   it("re-enters buffering after an exact drain", () => {
-    const jb = new JitterBuffer(4, 16);
+    const jb = new JitterBuffer(4, 16, 1);
     jb.push(ramp(1, 4));
-    expect(read(jb, 4).ok).toBe(true);
+    expect(readMono(jb, 4).ok).toBe(true);
     expect(jb.buffered).toBe(0);
-    expect(read(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
 
     jb.push(ramp(5, 3));
-    expect(read(jb, 4).ok).toBe(false);
+    expect(readMono(jb, 4).ok).toBe(false);
   });
 
   it("a push past capacity sheds the oldest samples back toward target, not merely under the cap", () => {
-    const jb = new JitterBuffer(2, 8);
+    const jb = new JitterBuffer(2, 8, 1);
     jb.push(ramp(1, 6));
     jb.push(ramp(7, 6));
     // All 6 old samples dropped (target is 2, the new chunk alone exceeds it): depth resumes
     // at the chunk size, not parked at the 8-sample cap.
     expect(jb.buffered).toBe(6);
-    expect(read(jb, 6).out).toEqual([7, 8, 9, 10, 11, 12]);
+    expect(readMono(jb, 6).out).toEqual([7, 8, 9, 10, 11, 12]);
   });
 
   it("a burst past capacity resumes at target depth", () => {
-    const jb = new JitterBuffer(4, 16);
+    const jb = new JitterBuffer(4, 16, 1);
     jb.push(ramp(1, 14));
     jb.push(ramp(15, 4));
     expect(jb.buffered).toBe(4);
-    expect(read(jb, 4).out).toEqual([15, 16, 17, 18]);
+    expect(readMono(jb, 4).out).toEqual([15, 16, 17, 18]);
   });
 
   it("sheds sustained sub-cap backlog back to the target", () => {
     // trimAbove = 8, trimHold = 40 pushed samples for (target 4, max 16).
-    const jb = new JitterBuffer(4, 16);
+    const jb = new JitterBuffer(4, 16, 1);
     jb.push(ramp(1, 10));
     let next = 11;
     // Steady state: inflow equals outflow, but depth is parked at 10 (2.5x target).
     for (let i = 0; i < 7; i++) {
-      read(jb, 4);
+      readMono(jb, 4);
       jb.push(ramp(next, 4));
       next += 4;
       expect(jb.buffered).toBe(10);
     }
     // The sustained-high streak crosses trimHold on this push: shed to target.
-    read(jb, 4);
+    readMono(jb, 4);
     jb.push(ramp(next, 4));
     expect(jb.buffered).toBe(4);
-    expect(read(jb, 4).out).toEqual([39, 40, 41, 42]);
+    expect(readMono(jb, 4).out).toEqual([39, 40, 41, 42]);
   });
 
   it("keeps only the newest samples of a chunk larger than capacity", () => {
-    const jb = new JitterBuffer(2, 4);
+    const jb = new JitterBuffer(2, 4, 1);
     jb.push(ramp(1, 10));
     expect(jb.buffered).toBe(4);
-    expect(read(jb, 4).out).toEqual([7, 8, 9, 10]);
+    expect(readMono(jb, 4).out).toEqual([7, 8, 9, 10]);
   });
 
   it("stays correct across ring wraparound", () => {
-    const jb = new JitterBuffer(2, 5);
+    const jb = new JitterBuffer(2, 5, 1);
     jb.push(ramp(1, 4));
-    expect(read(jb, 3).out).toEqual([1, 2, 3]);
+    expect(readMono(jb, 3).out).toEqual([1, 2, 3]);
     jb.push(ramp(5, 4));
-    expect(read(jb, 5).out).toEqual([4, 5, 6, 7, 8]);
+    expect(readMono(jb, 5).out).toEqual([4, 5, 6, 7, 8]);
   });
 
   it("clear resets to an empty buffering state", () => {
-    const jb = new JitterBuffer(2, 8);
+    const jb = new JitterBuffer(2, 8, 1);
     jb.push(ramp(1, 4));
     jb.clear();
     expect(jb.buffered).toBe(0);
-    expect(read(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
+    expect(readMono(jb, 4)).toEqual({ ok: false, out: [0, 0, 0, 0] });
     jb.push(ramp(1, 2));
-    expect(read(jb, 2)).toEqual({ ok: true, out: [1, 2] });
+    expect(readMono(jb, 2)).toEqual({ ok: true, out: [1, 2] });
+  });
+
+  it("deinterleaves stereo frames into one output per channel", () => {
+    const jb = new JitterBuffer(2, 8, 2);
+    // Left counts up, right counts down: a swapped or shifted lane is visible in the values.
+    jb.push(Float32Array.from([1, -1, 2, -2, 3, -3]));
+    expect(jb.buffered).toBe(3);
+    expect(read(jb, 3, 2).out).toEqual([
+      [1, 2, 3],
+      [-1, -2, -3],
+    ]);
+  });
+
+  it("counts depth, target and capacity in frames rather than samples", () => {
+    const jb = new JitterBuffer(4, 8, 2);
+    // Three stereo frames is six samples, and must still be under a four-frame target.
+    jb.push(Float32Array.from([1, -1, 2, -2, 3, -3]));
+    expect(jb.buffered).toBe(3);
+    expect(read(jb, 4, 2).ok).toBe(false);
+
+    jb.push(Float32Array.from([4, -4]));
+    expect(read(jb, 4, 2)).toEqual({
+      ok: true,
+      out: [
+        [1, 2, 3, 4],
+        [-1, -2, -3, -4],
+      ],
+    });
+  });
+
+  it("stays correct across ring wraparound in stereo", () => {
+    const jb = new JitterBuffer(2, 3, 2);
+    jb.push(Float32Array.from([1, -1, 2, -2]));
+    expect(read(jb, 1, 2).out).toEqual([[1], [-1]]);
+    jb.push(Float32Array.from([3, -3, 4, -4]));
+    expect(read(jb, 3, 2).out).toEqual([
+      [2, 3, 4],
+      [-2, -3, -4],
+    ]);
+  });
+
+  it("feeds every output channel from a stream with fewer of them", () => {
+    const jb = new JitterBuffer(2, 8, 1);
+    jb.push(ramp(1, 3));
+    expect(read(jb, 3, 2).out).toEqual([
+      [1, 2, 3],
+      [1, 2, 3],
+    ]);
   });
 });

--- a/web/src/lib/audio/jitter.ts
+++ b/web/src/lib/audio/jitter.ts
@@ -1,8 +1,15 @@
 // Jitter-buffer scheduling for audio playback (PLAN §9: 60–100 ms target). This class is
 // injected into the AudioWorklet via `JitterBuffer.toString()` (see worklet.ts), so it must
 // stay fully self-contained: no imports, no references to anything in module scope.
+//
+// Everything is counted in sample frames, never in samples: the ring holds interleaved audio
+// and `read` deinterleaves it into one output per channel, so depth and timing mean the same
+// thing whatever layout the stream is in.
 export class JitterBuffer {
   private readonly buf: Float32Array;
+  private readonly channels: number;
+  /** Ring size in frames. */
+  private readonly capacity: number;
   private readonly target: number;
   /** Depth above which a sustained backlog counts as latency to shed, not jitter headroom. */
   private readonly trimAbove: number;
@@ -14,33 +21,42 @@ export class JitterBuffer {
   private buffering = true;
   private trimStreak = 0;
 
-  constructor(targetSamples: number, maxSamples: number) {
-    this.buf = new Float32Array(maxSamples);
-    this.target = Math.min(targetSamples, maxSamples);
-    this.trimAbove = Math.min(2 * this.target, maxSamples);
+  constructor(targetFrames: number, maxFrames: number, channels: number) {
+    this.channels = channels;
+    this.capacity = maxFrames;
+    this.buf = new Float32Array(maxFrames * channels);
+    this.target = Math.min(targetFrames, maxFrames);
+    this.trimAbove = Math.min(2 * this.target, maxFrames);
     this.trimHold = 10 * this.target;
   }
 
+  /** Buffered depth, in sample frames. */
   get buffered(): number {
     return this.length;
   }
 
   /**
-   * Append PCM. A push past capacity (tab sleep, network burst) sheds the oldest samples all
-   * the way back to `target` — merely staying under the cap would park playback ~maxSamples
-   * behind realtime for the rest of the stream. Sub-cap backlog that persists (repeated
-   * bursts ratcheting the depth up) is shed the same way once it outlasts `trimHold`.
+   * Append interleaved PCM. A push past capacity (tab sleep, network burst) sheds the oldest
+   * frames all the way back to `target` — merely staying under the cap would park playback
+   * ~maxFrames behind realtime for the rest of the stream. Sub-cap backlog that persists
+   * (repeated bursts ratcheting the depth up) is shed the same way once it outlasts `trimHold`.
    */
   push(chunk: Float32Array): void {
-    const cap = this.buf.length;
-    const start = chunk.length > cap ? chunk.length - cap : 0;
-    const n = chunk.length - start;
+    const cap = this.capacity;
+    const ch = this.channels;
+    const frames = Math.floor(chunk.length / ch);
+    const start = frames > cap ? frames - cap : 0;
+    const n = frames - start;
     if (this.length + n > cap) {
       this.dropOldest(this.length + n - this.target);
       this.trimStreak = 0;
     }
-    for (let i = start; i < chunk.length; i++) {
-      this.buf[this.writePos] = chunk[i] ?? 0;
+    for (let f = start; f < frames; f++) {
+      const src = f * ch;
+      const dst = this.writePos * ch;
+      for (let c = 0; c < ch; c++) {
+        this.buf[dst + c] = chunk[src + c] ?? 0;
+      }
       this.writePos = (this.writePos + 1) % cap;
     }
     this.length += n;
@@ -59,24 +75,40 @@ export class JitterBuffer {
   }
 
   /**
-   * Fill `out` with the next samples; silence while pre-buffering. An underrun (fewer buffered
-   * samples than `out` needs) pads with silence and re-enters buffering until `target` is
-   * reached again. Returns whether any real samples were written.
+   * Fill one output buffer per channel with the next frames; silence while pre-buffering. An
+   * underrun (fewer buffered frames than the outputs need) pads with silence and re-enters
+   * buffering until `target` is reached again. Returns whether any real frames were written.
    */
-  read(out: Float32Array): boolean {
+  read(outputs: Float32Array[]): boolean {
+    const wanted = outputs[0]?.length ?? 0;
     if (this.buffering) {
-      out.fill(0);
+      for (const out of outputs) {
+        out.fill(0);
+      }
       return false;
     }
-    const cap = this.buf.length;
-    const n = Math.min(out.length, this.length);
-    for (let i = 0; i < n; i++) {
-      out[i] = this.buf[this.readPos] ?? 0;
-      this.readPos = (this.readPos + 1) % cap;
+    const cap = this.capacity;
+    const ch = this.channels;
+    const n = Math.min(wanted, this.length);
+    for (let c = 0; c < outputs.length; c++) {
+      const out = outputs[c];
+      if (!out) {
+        continue;
+      }
+      // A stream with fewer channels than the output has feeds its last channel to the rest.
+      const lane = Math.min(c, ch - 1);
+      let pos = this.readPos;
+      for (let f = 0; f < n; f++) {
+        out[f] = this.buf[pos * ch + lane] ?? 0;
+        pos = (pos + 1) % cap;
+      }
+      if (n < wanted) {
+        out.fill(0, n);
+      }
     }
+    this.readPos = (this.readPos + n) % cap;
     this.length -= n;
-    if (n < out.length) {
-      out.fill(0, n);
+    if (n < wanted) {
       this.buffering = true;
     }
     return n > 0;
@@ -95,7 +127,7 @@ export class JitterBuffer {
     if (drop <= 0) {
       return;
     }
-    this.readPos = (this.readPos + drop) % this.buf.length;
+    this.readPos = (this.readPos + drop) % this.capacity;
     this.length -= drop;
   }
 }

--- a/web/src/lib/audio/loss.test.ts
+++ b/web/src/lib/audio/loss.test.ts
@@ -12,12 +12,12 @@ describe("LossTracker", () => {
     expect(t.next(2_880n)).toEqual({ kind: "continuous" });
   });
 
-  it("reports the exact number of missing samples on a gap", () => {
+  it("reports the exact number of missing frames on a gap", () => {
     const t = new LossTracker(MAX_GAP);
     t.next(0n);
     t.next(960n);
     // Two packets lost: the delta is three packet durations.
-    expect(t.next(3_840n)).toEqual({ kind: "gap", samples: 1_920 });
+    expect(t.next(3_840n)).toEqual({ kind: "gap", frames: 1_920 });
     // The clock is intact afterwards.
     expect(t.next(4_800n)).toEqual({ kind: "continuous" });
   });
@@ -36,7 +36,7 @@ describe("LossTracker", () => {
     t.next(960n);
     expect(t.next(0n)).toEqual({ kind: "reset" });
     expect(t.next(960n)).toEqual({ kind: "continuous" });
-    expect(t.next(2_880n)).toEqual({ kind: "gap", samples: 960 });
+    expect(t.next(2_880n)).toEqual({ kind: "gap", frames: 960 });
   });
 
   it("adopts a smaller delta when the first delta was itself a loss gap", () => {
@@ -47,7 +47,7 @@ describe("LossTracker", () => {
     // A true back-to-back pair corrects it downward.
     expect(t.next(2_880n)).toEqual({ kind: "continuous" });
     expect(t.next(3_840n)).toEqual({ kind: "continuous" });
-    expect(t.next(5_760n)).toEqual({ kind: "gap", samples: 960 });
+    expect(t.next(5_760n)).toEqual({ kind: "gap", frames: 960 });
   });
 
   it("reset() forgets history so a rebound stream starts clean", () => {

--- a/web/src/lib/audio/loss.ts
+++ b/web/src/lib/audio/loss.ts
@@ -1,24 +1,26 @@
-// Audio-loss detection (PLAN §9). Each Opus frame carries a 48 kHz-domain sample timestamp;
-// a hole in that clock is the loss signal (seq is per-stream bookkeeping, not authoritative).
-// Pure logic so the engine's gap handling stays unit-testable.
+// Audio-loss detection (PLAN §9). Each Opus frame carries a 48 kHz-domain sample-frame
+// timestamp; a hole in that clock is the loss signal (seq is per-stream bookkeeping, not
+// authoritative). Counting frames rather than samples is what keeps this independent of the
+// stream's channel layout, which can change mid-stream. Pure logic so the engine's gap
+// handling stays unit-testable.
 
 export type LossAction =
   | { kind: "continuous" }
-  // `samples` of audio are missing; conceal them so buffered depth and timing stay honest.
-  | { kind: "gap"; samples: number }
+  // `frames` of audio are missing; conceal them so buffered depth and timing stay honest.
+  | { kind: "gap"; frames: number }
   // Timestamps regressed or the hole is too big to conceal: drop buffered audio, rebuffer.
   | { kind: "reset" };
 
 /**
- * Timestamps advance by exactly one packet's samples when nothing is lost. The packet
+ * Timestamps advance by exactly one packet's frames when nothing is lost. The packet
  * duration is not in the frame header, so it is learned from the deltas themselves: the
  * smallest observed delta is the duration, because loss makes deltas larger, never smaller.
  */
 export class LossTracker {
   private lastTimestamp: bigint | null = null;
-  private packetSamples: bigint | null = null;
+  private packetFrames: bigint | null = null;
 
-  constructor(private readonly maxGapSamples: number) {}
+  constructor(private readonly maxGapFrames: number) {}
 
   next(timestamp: bigint): LossAction {
     const last = this.lastTimestamp;
@@ -29,25 +31,25 @@ export class LossTracker {
     const delta = timestamp - last;
     if (delta <= 0n) {
       // Non-monotonic clock ⇒ the stream restarted behind our back; relearn everything.
-      this.packetSamples = null;
+      this.packetFrames = null;
       return { kind: "reset" };
     }
-    if (this.packetSamples === null || delta < this.packetSamples) {
-      this.packetSamples = delta;
+    if (this.packetFrames === null || delta < this.packetFrames) {
+      this.packetFrames = delta;
       return { kind: "continuous" };
     }
-    const gap = delta - this.packetSamples;
+    const gap = delta - this.packetFrames;
     if (gap === 0n) {
       return { kind: "continuous" };
     }
-    if (gap > BigInt(this.maxGapSamples)) {
+    if (gap > BigInt(this.maxGapFrames)) {
       return { kind: "reset" };
     }
-    return { kind: "gap", samples: Number(gap) };
+    return { kind: "gap", frames: Number(gap) };
   }
 
   reset(): void {
     this.lastTimestamp = null;
-    this.packetSamples = null;
+    this.packetFrames = null;
   }
 }

--- a/web/src/lib/audio/sink.test.ts
+++ b/web/src/lib/audio/sink.test.ts
@@ -102,7 +102,7 @@ describe("createWebAudioSink", () => {
   });
 
   it("reports a suspended context, retries resume on gesture, and reports recovery", async () => {
-    createDecoder.mockResolvedValue({ decode: vi.fn(), close: vi.fn() });
+    createDecoder.mockResolvedValue({ channels: 1, decode: vi.fn(), close: vi.fn() });
     const sinkModule = await importSink();
     const reported: boolean[] = [];
     sinkModule.onOutputStateChange((running) => reported.push(running));
@@ -123,7 +123,7 @@ describe("createWebAudioSink", () => {
   });
 
   it("a context created suspended (autoplay veto) is resumed inside the creating gesture", async () => {
-    createDecoder.mockResolvedValue({ decode: vi.fn(), close: vi.fn() });
+    createDecoder.mockResolvedValue({ channels: 1, decode: vi.fn(), close: vi.fn() });
     FakeAudioContext.initialState = "suspended";
     const sinkModule = await importSink();
     const reported: boolean[] = [];
@@ -141,17 +141,72 @@ describe("createWebAudioSink", () => {
   });
 
   it("conceal posts a silence buffer of exactly the gap size", async () => {
-    createDecoder.mockResolvedValue({ decode: vi.fn(), close: vi.fn() });
+    createDecoder.mockResolvedValue({ channels: 1, decode: vi.fn(), close: vi.fn() });
     const { createWebAudioSink } = await importSink();
 
     const sink = await createWebAudioSink(1, () => {});
     const node = FakeWorkletNode.instances[0];
     node?.port.postMessage.mockClear();
 
+    // The graph is two-channel, so a 480-frame gap is 960 interleaved samples of silence.
     sink.conceal(480);
     const posted = node?.port.postMessage.mock.calls[0]?.[0] as Float32Array | undefined;
     expect(posted).toBeInstanceOf(Float32Array);
-    expect(posted?.length).toBe(480);
+    expect(posted?.length).toBe(480 * 2);
     expect(posted?.every((v) => v === 0)).toBe(true);
+  });
+
+  it("plays a mono stream on both output channels", async () => {
+    let emit: ((pcm: Float32Array) => void) | undefined;
+    createDecoder.mockImplementation((channels: number, onPcm: (pcm: Float32Array) => void) => {
+      emit = onPcm;
+      return Promise.resolve({ channels, decode: vi.fn(), close: vi.fn() });
+    });
+    const { createWebAudioSink } = await importSink();
+
+    await createWebAudioSink(1, () => {});
+    const node = FakeWorkletNode.instances[0];
+    node?.port.postMessage.mockClear();
+
+    emit?.(Float32Array.from([0.25, -0.5]));
+    const posted = node?.port.postMessage.mock.calls[0]?.[0] as Float32Array | undefined;
+    expect(Array.from(posted ?? [])).toEqual([0.25, 0.25, -0.5, -0.5]);
+  });
+
+  // A channel that switches to stereo mid-stream cannot be decoded by the mono decoder, and
+  // no Opus decoder can be reconfigured in place: the sink has to build a replacement.
+  it("swaps in a decoder for the packet's layout and passes its pcm through untouched", async () => {
+    const decoders: {
+      channels: number;
+      decode: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+    }[] = [];
+    let emit: ((pcm: Float32Array) => void) | undefined;
+    createDecoder.mockImplementation((channels: number, onPcm: (pcm: Float32Array) => void) => {
+      emit = onPcm;
+      const decoder = { channels, decode: vi.fn(), close: vi.fn() };
+      decoders.push(decoder);
+      return Promise.resolve(decoder);
+    });
+    const { createWebAudioSink } = await importSink();
+
+    const sink = await createWebAudioSink(1, () => {});
+    const packet = Uint8Array.from([1, 2, 3]);
+
+    // The packet that announces the new layout is dropped, not decoded with the wrong one.
+    sink.push(packet, 0, 2);
+    expect(decoders[0]?.decode).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(decoders).toHaveLength(2));
+    expect(decoders[1]?.channels).toBe(2);
+    expect(decoders[0]?.close).toHaveBeenCalled();
+
+    sink.push(packet, 20_000, 2);
+    expect(decoders[1]?.decode).toHaveBeenCalledWith(packet, 20_000);
+
+    const node = FakeWorkletNode.instances[0];
+    node?.port.postMessage.mockClear();
+    emit?.(Float32Array.from([0.25, -0.5]));
+    const posted = node?.port.postMessage.mock.calls[0]?.[0] as Float32Array | undefined;
+    expect(Array.from(posted ?? [])).toEqual([0.25, -0.5]);
   });
 });

--- a/web/src/lib/audio/sink.ts
+++ b/web/src/lib/audio/sink.ts
@@ -4,7 +4,14 @@ import type { OpusPacketDecoder } from "./decoder";
 import { createOpusPacketDecoder } from "./decoder";
 import type { AudioSink, SinkFactory } from "./engine";
 import type { WorkletMessage } from "./worklet";
-import { MAX_SAMPLES, PROCESSOR_NAME, processorUrl, SAMPLE_RATE, TARGET_SAMPLES } from "./worklet";
+import {
+  CHANNELS,
+  MAX_FRAMES,
+  PROCESSOR_NAME,
+  processorUrl,
+  SAMPLE_RATE,
+  TARGET_FRAMES,
+} from "./worklet";
 
 let ctx: AudioContext | null = null;
 let workletModule: Promise<void> | null = null;
@@ -83,6 +90,25 @@ function post(node: AudioWorkletNode, message: WorkletMessage): void {
   }
 }
 
+/**
+ * Spread `pcm` (interleaved at `channels`) across the graph's fixed `CHANNELS` output: a mono
+ * stream plays on both sides rather than only on the left.
+ */
+function toOutputLayout(pcm: Float32Array, channels: number): Float32Array {
+  if (channels === CHANNELS) {
+    return pcm;
+  }
+  const frames = Math.floor(pcm.length / channels);
+  const out = new Float32Array(frames * CHANNELS);
+  for (let f = 0; f < frames; f++) {
+    for (let c = 0; c < CHANNELS; c++) {
+      // Fewer source channels than outputs: the last one feeds the rest.
+      out[f * CHANNELS + c] = pcm[f * channels + Math.min(c, channels - 1)] ?? 0;
+    }
+  }
+  return out;
+}
+
 export const createWebAudioSink: SinkFactory = async (volume, onError) => {
   // Runs synchronously inside the user's start() gesture — the standard autoplay unlock:
   // both context creation and resume() must happen before the first await.
@@ -106,20 +132,30 @@ export const createWebAudioSink: SinkFactory = async (volume, onError) => {
   const node = new AudioWorkletNode(context, PROCESSOR_NAME, {
     numberOfInputs: 0,
     numberOfOutputs: 1,
-    outputChannelCount: [1],
-    processorOptions: { targetSamples: TARGET_SAMPLES, maxSamples: MAX_SAMPLES },
+    outputChannelCount: [CHANNELS],
+    processorOptions: {
+      targetFrames: TARGET_FRAMES,
+      maxFrames: MAX_FRAMES,
+      channels: CHANNELS,
+    },
   });
   const gain = new GainNode(context, { gain: volume });
   node.connect(gain).connect(context.destination);
 
   let closed = false;
+  // Bound into each decoder's callback, never read from here: a late frame from the decoder
+  // being replaced must be spread with the layout it was decoded in, not the incoming one.
+  const emit = (channels: number) => (pcm: Float32Array) => {
+    if (!closed) {
+      post(node, toOutputLayout(pcm, channels));
+    }
+  };
+
   let decoder: OpusPacketDecoder;
   try {
-    decoder = await createOpusPacketDecoder((pcm) => {
-      if (!closed) {
-        post(node, pcm);
-      }
-    }, onError);
+    // Mono up front so a decoder that cannot be built at all still fails the sink (and the
+    // channel) here, rather than silently on the first packet. A stereo stream swaps below.
+    decoder = await createOpusPacketDecoder(1, emit(1), onError);
   } catch (err) {
     // The worklet processor only ends on "close"; without this teardown the node keeps
     // running on the audio thread forever while the engine holds no sink handle to close.
@@ -129,14 +165,45 @@ export const createWebAudioSink: SinkFactory = async (volume, onError) => {
     throw err;
   }
 
+  // A channel may change layout mid-stream (WFM stereo toggled), which no Opus decoder can
+  // be reconfigured for: build the replacement, then swap. Packets that arrive meanwhile are
+  // dropped rather than decoded with the wrong channel count — the client hears the same
+  // few-frame gap the encoder's own layout switch already leaves.
+  let swapping = false;
+  const useLayout = (channels: number): void => {
+    if (closed || swapping || channels === decoder.channels) {
+      return;
+    }
+    swapping = true;
+    createOpusPacketDecoder(channels, emit(channels), onError)
+      .then((next) => {
+        swapping = false;
+        if (closed) {
+          next.close();
+          return;
+        }
+        decoder.close();
+        decoder = next;
+      })
+      .catch((err: unknown) => {
+        swapping = false;
+        onError(err);
+      });
+  };
+
   const sink: AudioSink = {
-    push(opus, timestampUs) {
-      if (!closed) {
-        decoder.decode(opus, timestampUs);
+    push(opus, timestampUs, channels) {
+      if (closed) {
+        return;
       }
+      if (channels !== decoder.channels) {
+        useLayout(channels);
+        return;
+      }
+      decoder.decode(opus, timestampUs);
     },
-    conceal(samples) {
-      post(node, new Float32Array(samples));
+    conceal(frames) {
+      post(node, new Float32Array(frames * CHANNELS));
     },
     setVolume(v) {
       gain.gain.value = v;

--- a/web/src/lib/audio/worklet.ts
+++ b/web/src/lib/audio/worklet.ts
@@ -7,12 +7,21 @@ import { JitterBuffer } from "./jitter";
 export const PROCESSOR_NAME = "sdr-audio-playback";
 
 export const SAMPLE_RATE = 48_000;
-/** ~100 ms pre-buffer (PLAN §9: 60–100 ms jitter buffer). */
-export const TARGET_SAMPLES = 4_800;
-/** ~400 ms cap; a burst past it (tab sleep) sheds back to `TARGET_SAMPLES`, not to the cap. */
-export const MAX_SAMPLES = 19_200;
+/**
+ * The graph is always two-channel: a channel can switch between mono and stereo mid-stream
+ * (WFM's stereo toggle), and rebuilding the node — and its buffered audio — for that would
+ * cost a gap. Mono streams are duplicated into both channels on the way in instead.
+ */
+export const CHANNELS = 2;
+/** ~100 ms pre-buffer (PLAN §9: 60–100 ms jitter buffer), in sample frames. */
+export const TARGET_FRAMES = 4_800;
+/** ~400 ms cap; a burst past it (tab sleep) sheds back to `TARGET_FRAMES`, not to the cap. */
+export const MAX_FRAMES = 19_200;
 
-/** Port protocol: Float32Array = PCM, "reset" = clear buffer, "close" = end the processor. */
+/**
+ * Port protocol: Float32Array = interleaved PCM at `CHANNELS`, "reset" = clear buffer,
+ * "close" = end the processor.
+ */
 export type WorkletMessage = Float32Array | "reset" | "close";
 
 const processorSource = `
@@ -21,8 +30,8 @@ const JitterBuffer = ${JitterBuffer.toString()};
 class PlaybackProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super();
-    const { targetSamples, maxSamples } = options.processorOptions;
-    this.jitter = new JitterBuffer(targetSamples, maxSamples);
+    const { targetFrames, maxFrames, channels } = options.processorOptions;
+    this.jitter = new JitterBuffer(targetFrames, maxFrames, channels);
     this.ended = false;
     this.port.onmessage = (event) => {
       const data = event.data;
@@ -36,9 +45,9 @@ class PlaybackProcessor extends AudioWorkletProcessor {
     };
   }
   process(inputs, outputs) {
-    const channel = outputs[0][0];
-    if (channel) {
-      this.jitter.read(channel);
+    const channels = outputs[0];
+    if (channels && channels.length > 0) {
+      this.jitter.read(channels);
     }
     return !this.ended;
   }

--- a/web/src/lib/frame.test.ts
+++ b/web/src/lib/frame.test.ts
@@ -32,10 +32,10 @@ function spectrumBuffer(bins: Uint8Array): ArrayBuffer {
   return buf;
 }
 
-function audioBuffer(opus: Uint8Array): ArrayBuffer {
+function audioBuffer(opus: Uint8Array, chLayout = 1): ArrayBuffer {
   const buf = new ArrayBuffer(16 + 1 + opus.length);
   const view = header(buf, FRAME_KIND_AUDIO_OPUS, 3, 512, 96_000n);
-  view.setUint8(16, 1);
+  view.setUint8(16, chLayout);
   new Uint8Array(buf, 17).set(opus);
   return buf;
 }
@@ -90,6 +90,13 @@ describe("decodeAudio", () => {
     expect(frame?.seq).toBe(512);
     expect(frame?.timestamp).toBe(96_000n);
     expect(frame?.chLayout).toBe(1);
+    expect(Array.from(frame?.opus ?? [])).toEqual(Array.from(opus));
+  });
+
+  it("reads the stereo layout without shifting the payload", () => {
+    const opus = Uint8Array.from([9, 8, 7]);
+    const frame = decodeAudio(audioBuffer(opus, 2));
+    expect(frame?.chLayout).toBe(2);
     expect(Array.from(frame?.opus ?? [])).toEqual(Array.from(opus));
   });
 

--- a/web/src/lib/frame.ts
+++ b/web/src/lib/frame.ts
@@ -56,9 +56,9 @@ export function decodeSpectrum(buffer: ArrayBuffer): SpectrumFrame | null {
 export interface AudioFrame {
   streamId: number;
   seq: number;
-  /** 48 kHz-domain sample count since the channel's audio started (PLAN §5). */
+  /** 48 kHz-domain sample-frame count since the channel's audio started (PLAN §5). */
   timestamp: bigint;
-  /** 1 = mono. */
+  /** Layout of this packet: 1 = mono, 2 = stereo. A channel may switch between them. */
   chLayout: number;
   /** One Opus packet: byte `HEADER_LEN + 1` to the end of the WS frame. */
   opus: Uint8Array;


### PR DESCRIPTION
Recovers the FM stereo difference signal and makes the whole audio path two-channel: interleaved PCM → stereo Opus → per-frame `ch_layout` → two-channel worklet.

## Signal path
- **Pilot recovery** (`channels/wfm.rs`): NCO mix to DC → 3-stage complex one-pole (new `dsp::ComplexOnePole`) → `Pll`. The analytic pilot is rebuilt as `conj(mix)·reference` and squared onto the 38 kHz subcarrier; with a cosine pilot the standard's zero-crossing rule makes the difference carrier `−sin(2θ) = −Im(P²)`.
- **Matrix**: sum and difference decimate through identical filters, de-emphasis is applied to each (it is LTI, so that equals applying it to L and R), then `L = M+S`, `R = M−S`.
- **No pilot → dual mono**: the difference signal is gated by a hysteretic, ramped pilot-lock blend, so a mono station plays the same programme on both channels and a fading pilot cannot click.

## Wire and layout
`PcmBlock` and `AudioPacket` carry the channel count, and the encoder rebuilds itself when it changes — toggling stereo is a params patch, so it reaches the live pipeline as a settings command, never a rebuild. Timestamps count **sample frames**, so a layout change mid-stream does not disturb the clock a client detects loss on. Client side the worklet graph is fixed at two channels with an interleaved jitter buffer, and the sink swaps decoders when a packet announces a layout its decoder cannot read.

## Things a reviewer can't see in the diff
- **`stereo` defaults on**, so existing saved WFM channels start streaming stereo (96 kbit/s instead of 64) after upgrade. Intended: stereo is what WFM means to a listener.
- **The mono path changed audibly too.** De-emphasis had to move behind the decimation — on the composite it flattened the 38 kHz subcarrier (−15 dB and rotated) before the demux could see it — and the audio decimator grew 127 → 199 taps so the 19 kHz pilot lands in the stopband rather than the transition band. Net: no pilot whine, passband flat to ~11.7 kHz instead of ~9.8 kHz, still −6 dB at 15 kHz.
- **No `PROTOCOL_VERSION` bump.** The byte layout is unchanged; the existing `ch_layout` field simply gained the value 2, and client and server ship together.
- The descriptor is renamed `WFM (mono)` → `WFM (broadcast)`.

## Tests
- `dsp`: analytic response, DC-phase and non-finite recovery for `ComplexOnePole`.
- `channels`: a new `testgen::wfm` multiplex generator (its own phase/level tests), then separation ≥ 20 dB both ways, dual-mono on a pilotless station, no pilot in the mono audio, live stereo on/off, and RDS decoding while the matrix runs. A registry test binds `audio_channels()` to the frames each mode actually produces.
- `engine`: encoder frame-clock and mid-stream layout-swap unit tests; e2e through `device-virtual` asserts WFM comes out as a two-channel stream on the unlocked-pilot path, and that a live stereo toggle changes the layout while the frame clock stays contiguous.
- `server`: the frame's `ch_layout` follows each packet.
- `web`: interleaved/deinterleaving jitter buffer, decoder swap and mono up-mix in the sink, layout routed through the audio engine, stereo frame decode.
- **Untestable in CI**: the WebCodecs *stereo* decode path needs a real browser (jsdom has no `AudioDecoder`). The planar-copy-then-interleave was chosen precisely because `copyTo`'s interleaved-f32 conversion is inconsistent across engines; worth one listen on real hardware.