### PR TITLE
ATV (analog TV): demodulator, video transport and a canvas panel

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -143,7 +143,9 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 - **[shipped]** Mode changed in place on a live channel, keeping audio subscribers
 - **[shipped]** RDS — 19 kHz pilot PLL → 3rd harmonic → symbol sync → differential decode → offset-word block sync; groups 0A/0B (PS, TP/TA/MS, AF), 2A/2B (RadioText), PTY; emitted only when a field changes. **It decodes the synthesized fixture completely and has never decoded off air** — six real stations on two radios produced nothing, reproduced deterministically from a committed-out 8 s capture; the leading (untested) hypothesis is the stereo L−R subcarrier sitting against 57 kHz
 - **[planned]** WFM **stereo** — the audio path becomes two-channel end to end (PCM, Opus, frame layout, worklet)
-- **[planned]** ATV (analog TV)
+- **[shipped]** **ATV (analog TV)** — envelope (AM, negative-modulated) or discriminator (FM) → sync-tip/peak-white level tracking → pulse-width sync separation → per-line resampling into 8-bit luma. 625/25, 525/30 and 405/25 from their own timing tables; a flywheel that coasts through a sync the noise ate; interlace recovered from the half-line offset of the field's vertical sync; black clamped per line off its own back porch. Nothing reaches the picture until the line clock locks, so a dead channel shows nothing rather than a raster the decoder invented. **Specification-proven only** — it scans the synthesized raster from the reference modulator and has never seen a real transmission
+- **[shipped]** Video as a first-class stream — a `VIDEO_GRAY` binary WS frame kind, `SubscribeVideo` with per-connection ids drawn from the same media range audio uses, a refcounted client hub, and a canvas panel on the channel's own face. This is the transport WEFAX and SSTV were blocked on
+- **[planned]** ATV colour and the sound subcarrier — luma only today; chroma is left where it is in the video band
 - **[planned]** Notch and audio filters per channel
 - **[planned]** CTCSS/DCS detection on NFM; Selcall (CCIR/ZVEI)
 
@@ -198,7 +200,7 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 
 - **[planned]** NOAA APT; Meteor M-2 LRPT
 - **[planned]** Radiosonde (RS41 …) + map/log feature; later DFM, M10/M20, iMet
-- **[planned]** HF WEFAX — the DSP is the easy half; it needs an `IMAGE` binary frame kind, a server-side page store and a canvas panel first, which is a transport decision and not a decoder
+- **[planned]** HF WEFAX — the DSP is the easy half; the picture transport ATV shipped (§8) is now the half that exists, so what is left is the decoder plus a server-side page store for a mode whose picture takes minutes rather than milliseconds
 - **[planned]** SSTV RX; APRS weather aggregation
 
 ## 14. Broadcast & wideband digital

--- a/crates/channels/src/atv.rs
+++ b/crates/channels/src/atv.rs
@@ -1,0 +1,809 @@
+//! ATV — analog television (PLAN §13). Envelope or discriminator → level clamp → sync
+//! separator → per-line resampler → one 8-bit luma picture per field.
+//!
+//! The whole mode is a clock-recovery problem wearing a picture: a raster is a stream whose
+//! only framing is the shape of its own blanking, so everything here hangs off classifying
+//! low pulses by width. A short one is a line, a long one is a field, and a half-width one is
+//! an equalizing pulse that must be ignored or every line comes out twice as fast.
+//!
+//! Luma only. The colour subcarrier (PAL/NTSC/SECAM alike) rides inside the video band this
+//! samples and is left where it is — at the bandwidths an SDR channel gives an amateur
+//! transmission, chroma would be noise on the luma rather than a second picture.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{Decimator, FmDemod, design_lowpass, flat_bandwidth_hz};
+use sdrmm_wire::{
+    AtvModulation, AtvParams, AtvStandard, ChannelDescriptor, ChannelParams, ChannelSettings,
+};
+
+use crate::{
+    ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, VideoPicture,
+    check_input_rate,
+};
+
+/// The channel's IQ rate. 2 Msps is the lowest rate that resolves a 625-line raster at all —
+/// 128 samples to a line — and the highest that every receiver on the shelf can feed: an
+/// RTL-SDR runs 2.048 or 2.4 Msps, both of which the DDC decimates onto this exactly. It is
+/// also the ceiling on horizontal detail, which is why `bandwidth_hz` is the resolution knob
+/// and the picture is as wide as the active line is long in samples.
+const INPUT_RATE_HZ: f64 = 2_000_000.0;
+
+/// Selectivity ahead of the detector. Short by this crate's standards on purpose: at 2 Msps a
+/// 129-tap filter costs more than everything else in the channel put together, and 63 taps
+/// still land the Blackman stopband (5.5/N ≈ 0.087 of the rate) inside Nyquist for the widest
+/// band this mode admits.
+const CHANNEL_TAPS: usize = 63;
+
+/// Narrowest channel that still carries a raster: a 4.7 µs sync pulse needs roughly 200 kHz to
+/// keep an edge, and below 100 kHz the separator has nothing to slice.
+const MIN_BANDWIDTH_HZ: f64 = 100_000.0;
+
+/// Slicing level between the sync tip (0.0) and peak white (1.0) — halfway to the 30 % blanking
+/// level all three standards put the picture above.
+const SYNC_SLICE: f32 = 0.15;
+
+/// Sync-pulse width bounds as a fraction of the standard's nominal. The lower bound is what
+/// rejects equalizing pulses, which are exactly half a sync wide.
+const SYNC_MIN_FRAC: f64 = 0.65;
+const SYNC_MAX_FRAC: f64 = 2.5;
+
+/// A low pulse at least this fraction of a line long is a broad (vertical-sync) pulse. The
+/// broad pulses of every standard here run past 0.4 of a line; nothing else comes close.
+const BROAD_MIN_FRAC: f64 = 0.25;
+
+/// How far from the flywheel's prediction a sync may land and still be this line's, once
+/// locked. Wider and interference re-datums the line; narrower and a drifting source is lost.
+const SYNC_WINDOW_FRAC: f64 = 0.08;
+
+/// The line ends here whether or not a sync arrived — the flywheel coasting through a sync
+/// the noise ate. Past [`SYNC_WINDOW_FRAC`], so a late-but-plausible sync is still taken.
+const MAX_COAST_FRAC: f64 = 1.15;
+
+/// Accepted syncs before the flywheel trusts its own prediction enough to start refusing the
+/// ones that land elsewhere.
+const LOCK_LINES: u8 = 4;
+
+/// How hard a measured line length pulls the estimate, per line.
+const LINE_TRACK: f64 = 0.05;
+/// …and how far it may be pulled from the standard's nominal. A source that is 2 % off is
+/// mistuned or mis-standard; chasing it further would let noise walk the estimate away.
+const LINE_TRACK_LIMIT: f64 = 0.02;
+
+/// Lines a vertical sync stays "the same one" for, so the several broad pulses of one group do
+/// not each start a field. Longer than any group, far shorter than a field.
+const VERTICAL_HOLD_LINES: u16 = 8;
+
+/// Narrowest picture worth scanning out.
+const MIN_WIDTH: u16 = 16;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "atv".to_owned(),
+    name: "ATV".to_owned(),
+    bandwidth_hz: 1_500_000.0,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    has_video: true,
+    ..ChannelDescriptor::default()
+});
+
+/// One standard's raster, as fractions of a line period measured from the sync leading edge.
+#[derive(Clone, Copy, Debug)]
+struct Timing {
+    /// Nominal horizontal sync width.
+    sync: f64,
+    /// Active video window, `[start, end)`.
+    active: (f64, f64),
+    /// Lines carrying picture, of the standard's total — the height of what this scans out.
+    active_lines: u16,
+    /// Lines from the leading edge of the first broad pulse to the first line carrying picture.
+    /// Read off the field-blanking tables rather than derived: the equalizing, broad and
+    /// post-equalizing groups that precede the picture are not a fixed share of the blanked
+    /// lines, and it is the broad pulse — not the field's first line — that is detectable.
+    picture_delay: u16,
+}
+
+fn timing(standard: AtvStandard) -> Timing {
+    // Sync, back porch and active window in µs, straight off the standard's timing table, plus
+    // the picture's height and where it starts relative to the broad pulses.
+    let (sync_us, back_us, active_us, active_lines, picture_delay) = match standard {
+        // CCIR System B/G: the picture starts at line 23 of the field, the broad pulses at 3.5.
+        AtvStandard::Ccir625 => (4.7, 5.8, 51.95, 576, 20),
+        // EIA RS-170A: the picture starts at line 21, the broad pulses at line 4.
+        AtvStandard::Eia525 => (4.7, 4.5, 52.6, 480, 17),
+        // System A has no equalizing group at all — the broad pulses open the field, and the
+        // picture starts 14 lines later.
+        AtvStandard::SystemA405 => (9.0, 5.8, 82.2, 376, 14),
+    };
+    // Per-line fractions rather than sample counts, so a source whose line rate is a little off
+    // the standard's is resampled by *its* line and not by the nominal one.
+    let line_us = 1e6 / standard.line_rate_hz();
+    let start = (sync_us + back_us) / line_us;
+    Timing {
+        sync: sync_us / line_us,
+        active: (start, start + active_us / line_us),
+        active_lines,
+        picture_delay,
+    }
+}
+
+/// Peak tracker over the demodulated video: fast onto a new extreme, slow off it. The two ends
+/// are the sync tip and peak white, which is the only absolute reference an analog raster
+/// carries — every level below is measured against them.
+#[derive(Clone, Debug)]
+struct Levels {
+    lo: f32,
+    hi: f32,
+    attack: f32,
+    decay: f32,
+    primed: bool,
+}
+
+impl Levels {
+    fn new(rate: f64) -> Self {
+        Self {
+            lo: 0.0,
+            hi: 1.0,
+            // ~2 µs onto an extreme: a sync tip is 4.7 µs, so the tracker reaches it inside one.
+            attack: (1.0 - (-1.0 / (rate * 2e-6)).exp()) as f32,
+            // ~50 ms off it, which is 800 lines — long enough that a white-free picture does not
+            // pump, short enough to follow a fade.
+            decay: (1.0 / (rate * 0.05)) as f32,
+            primed: false,
+        }
+    }
+
+    /// Track `v` and return it normalized so the sync tip reads 0.0 and peak white 1.0.
+    fn normalize(&mut self, v: f32) -> f32 {
+        if !self.primed {
+            self.primed = true;
+            self.lo = v;
+            self.hi = v + 1e-3;
+        }
+        let coeff = |toward_extreme: bool| {
+            if toward_extreme {
+                self.attack
+            } else {
+                self.decay
+            }
+        };
+        self.lo += (v - self.lo) * coeff(v < self.lo);
+        self.hi += (v - self.hi) * coeff(v > self.hi);
+        // A carrier that has not been modulated yet collapses the two together; a floor here
+        // keeps the slicer finite rather than letting it divide by nothing.
+        let span = (self.hi - self.lo).max(1e-6);
+        (v - self.lo) / span
+    }
+}
+
+pub struct AtvChannel {
+    params: AtvParams,
+    timing: Timing,
+    /// Samples per line the standard asks for, and what the tracker currently believes.
+    nominal_line: f64,
+    line_len: f64,
+    /// Demodulated video, one sample per input sample; reused across blocks.
+    video: Vec<f32>,
+    fm: Option<FmDemod>,
+    /// −1.0 when the transmission keys sync at the *top* of the demodulated signal
+    /// (negative-modulation AM), so everything below sees a video whose minimum is the sync tip.
+    polarity: f32,
+    levels: Levels,
+    /// The current line, index 0 at its accepted sync leading edge.
+    line: Vec<f32>,
+    in_sync: bool,
+    low_run: u32,
+    /// Index in [`AtvChannel::line`] where the low pulse being measured began.
+    pulse_start: usize,
+    /// Consecutive lines whose sync landed where the flywheel predicted, capped at [`LOCK_LINES`].
+    lock: u8,
+    in_vertical: bool,
+    vertical_hold: u16,
+    /// Lines since the vertical sync — where in the field the current line sits.
+    field_row: u16,
+    /// Row offset of the field being written: 1 for the half-line-offset field of an interlaced
+    /// source, 0 otherwise.
+    parity: u16,
+    /// Rows written since the field started. A field that wrote none scans out nothing.
+    written: u32,
+    frame: Vec<u8>,
+    width: u16,
+    height: u16,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&AtvParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Atv(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "atv channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+fn check_bandwidth(p: &AtvParams) -> Result<(), ChannelError> {
+    let widest = flat_bandwidth_hz(INPUT_RATE_HZ);
+    if p.bandwidth_hz.is_finite() && (MIN_BANDWIDTH_HZ..=widest).contains(&p.bandwidth_hz) {
+        Ok(())
+    } else {
+        Err(ChannelError::InvalidSettings(format!(
+            "atv bandwidth must be in [{MIN_BANDWIDTH_HZ}, {widest}] Hz, got {}",
+            p.bandwidth_hz
+        )))
+    }
+}
+
+pub(crate) fn channel_filter(p: &AtvParams) -> Result<ChannelFilter, ChannelError> {
+    check_bandwidth(p)?;
+    let cutoff = p.bandwidth_hz / 2.0 / INPUT_RATE_HZ;
+    Ok(ChannelFilter::Symmetric(Decimator::new(
+        &design_lowpass(CHANNEL_TAPS, cutoff),
+        1,
+    )))
+}
+
+/// The band an ATV channel occupies, symmetric about its carrier. A broadcast transmission is
+/// vestigial-sideband and therefore not symmetric, but a symmetric selection about the carrier
+/// is what an envelope detector wants either way; what it costs is a lift below the vestige's
+/// corner, which reads as a soft low-frequency contrast boost and not as a lost picture.
+pub(crate) fn occupied_band(p: &AtvParams) -> (f64, f64) {
+    (-p.bandwidth_hz / 2.0, p.bandwidth_hz / 2.0)
+}
+
+impl AtvChannel {
+    fn configure(&mut self, p: &AtvParams) -> Result<(), ChannelError> {
+        check_bandwidth(p)?;
+        let timing = timing(p.standard);
+        let nominal_line = INPUT_RATE_HZ / p.standard.line_rate_hz();
+        let width = ((timing.active.1 - timing.active.0) * nominal_line).round();
+        let width = if width >= f64::from(MIN_WIDTH) {
+            width as u16
+        } else {
+            return Err(ChannelError::InvalidSettings(format!(
+                "{} lines leave only {width} samples of active video at {INPUT_RATE_HZ} Hz",
+                p.standard.lines()
+            )));
+        };
+        self.timing = timing;
+        self.nominal_line = nominal_line;
+        self.line_len = nominal_line;
+        self.width = width;
+        self.height = timing.active_lines;
+        self.frame.clear();
+        self.frame
+            .resize(usize::from(width) * usize::from(timing.active_lines), 0);
+        // A discriminator's scale cancels in the level tracker, so the deviation only has to
+        // keep the output near unity rather than match the transmitter's.
+        self.fm = matches!(p.modulation, AtvModulation::Fm)
+            .then(|| FmDemod::new(INPUT_RATE_HZ, p.bandwidth_hz / 2.0));
+        // AM television is negative-modulated — peak carrier is the sync tip — so its envelope
+        // arrives upside down; FM ATV keys the other way. `invert` flips whichever applies.
+        let flipped = matches!(p.modulation, AtvModulation::Am) != p.invert;
+        self.polarity = if flipped { -1.0 } else { 1.0 };
+        self.params = p.clone();
+        self.restart();
+        Ok(())
+    }
+
+    /// Drop everything tied to the raster being scanned — the sync hunt starts over, and no
+    /// half-written picture from the old geometry escapes.
+    fn restart(&mut self) {
+        self.line.clear();
+        self.in_sync = false;
+        self.low_run = 0;
+        self.pulse_start = 0;
+        self.lock = 0;
+        self.in_vertical = false;
+        self.vertical_hold = 0;
+        self.field_row = 0;
+        self.parity = 0;
+        self.written = 0;
+        self.frame.fill(0);
+    }
+
+    /// Rows between one field's lines in the frame: interlaced fields land on alternate rows.
+    fn row_step(&self) -> u32 {
+        if self.params.interlace { 2 } else { 1 }
+    }
+
+    fn push_sample(&mut self, v: f32, out: &mut ChannelOutputs) {
+        let n = self.levels.normalize(v);
+        if n < SYNC_SLICE {
+            if self.in_sync {
+                self.low_run += 1;
+            } else {
+                self.in_sync = true;
+                self.low_run = 1;
+                self.pulse_start = self.line.len();
+            }
+        } else if self.in_sync {
+            self.in_sync = false;
+            self.classify(out);
+        }
+        self.line.push(n);
+        if self.line.len() as f64 >= self.line_len * MAX_COAST_FRAC {
+            // No sync arrived where one was due: end the line on the flywheel's own count so a
+            // burst of noise costs one torn line instead of the rest of the field.
+            let len = self.line_len.round() as usize;
+            self.end_line(len, out);
+            self.lock = self.lock.saturating_sub(1);
+        }
+    }
+
+    /// A low pulse just ended: decide what it was and, if it was this line's sync, close the
+    /// line on it.
+    fn classify(&mut self, out: &mut ChannelOutputs) {
+        let start = self.pulse_start;
+        let width = f64::from(self.low_run);
+        if width >= self.line_len * BROAD_MIN_FRAC {
+            self.vertical(start, out);
+            return;
+        }
+        let nominal = self.timing.sync * self.line_len;
+        if width < nominal * SYNC_MIN_FRAC || width > nominal * SYNC_MAX_FRAC {
+            // An equalizing pulse or a noise notch. The flywheel keeps time through it.
+            return;
+        }
+        let measured = start as f64;
+        if self.lock >= LOCK_LINES
+            && (measured - self.line_len).abs() > self.line_len * SYNC_WINDOW_FRAC
+        {
+            return;
+        }
+        if measured < self.line_len * 0.5 {
+            // Far too soon to be the next line's sync — the hunt landed mid-line. Re-datum on
+            // it without scanning out the fragment before it.
+            self.line.drain(..start);
+            return;
+        }
+        // The measured length is the truth about this source's line rate; let it pull the
+        // estimate, bounded so noise cannot walk it off the standard.
+        let pulled = self.line_len + (measured - self.line_len) * LINE_TRACK;
+        let limit = self.nominal_line * LINE_TRACK_LIMIT;
+        self.line_len = pulled.clamp(self.nominal_line - limit, self.nominal_line + limit);
+        self.end_line(start, out);
+        self.lock = (self.lock + 1).min(LOCK_LINES);
+    }
+
+    /// Scan the first `len` samples of the buffer out as a row and drop them.
+    fn end_line(&mut self, len: usize, out: &mut ChannelOutputs) {
+        let len = len.min(self.line.len());
+        self.write_row(len);
+        self.line.drain(..len);
+        self.field_row = self.field_row.saturating_add(1);
+        if self.vertical_hold > 0 {
+            self.vertical_hold -= 1;
+            if self.vertical_hold == 0 {
+                self.in_vertical = false;
+            }
+        }
+        // A source whose vertical sync never arrives (or is unreadable) would otherwise write
+        // the same rows forever; rolling the field over keeps a picture moving instead.
+        if self.field_row > self.timing.active_lines + self.timing.picture_delay {
+            self.finish_field(out);
+            self.field_row = 0;
+        }
+    }
+
+    /// Resample the active window of `line[..len]` into the frame row this line belongs to.
+    fn write_row(&mut self, len: usize) {
+        // Nothing reaches the picture until the line clock is locked. An unlocked flywheel is
+        // free-running at the standard's nominal rate over whatever is on the channel, and what
+        // it would scan out is a raster this code invented rather than one anybody transmitted.
+        if self.lock < LOCK_LINES
+            || self.field_row < self.timing.picture_delay
+            || len < MIN_WIDTH as usize
+        {
+            return;
+        }
+        let row = u32::from(self.field_row - self.timing.picture_delay);
+        let dest = row * self.row_step() + u32::from(self.parity);
+        if dest >= u32::from(self.height) {
+            return;
+        }
+        let span = len as f64;
+        // Black comes off this line's own back porch rather than from the assumed 30 % blanking
+        // level: a clamp per line is what holds the brightness steady through a fade, and it is
+        // free here because the samples are already in hand.
+        let (mut b0, mut b1) = (self.timing.sync * span, self.timing.active.0 * span);
+        let inset = (b1 - b0) * 0.25;
+        b0 += inset;
+        b1 -= inset;
+        let black = mean(&self.line[b0 as usize..(b1 as usize).max(b0 as usize + 1)]);
+        // Peak white is 1.0 by construction of the level tracker, so what is left above black
+        // is the whole picture range; a collapsed one falls back to the standard 70 %.
+        let range = if 1.0 - black > 0.05 { 1.0 - black } else { 0.7 };
+
+        let start = self.timing.active.0 * span;
+        let active = (self.timing.active.1 - self.timing.active.0) * span;
+        let base = usize::from(self.width) * dest as usize;
+        for k in 0..usize::from(self.width) {
+            let x = start + (k as f64 + 0.5) * active / f64::from(self.width);
+            let i = x as usize;
+            let v = if i + 1 < len {
+                let f = (x - i as f64) as f32;
+                self.line[i] + (self.line[i + 1] - self.line[i]) * f
+            } else {
+                self.line[len - 1]
+            };
+            self.frame[base + k] = (((v - black) / range).clamp(0.0, 1.0) * 255.0) as u8;
+        }
+        self.written += 1;
+    }
+
+    /// A broad pulse: the field this line belongs to has just started.
+    fn vertical(&mut self, start: usize, out: &mut ChannelOutputs) {
+        self.vertical_hold = VERTICAL_HOLD_LINES;
+        if self.in_vertical {
+            return;
+        }
+        self.in_vertical = true;
+        // Interlace is a half-line offset and nothing else: the second field's vertical sync
+        // arrives half a line late, which is the whole of what tells the two apart.
+        let phase = (start as f64 / self.line_len).rem_euclid(1.0);
+        self.parity = u16::from(self.params.interlace && (0.25..0.75).contains(&phase));
+        self.finish_field(out);
+        self.field_row = 0;
+    }
+
+    /// Hand over the frame as it now stands, if this field put anything into it.
+    fn finish_field(&mut self, out: &mut ChannelOutputs) {
+        if self.written == 0 {
+            return;
+        }
+        self.written = 0;
+        // The one allocation on this path, and the same bounded deviation from PLAN §7 the PCM
+        // hand-off takes: a picture per field is 50 a second, and the alternative is a pool the
+        // host would have to hand back on a thread it does not own.
+        out.video.push(VideoPicture {
+            width: self.width,
+            height: self.height,
+            luma: self.frame.clone(),
+        });
+    }
+}
+
+fn mean(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.iter().sum::<f32>() / samples.len() as f32
+}
+
+impl ChannelRx for AtvChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        let p = params(&settings)?;
+        let mut chan = Self {
+            params: p.clone(),
+            timing: timing(p.standard),
+            nominal_line: 0.0,
+            line_len: 0.0,
+            video: Vec::new(),
+            fm: None,
+            polarity: 1.0,
+            levels: Levels::new(INPUT_RATE_HZ),
+            line: Vec::new(),
+            in_sync: false,
+            low_run: 0,
+            pulse_start: 0,
+            lock: 0,
+            in_vertical: false,
+            vertical_hold: 0,
+            field_row: 0,
+            parity: 0,
+            written: 0,
+            frame: Vec::new(),
+            width: 0,
+            height: 0,
+        };
+        chan.configure(p)?;
+        Ok(chan)
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        let p = params(&settings)?;
+        // Geometry, polarity and detector all change the meaning of the raster mid-scan, so the
+        // hunt restarts rather than splicing the new standard onto the old field.
+        self.configure(p)
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // Taken out so the per-sample loop can call back into `self`; put back below, so the
+        // buffer's capacity survives the block and nothing here allocates in steady state.
+        let mut video = std::mem::take(&mut self.video);
+        match self.fm.as_mut() {
+            Some(fm) => fm.process(iq, &mut video),
+            None => {
+                video.clear();
+                video.extend(iq.iter().map(|x| x.norm()));
+            }
+        }
+        let polarity = self.polarity;
+        for &v in &video {
+            self.push_sample(v * polarity, out);
+        }
+        self.video = video;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sdrmm_wire::NfmParams;
+
+    use super::*;
+    use crate::{
+        testgen::atv::{AtvSource, BAR_LEVELS, bars},
+        testutil::settings,
+    };
+
+    fn channel(p: AtvParams) -> AtvChannel {
+        AtvChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Atv(p)),
+        )
+        .unwrap()
+    }
+
+    /// Run `iq` through in ragged blocks (the sizes a device really hands over) and collect
+    /// every picture that came out.
+    fn run(chan: &mut AtvChannel, iq: &[Complex<f32>]) -> Vec<VideoPicture> {
+        let mut out = ChannelOutputs::default();
+        let mut pictures = Vec::new();
+        let mut at = 0;
+        for (k, size) in [4_096usize, 1_000, 65_536, 777]
+            .iter()
+            .copied()
+            .cycle()
+            .enumerate()
+        {
+            let _ = k;
+            if at >= iq.len() {
+                break;
+            }
+            let end = (at + size).min(iq.len());
+            out.reset();
+            chan.process(&iq[at..end], &mut out);
+            pictures.append(&mut out.video);
+            at = end;
+        }
+        pictures
+    }
+
+    /// Mean luma of the middle of the `bar`-th vertical bar on `row`.
+    fn bar_luma(picture: &VideoPicture, row: usize, bar: usize) -> f64 {
+        let bars = BAR_LEVELS.len();
+        let w = usize::from(picture.width);
+        let lo = w * bar / bars;
+        let hi = w * (bar + 1) / bars;
+        // Bar edges smear over the channel filter's rise time; measure the settled middle.
+        let inset = (hi - lo) / 4;
+        let span = &picture.luma[row * w + lo + inset..row * w + hi - inset];
+        span.iter().map(|&v| f64::from(v)).sum::<f64>() / span.len() as f64
+    }
+
+    fn params_for(standard: AtvStandard, modulation: AtvModulation) -> AtvParams {
+        AtvParams {
+            modulation,
+            standard,
+            ..AtvParams::default()
+        }
+    }
+
+    /// The mode's whole claim: a standards-timed bar pattern comes back as a picture of the
+    /// right geometry with the bars at the right places and the right brightnesses.
+    #[test]
+    fn decodes_a_bar_pattern_from_a_ccir_625_transmission() {
+        let p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 6);
+        let mut chan = channel(p);
+        let pictures = run(&mut chan, &iq);
+
+        // Six frames in, both fields of at least two frames must have been scanned out.
+        assert!(pictures.len() >= 8, "pictures {}", pictures.len());
+        let picture = pictures.last().expect("at least one picture");
+        assert_eq!((picture.width, picture.height), (104, 576));
+        assert_eq!(
+            picture.luma.len(),
+            usize::from(picture.width) * usize::from(picture.height)
+        );
+
+        // Rows well inside the picture, one from each interlaced field, so the weave is proven
+        // and not just the first field.
+        for row in [200usize, 201, 400] {
+            for (bar, &level) in BAR_LEVELS.iter().enumerate() {
+                let got = bar_luma(picture, row, bar);
+                let want = f64::from(level) * 255.0;
+                assert!(
+                    (got - want).abs() < 26.0,
+                    "row {row} bar {bar}: luma {got:.0}, expected {want:.0}"
+                );
+            }
+        }
+    }
+
+    /// The bars must be monotonically brighter left to right in every standard and either
+    /// modulation — which is the assertion that catches an inverted polarity, a half-line
+    /// horizontal offset, or a resampler reading the wrong window.
+    #[test]
+    fn every_standard_and_modulation_scans_the_bars_in_order() {
+        for standard in [
+            AtvStandard::Ccir625,
+            AtvStandard::Eia525,
+            AtvStandard::SystemA405,
+        ] {
+            for modulation in [AtvModulation::Am, AtvModulation::Fm] {
+                let p = params_for(standard, modulation);
+                let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 4);
+                let mut chan = channel(p);
+                let pictures = run(&mut chan, &iq);
+                let picture = pictures
+                    .last()
+                    .unwrap_or_else(|| panic!("{standard:?}/{modulation:?} produced no picture"));
+                assert_eq!(picture.height, timing(standard).active_lines);
+                let row = usize::from(picture.height) / 2;
+                let luma: Vec<f64> = (0..BAR_LEVELS.len())
+                    .map(|bar| bar_luma(picture, row, bar))
+                    .collect();
+                for pair in luma.windows(2) {
+                    assert!(
+                        pair[1] > pair[0] + 10.0,
+                        "{standard:?}/{modulation:?}: bars not ascending: {luma:?}"
+                    );
+                }
+                assert!(
+                    luma[0] < 40.0,
+                    "{standard:?}/{modulation:?}: black {luma:?}"
+                );
+                assert!(
+                    *luma.last().unwrap() > 215.0,
+                    "{standard:?}/{modulation:?}: white {luma:?}"
+                );
+            }
+        }
+    }
+
+    /// `invert` is what an operator reaches for when the picture comes back as a negative, so
+    /// inverting the transmission *and* the setting must land back on the same picture.
+    #[test]
+    fn invert_undoes_a_reversed_transmission() {
+        let mut p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        p.invert = true;
+        let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 4);
+        let mut chan = channel(p);
+        let picture = run(&mut chan, &iq).pop().expect("a picture");
+        let row = usize::from(picture.height) / 2;
+        assert!(bar_luma(&picture, row, 0) < 40.0);
+        assert!(bar_luma(&picture, row, BAR_LEVELS.len() - 1) > 215.0);
+    }
+
+    /// A progressive source has no half-line offset, so every line must land on consecutive
+    /// rows — read back as a picture with no blank alternate rows.
+    #[test]
+    fn progressive_sources_fill_every_row() {
+        let mut p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        p.interlace = false;
+        let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 4);
+        let mut chan = channel(p);
+        let picture = run(&mut chan, &iq).pop().expect("a picture");
+        let white = BAR_LEVELS.len() - 1;
+        for row in [100usize, 101, 102, 103] {
+            assert!(
+                bar_luma(&picture, row, white) > 215.0,
+                "row {row} of a progressive scan is blank"
+            );
+        }
+    }
+
+    /// Noise must cost lines, not the lock: the flywheel exists so a burst that eats a sync
+    /// leaves the picture standing.
+    #[test]
+    fn a_noisy_channel_still_scans_a_recognizable_picture() {
+        let p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        let mut iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 4);
+        crate::testgen::add_noise(&mut iq, 0xA7C3, 0.08);
+        let mut chan = channel(p);
+        let picture = run(&mut chan, &iq).pop().expect("a picture");
+        let row = usize::from(picture.height) / 2;
+        let black = bar_luma(&picture, row, 0);
+        let white = bar_luma(&picture, row, BAR_LEVELS.len() - 1);
+        assert!(white - black > 150.0, "contrast {black:.0}..{white:.0}");
+    }
+
+    /// Silence must not scan out a picture of noise: with no sync there is no raster, and a
+    /// panel showing snow it invented is worse than a panel showing nothing.
+    #[test]
+    fn an_empty_channel_produces_no_picture() {
+        let p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        let mut chan = channel(p);
+        let quiet = vec![Complex::new(0.0, 0.0); 400_000];
+        assert!(run(&mut chan, &quiet).is_empty());
+    }
+
+    #[test]
+    fn apply_changes_the_standard_and_the_geometry_with_it() {
+        let mut chan = channel(params_for(AtvStandard::Ccir625, AtvModulation::Am));
+        assert_eq!((chan.width, chan.height), (104, 576));
+        let p = params_for(AtvStandard::SystemA405, AtvModulation::Fm);
+        chan.apply(settings(ChannelParams::Atv(p.clone()))).unwrap();
+        assert_eq!(chan.height, 376);
+        let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 4);
+        let picture = run(&mut chan, &iq).pop().expect("a picture");
+        assert_eq!((picture.width, picture.height), (chan.width, 376));
+    }
+
+    #[test]
+    fn mismatched_params_variant_is_rejected() {
+        let mut chan = channel(AtvParams::default());
+        assert!(matches!(
+            chan.apply(settings(ChannelParams::Nfm(NfmParams::default()))),
+            Err(ChannelError::InvalidSettings(_))
+        ));
+    }
+
+    #[test]
+    fn out_of_range_bandwidth_is_rejected() {
+        for bandwidth_hz in [0.0, f64::NAN, 50_000.0, 1_900_000.0] {
+            let p = AtvParams {
+                bandwidth_hz,
+                ..AtvParams::default()
+            };
+            assert!(
+                matches!(channel_filter(&p), Err(ChannelError::InvalidSettings(_))),
+                "{bandwidth_hz} must be rejected"
+            );
+            assert!(matches!(
+                AtvChannel::new(
+                    ChannelCtx {
+                        input_rate: INPUT_RATE_HZ
+                    },
+                    settings(ChannelParams::Atv(p)),
+                ),
+                Err(ChannelError::InvalidSettings(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_a_mismatched_input_rate() {
+        assert!(matches!(
+            AtvChannel::new(
+                ChannelCtx {
+                    input_rate: 48_000.0
+                },
+                settings(ChannelParams::Atv(AtvParams::default())),
+            ),
+            Err(ChannelError::InvalidSettings(_))
+        ));
+    }
+
+    /// The heaviest per-sample path in the crate after ADS-B, and the one most able to stall a
+    /// DSP thread that has other channels on it. The budget is real time in an *unoptimized*
+    /// build, which this beats by roughly 3× today: a gate against the order-of-magnitude
+    /// regression that would make ATV unhostable, not a benchmark.
+    #[test]
+    fn keeps_ahead_of_the_channel_rate() {
+        let p = params_for(AtvStandard::Ccir625, AtvModulation::Am);
+        let iq = bars(&AtvSource::new(&p, INPUT_RATE_HZ), 10);
+        let seconds = iq.len() as f64 / INPUT_RATE_HZ;
+        let mut chan = channel(p);
+        let mut out = ChannelOutputs::default();
+        let started = std::time::Instant::now();
+        for block in iq.chunks(16_384) {
+            out.reset();
+            chan.process(block, &mut out);
+        }
+        let elapsed = started.elapsed().as_secs_f64();
+        assert!(
+            elapsed < seconds,
+            "{seconds:.2} s of video took {elapsed:.2} s"
+        );
+    }
+}

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -1,14 +1,15 @@
 //! `sdrmm-channels` — the `ChannelRx` plugin surface (PLAN §8). Depends only on `dsp` + `wire`.
 //! Phase-1 analog demodulators plus the wave-1 and wave-2 data decoders (PLAN §13): NFM, AM,
-//! SSB, WFM mono (+RDS), POCSAG, ADS-B, AIS, APRS/AX.25, RTTY, Morse, NAVTEX, ACARS, sub-GHz. Each mode is one module whose
-//! descriptor and constructor sit in the same [`REGISTRY`] row, so the "add channel" UI and
-//! `create` dispatch cannot drift apart.
+//! SSB, WFM mono (+RDS), POCSAG, ADS-B, AIS, APRS/AX.25, RTTY, Morse, NAVTEX, ACARS, sub-GHz and
+//! ATV. Each mode is one module whose descriptor and constructor sit in the same [`REGISTRY`]
+//! row, so the "add channel" UI and `create` dispatch cannot drift apart.
 
 mod acars;
 mod adsb;
 mod ais;
 mod am;
 mod aprs;
+mod atv;
 mod morse;
 mod navtex;
 mod nfm;
@@ -34,6 +35,7 @@ pub use adsb::AdsbChannel;
 pub use ais::AisChannelRx;
 pub use am::{AmChannel, AmTx};
 pub use aprs::{AprsChannel, AprsTx};
+pub use atv::AtvChannel;
 pub use morse::MorseChannel;
 pub use navtex::NavtexChannel;
 pub use nfm::{NfmChannel, NfmTx};
@@ -84,6 +86,7 @@ pub fn occupied_band(params: &ChannelParams) -> (f64, f64) {
         ChannelParams::Navtex(_) => navtex::occupied_band(),
         ChannelParams::Acars(p) => acars::occupied_band(p),
         ChannelParams::Subghz(p) => subghz::occupied_band(p),
+        ChannelParams::Atv(p) => atv::occupied_band(p),
     }
 }
 
@@ -130,6 +133,7 @@ pub fn channel_filter(params: &ChannelParams) -> Result<ChannelFilter, ChannelEr
         ChannelParams::Navtex(_) => Ok(navtex::channel_filter()),
         ChannelParams::Acars(p) => acars::channel_filter(p),
         ChannelParams::Subghz(p) => subghz::channel_filter(p),
+        ChannelParams::Atv(p) => atv::channel_filter(p),
     }
 }
 
@@ -156,8 +160,18 @@ pub struct ChannelCtx {
     pub input_rate: f64,
 }
 
-/// Sink a channel writes into each `process` call: demodulated audio, typed events, and
-/// low-rate IQ taps for the analyzer (PLAN §8). Buffers are reused across calls by the host.
+/// One picture a video channel scanned out: 8-bit luma, row-major from the top line, exactly
+/// `width · height` bytes. Grayscale because that is what an analog raster carries once the
+/// colour subcarrier is left alone (PLAN §13: ATV decodes luma).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VideoPicture {
+    pub width: u16,
+    pub height: u16,
+    pub luma: Vec<u8>,
+}
+
+/// Sink a channel writes into each `process` call: demodulated audio, typed events, pictures,
+/// and low-rate IQ taps for the analyzer (PLAN §8). Buffers are reused across calls by the host.
 #[derive(Default)]
 pub struct ChannelOutputs {
     /// Interleaved/mono PCM plus its sample rate, when the channel produced audio this block.
@@ -166,6 +180,10 @@ pub struct ChannelOutputs {
     /// Typed decoder frames produced this block (PLAN §5). The host stamps them with time and
     /// frequency; a decoder never formats or serializes on the DSP thread.
     pub events: Vec<DecoderEvent>,
+    /// Pictures completed this block. A `Vec` rather than one slot because a block is sized by
+    /// the device's USB transfers, not by the raster: nothing stops one from spanning two
+    /// fields, and the second picture must not be the one that silently vanishes.
+    pub video: Vec<VideoPicture>,
     /// Decimated IQ for scope/constellation panels.
     pub iq_tap: Vec<Complex<f32>>,
 }
@@ -176,6 +194,7 @@ impl ChannelOutputs {
         self.audio_pcm.clear();
         self.audio_rate = 0;
         self.events.clear();
+        self.video.clear();
         self.iq_tap.clear();
     }
 }
@@ -358,6 +377,11 @@ const REGISTRY: &[Registration] = &[
         create: boxed::<SubghzChannel>,
         create_tx: None,
     },
+    Registration {
+        descriptor: AtvChannel::descriptor,
+        create: boxed::<AtvChannel>,
+        create_tx: None,
+    },
 ];
 
 /// Descriptors for every compiled-in channel type (PLAN §8: static registry).
@@ -464,8 +488,9 @@ mod tests {
     use std::collections::HashSet;
 
     use sdrmm_wire::{
-        AcarsParams, AdsbParams, AisParams, AmParams, AprsParams, ChannelParams, MorseParams,
-        NavtexParams, NfmParams, PocsagParams, RttyParams, SsbParams, SubghzParams, WfmParams,
+        AcarsParams, AdsbParams, AisParams, AmParams, AprsParams, AtvParams, ChannelParams,
+        MorseParams, NavtexParams, NfmParams, PocsagParams, RttyParams, SsbParams, SubghzParams,
+        WfmParams,
     };
 
     use super::*;
@@ -486,6 +511,7 @@ mod tests {
             "navtex" => ChannelParams::Navtex(NavtexParams::default()),
             "acars" => ChannelParams::Acars(AcarsParams::default()),
             "subghz" => ChannelParams::Subghz(SubghzParams::default()),
+            "atv" => ChannelParams::Atv(AtvParams::default()),
             other => panic!("unexpected type id {other}"),
         }
     }
@@ -493,13 +519,13 @@ mod tests {
     #[test]
     fn descriptors_are_unique_and_complete() {
         let all = descriptors();
-        assert_eq!(all.len(), 13);
+        assert_eq!(all.len(), 14);
         let ids: HashSet<&str> = all.iter().map(|d| d.type_id.as_str()).collect();
         assert_eq!(
             ids,
             HashSet::from([
                 "nfm", "am", "ssb", "wfm", "pocsag", "adsb", "ais", "aprs", "rtty", "morse",
-                "navtex", "acars", "subghz",
+                "navtex", "acars", "subghz", "atv",
             ])
         );
         for d in &all {
@@ -517,22 +543,29 @@ mod tests {
                 "navtex" => (600.0, 8_000.0),
                 "acars" => (12_500.0, 48_000.0),
                 "subghz" => (150_000.0, 250_000.0),
+                "atv" => (1_500_000.0, 2_000_000.0),
                 other => panic!("unexpected type id {other}"),
             };
             assert_eq!(d.bandwidth_hz, bandwidth, "{}", d.type_id);
             assert_eq!(d.input_rate_hz, rate, "{}", d.type_id);
             assert!(!d.name.is_empty(), "{}", d.type_id);
-            // Every channel type must be useful for something: audio, decoded frames, or
-            // both (WFM+RDS is the only current "both").
+            // Every channel type must be useful for something: audio, decoded frames, or a
+            // picture (WFM+RDS is the only current "both" of the first two).
             assert!(
-                d.has_audio || d.decoder_kind.is_some(),
-                "{} produces neither audio nor decoder events",
+                d.has_audio || d.decoder_kind.is_some() || d.has_video,
+                "{} produces neither audio, decoder events nor video",
                 d.type_id
             );
             assert_eq!(
                 d.has_audio,
                 matches!(d.type_id.as_str(), "nfm" | "am" | "ssb" | "wfm"),
                 "{} audio flag does not match its mode class",
+                d.type_id
+            );
+            assert_eq!(
+                d.has_video,
+                d.type_id == "atv",
+                "{} video flag does not match its mode class",
                 d.type_id
             );
         }

--- a/crates/channels/src/testgen/atv.rs
+++ b/crates/channels/src/testgen/atv.rs
@@ -1,0 +1,363 @@
+//! Reference ATV transmitter: a standards-timed analog raster, modulated the way the band it
+//! belongs to modulates it.
+//!
+//! Written from the standards' own timing tables in absolute microseconds — front porch, sync,
+//! back porch, active — and from their field-blanking structure in half-lines, which is where
+//! interlace lives: the two fields differ by exactly one half-line, and everything a receiver
+//! knows about which field it is looking at comes from that.
+//!
+//! Independent of [`crate::atv`] in method: this lays a raster out in time, while the decoder
+//! recovers one by classifying pulse widths. What the two share is the standard.
+
+use std::f64::consts::TAU;
+
+use num_complex::Complex;
+use sdrmm_wire::{AtvModulation, AtvParams, AtvStandard};
+
+/// Video levels, sync tip to peak white, as the standards define them: blanking sits 30 % of
+/// the way up and the picture occupies everything above it.
+const SYNC: f32 = 0.0;
+const BLANKING: f32 = 0.3;
+
+/// Peak-carrier fraction the picture is keyed down to at peak white. 87.5 % leaves white at
+/// 12.5 % of the sync tip, which is what broadcast negative modulation transmits.
+const AM_DEPTH: f64 = 0.875;
+
+/// Peak deviation of the FM form, in Hz. Small next to real FM ATV on purpose: Carson's rule
+/// has to keep the transmission inside the channel the test then filters it through.
+const FM_DEVIATION_HZ: f64 = 150_000.0;
+
+/// Luma of the vertical bars [`bars`] transmits, black to white.
+pub const BAR_LEVELS: [f32; 5] = [0.0, 0.25, 0.5, 0.75, 1.0];
+
+/// One standard's line, in seconds, and the vertical structure of one of its fields.
+#[derive(Clone, Copy, Debug)]
+struct Layout {
+    line_s: f64,
+    front_porch_s: f64,
+    sync_s: f64,
+    back_porch_s: f64,
+    active_s: f64,
+    /// Half-lines of equalizing pulses before the broad group, of broad pulses, and of
+    /// equalizing pulses after it.
+    pre_eq: u16,
+    broad: u16,
+    post_eq: u16,
+    /// Half-lines in one field: half the frame's lines, counted this way because the vertical
+    /// structure is on a half-line grid and the frame's is not.
+    field_half_lines: u16,
+    /// Whole lines of blanking between the vertical group and the first line of picture.
+    blank_after_group: u16,
+    /// Lines of picture in one field.
+    active_lines: u16,
+}
+
+fn layout(standard: AtvStandard) -> Layout {
+    let (sync_us, back_us, active_us, pre_eq, broad, post_eq, blank_after_group, active_lines) =
+        match standard {
+            // CCIR System B/G: 4.7 µs sync, 5.8 back porch, 51.95 active. Field blanking is
+            // 5 + 5 + 5 half-lines and the picture starts at line 23.
+            AtvStandard::Ccir625 => (4.7, 5.8, 51.95, 5, 5, 5, 15, 288),
+            // EIA RS-170A: 4.7 µs sync, 4.5 back porch, 52.6 active. Field blanking is
+            // 6 + 6 + 6 half-lines and the picture starts at line 21.
+            AtvStandard::Eia525 => (4.7, 4.5, 52.6, 6, 6, 6, 11, 240),
+            // System A: 9.0 µs sync, 5.8 back porch, 82.2 active. No equalizing pulses at all;
+            // four lines of broad pulses open the field and the picture starts at line 15.
+            AtvStandard::SystemA405 => (9.0, 5.8, 82.2, 0, 8, 0, 10, 188),
+        };
+    // The line period comes from the standard's line rate, not from a rounded figure: a frame
+    // that is a few samples long closes on the wrong sample and drifts a receiver every frame.
+    let line_s = 1.0 / standard.line_rate_hz();
+    Layout {
+        line_s,
+        // What the timed intervals leave over is the front porch, by construction.
+        front_porch_s: line_s - (sync_us + back_us + active_us) * 1e-6,
+        sync_s: sync_us * 1e-6,
+        back_porch_s: back_us * 1e-6,
+        active_s: active_us * 1e-6,
+        pre_eq,
+        broad,
+        post_eq,
+        field_half_lines: standard.lines(),
+        blank_after_group,
+        active_lines,
+    }
+}
+
+/// What a segment of the raster carries. Every one is either a half-line of the vertical
+/// structure or a whole line.
+#[derive(Clone, Copy)]
+enum Seg {
+    /// A half-line whose first half-sync marks time through the vertical interval.
+    Equalizing,
+    /// A half-line of the broad group: sync for all of it but the last sync width.
+    Broad,
+    /// A half-line of plain blanking, which is what carries the interlace offset.
+    HalfBlank,
+    /// A whole line, with picture in its active window or blanking instead.
+    Line { picture: bool },
+}
+
+/// A transmitter for one set of ATV settings at one sample rate.
+pub struct AtvSource {
+    rate: f64,
+    layout: Layout,
+    modulation: AtvModulation,
+    invert: bool,
+    interlace: bool,
+}
+
+impl AtvSource {
+    #[must_use]
+    pub fn new(params: &AtvParams, rate: f64) -> Self {
+        Self {
+            rate,
+            layout: layout(params.standard),
+            modulation: params.modulation,
+            invert: params.invert,
+            interlace: params.interlace,
+        }
+    }
+
+    /// The frame's segments. `second` selects the field whose vertical group arrives half a
+    /// line late — the only difference between the two, and the whole of interlace.
+    fn field(&self, second: bool) -> Vec<Seg> {
+        let l = self.layout;
+        let mut segs = Vec::new();
+        // The half-line that displaces this field's line grid. Emitted before the vertical
+        // group so the group itself, and with it the receiver's field-parity test, moves with it.
+        if second {
+            segs.push(Seg::HalfBlank);
+        }
+        segs.extend(std::iter::repeat_n(Seg::Equalizing, usize::from(l.pre_eq)));
+        segs.extend(std::iter::repeat_n(Seg::Broad, usize::from(l.broad)));
+        segs.extend(std::iter::repeat_n(Seg::Equalizing, usize::from(l.post_eq)));
+        let group = usize::from(second) + usize::from(l.pre_eq + l.broad + l.post_eq);
+        // Whole lines take two half-lines each; an odd remainder ends the field on a half-line,
+        // which is what puts the *next* field's group back on the other grid.
+        let remaining = usize::from(l.field_half_lines) - group;
+        let lines = remaining / 2;
+        for k in 0..lines {
+            let first = usize::from(l.blank_after_group);
+            segs.push(Seg::Line {
+                picture: k >= first && k < first + usize::from(l.active_lines),
+            });
+        }
+        if remaining % 2 == 1 {
+            segs.push(Seg::HalfBlank);
+        }
+        segs
+    }
+
+    /// Level of one segment at `u` seconds into it, `luma` sampled across the active window.
+    fn level(&self, seg: Seg, u: f64, luma: &dyn Fn(f64) -> f32) -> f32 {
+        let l = self.layout;
+        let half = l.line_s / 2.0;
+        match seg {
+            Seg::Equalizing => {
+                if u < l.sync_s / 2.0 {
+                    SYNC
+                } else {
+                    BLANKING
+                }
+            }
+            Seg::Broad => {
+                if u < half - l.sync_s {
+                    SYNC
+                } else {
+                    BLANKING
+                }
+            }
+            Seg::HalfBlank => BLANKING,
+            Seg::Line { picture } => {
+                let sync_end = l.front_porch_s + l.sync_s;
+                let active_start = sync_end + l.back_porch_s;
+                if u < l.front_porch_s || u >= active_start {
+                    if u >= active_start && picture {
+                        let x = (u - active_start) / l.active_s;
+                        return BLANKING + (1.0 - BLANKING) * luma(x.clamp(0.0, 1.0));
+                    }
+                    BLANKING
+                } else if u < sync_end {
+                    SYNC
+                } else {
+                    BLANKING
+                }
+            }
+        }
+    }
+
+    fn seg_seconds(&self, seg: Seg) -> f64 {
+        match seg {
+            Seg::Line { .. } => self.layout.line_s,
+            _ => self.layout.line_s / 2.0,
+        }
+    }
+
+    /// Render `frames` frames of `luma` as the video waveform, sync tip 0.0 to peak white 1.0.
+    fn video(&self, frames: u32, luma: &dyn Fn(f64) -> f32) -> Vec<f32> {
+        let mut segs = Vec::new();
+        for _ in 0..frames {
+            segs.extend(self.field(false));
+            // A progressive source repeats the same field structure: no half-line displacement,
+            // so a receiver weaves nothing and every vertical sync opens a whole picture.
+            segs.extend(self.field(self.interlace));
+        }
+        let mut out = Vec::new();
+        // Boundaries are tracked in fractional samples and rounded once, so a half-line offset
+        // survives a rate that does not divide the line period.
+        let mut start = 0.0f64;
+        for seg in segs {
+            let seconds = self.seg_seconds(seg);
+            let end = start + seconds * self.rate;
+            let first = start.round() as usize;
+            let count = end.round() as usize - first;
+            for k in 0..count {
+                let u = (first + k) as f64 - start;
+                out.push(self.level(seg, u / self.rate, luma));
+            }
+            start = end;
+        }
+        out
+    }
+
+    /// Modulate a video waveform onto complex baseband.
+    fn modulate(&self, video: &[f32]) -> Vec<Complex<f32>> {
+        let mut phase = 0.0f64;
+        video
+            .iter()
+            .map(|&v| {
+                // `invert` transmits the reversed polarity, which is what the receive-side
+                // setting of the same name exists to undo.
+                let m = f64::from(if self.invert { 1.0 - v } else { v });
+                match self.modulation {
+                    // Negative modulation: the sync tip is peak carrier and white is the trough.
+                    AtvModulation::Am => Complex::new((1.0 - AM_DEPTH * m) as f32, 0.0),
+                    AtvModulation::Fm => {
+                        phase += TAU * FM_DEVIATION_HZ * (2.0 * m - 1.0) / self.rate;
+                        Complex::from_polar(1.0, phase as f32)
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+/// `frames` frames of vertical bars at [`BAR_LEVELS`], as complex baseband IQ.
+#[must_use]
+pub fn bars(source: &AtvSource, frames: u32) -> Vec<Complex<f32>> {
+    let video = source.video(frames, &|x| {
+        let bar = ((x * BAR_LEVELS.len() as f64) as usize).min(BAR_LEVELS.len() - 1);
+        BAR_LEVELS[bar]
+    });
+    source.modulate(&video)
+}
+
+#[cfg(test)]
+mod tests {
+    use sdrmm_wire::AtvParams;
+
+    use super::*;
+
+    const RATE: f64 = 2_000_000.0;
+
+    fn source(standard: AtvStandard) -> AtvSource {
+        AtvSource::new(
+            &AtvParams {
+                standard,
+                ..AtvParams::default()
+            },
+            RATE,
+        )
+    }
+
+    /// A frame must be exactly the standard's own duration: the vertical structure is laid out
+    /// in half-lines and the picture in whole ones, and a raster that does not close on itself
+    /// would drift a receiver by a line a frame however good its flywheel is.
+    #[test]
+    fn a_frame_lasts_exactly_one_frame_period() {
+        for standard in [
+            AtvStandard::Ccir625,
+            AtvStandard::Eia525,
+            AtvStandard::SystemA405,
+        ] {
+            let src = source(standard);
+            let video = src.video(2, &|_| 1.0);
+            let want = 2.0 * RATE / standard.frame_rate_hz();
+            let got = video.len() as f64;
+            assert!(
+                (got - want).abs() <= 2.0,
+                "{standard:?}: {got} samples for two frames, expected {want}"
+            );
+        }
+    }
+
+    /// The two fields must differ by exactly one half-line, since that displacement is the only
+    /// thing a receiver can tell them apart by.
+    #[test]
+    fn the_second_field_is_displaced_by_half_a_line() {
+        let src = source(AtvStandard::Ccir625);
+        let first: f64 = src
+            .field(false)
+            .into_iter()
+            .map(|s| src.seg_seconds(s))
+            .sum();
+        let second: f64 = src
+            .field(true)
+            .into_iter()
+            .map(|s| src.seg_seconds(s))
+            .sum();
+        // Both fields last the same time — the displacement is where the group sits inside it.
+        assert!((first - second).abs() < 1e-12, "{first} vs {second}");
+        let group = |second: bool| {
+            src.field(second)
+                .into_iter()
+                .take_while(|s| !matches!(s, Seg::Broad))
+                .map(|s| src.seg_seconds(s))
+                .sum::<f64>()
+        };
+        let offset = group(true) - group(false);
+        assert!(
+            (offset - src.layout.line_s / 2.0).abs() < 1e-12,
+            "broad group moved by {offset} s, expected half a line"
+        );
+    }
+
+    /// Sync must be the lowest level in the waveform and white the highest, with blanking where
+    /// the standards put it — the levels every receiver slices against.
+    #[test]
+    fn levels_sit_where_the_standards_put_them() {
+        let src = source(AtvStandard::Ccir625);
+        let video = src.video(1, &|_| 1.0);
+        let lo = video.iter().copied().fold(f32::MAX, f32::min);
+        let hi = video.iter().copied().fold(f32::MIN, f32::max);
+        assert_eq!(lo, SYNC);
+        assert_eq!(hi, 1.0);
+        // The back porch of a line, which is blanking by construction. Counted from where the
+        // normal lines start — the vertical group sits on the half-line grid ahead of them.
+        let l = src.layout;
+        let at = |seconds: f64| video[(seconds * RATE) as usize];
+        let group = f64::from(l.pre_eq + l.broad + l.post_eq) * l.line_s / 2.0;
+        let line_start = group + 20.0 * l.line_s;
+        assert_eq!(
+            at(line_start + l.front_porch_s + l.sync_s + l.back_porch_s / 2.0),
+            BLANKING
+        );
+        assert_eq!(at(line_start + l.front_porch_s + l.sync_s / 2.0), SYNC);
+    }
+
+    /// Negative modulation is the claim the AM form makes: peak carrier at the sync tip, and
+    /// white keyed down to a small fraction of it.
+    #[test]
+    fn am_keys_sync_to_peak_carrier() {
+        let src = source(AtvStandard::Ccir625);
+        let iq = bars(&src, 1);
+        let peak = iq.iter().map(|s| s.norm()).fold(f32::MIN, f32::max);
+        let trough = iq.iter().map(|s| s.norm()).fold(f32::MAX, f32::min);
+        assert!((peak - 1.0).abs() < 1e-6, "peak {peak}");
+        assert!(
+            (trough - (1.0 - AM_DEPTH as f32)).abs() < 1e-6,
+            "trough {trough}"
+        );
+    }
+}

--- a/crates/channels/src/testgen/mod.rs
+++ b/crates/channels/src/testgen/mod.rs
@@ -24,6 +24,7 @@
 pub mod acars;
 pub mod adsb;
 pub mod ais;
+pub mod atv;
 pub mod morse;
 pub mod navtex;
 pub mod pocsag;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -32,14 +32,15 @@ pub mod audio;
 pub mod recording;
 pub mod runtime;
 pub mod scanner;
+pub mod video;
 pub use audio::AudioPacket;
 pub use recording::FinalizedRecording;
 pub use runtime::{SpectrumSnapshot, adaptive_db_window};
+pub use video::VideoPacket;
 
 use crate::{
-    audio::PcmBlock,
     recording::RecordingShared,
-    runtime::{CaptureRuntime, ChannelHost, DecodedSink, DspCommand, RawDecoded},
+    runtime::{CaptureRuntime, ChannelHost, ChannelSinks, DecodedSink, DspCommand, RawDecoded},
     scanner::{ScanPlan, ScannerState},
 };
 
@@ -146,15 +147,14 @@ impl EngineError {
 }
 
 /// A hosted channel queued for a pipeline rebuild swap: the settings snapshot it was listed
-/// under, plus the audio identity (PCM sender + shared sample position) the replacement host
-/// must reuse so the audio stream and its timestamps survive the swap.
+/// under, plus the media identity (PCM and picture senders with their shared positions) the
+/// replacement host must reuse, so a subscriber never notices the pipeline was replaced.
 struct RebuildEntry {
     id: u32,
     /// The rx stream the channel taps; the replacement host must land on the same lane.
     stream: u32,
     settings: ChannelSettings,
-    pcm_tx: broadcast::Sender<PcmBlock>,
-    pcm_pos: Arc<AtomicU64>,
+    sinks: ChannelSinks,
 }
 
 fn sample_rate_of(settings: &DeviceSettings) -> f64 {
@@ -286,25 +286,29 @@ fn validate_streams(
     Ok(())
 }
 
-/// A channel's audio identity: the PCM fan-in and Opus fan-out survive pipeline rebuilds
-/// (params type change, device rate change), so audio subscribers never notice a swap.
-struct ChannelAudio {
-    pcm_tx: broadcast::Sender<PcmBlock>,
-    /// 48 kHz-domain position of the channel's next PCM sample, shared into every host
-    /// built for this channel so packet timestamps stay continuous across rebuilds.
-    pcm_pos: Arc<AtomicU64>,
+/// A channel's media identity: the PCM fan-in, the Opus fan-out and the picture stream all
+/// survive pipeline rebuilds (params type change, device rate change), so subscribers of either
+/// kind never notice a swap.
+struct ChannelMedia {
+    /// What the DSP-side host writes into, handed to every host built for this channel.
+    sinks: ChannelSinks,
     audio_tx: broadcast::Sender<AudioPacket>,
     encoder: Option<std::thread::JoinHandle<()>>,
 }
 
-impl ChannelAudio {
+impl ChannelMedia {
     fn new() -> Result<Self, EngineError> {
         let (pcm_tx, pcm_rx) = broadcast::channel(audio::PCM_CHANNEL_CAP);
         let (audio_tx, _) = broadcast::channel(audio::AUDIO_CHANNEL_CAP);
+        let (video_tx, _) = broadcast::channel(video::VIDEO_CHANNEL_CAP);
         let encoder = audio::spawn_encoder(pcm_rx, audio_tx.clone())?;
         Ok(Self {
-            pcm_tx,
-            pcm_pos: Arc::new(AtomicU64::new(0)),
+            sinks: ChannelSinks {
+                pcm_tx,
+                pcm_pos: Arc::new(AtomicU64::new(0)),
+                video_tx,
+                video_pos: Arc::new(AtomicU64::new(0)),
+            },
             audio_tx,
             encoder: Some(encoder),
         })
@@ -372,9 +376,9 @@ struct DeviceSetState {
     settings: DeviceSettings,
     status: DeviceSetStatus,
     channels: Vec<ChannelInfo>,
-    /// Audio plumbing per channel id, kept beside the projected `channels` so rebuild swaps
-    /// can preserve a channel's streams while replacing its DSP pipeline.
-    audio: HashMap<u32, ChannelAudio>,
+    /// Audio and video plumbing per channel id, kept beside the projected `channels` so
+    /// rebuild swaps can preserve a channel's streams while replacing its DSP pipeline.
+    media: HashMap<u32, ChannelMedia>,
     next_channel_id: u32,
     error: Option<String>,
     recording: Option<RecordingState>,
@@ -987,12 +991,11 @@ impl Engine {
                 .channels
                 .iter()
                 .filter_map(|c| {
-                    state.audio.get(&c.id).map(|a| RebuildEntry {
+                    state.media.get(&c.id).map(|m| RebuildEntry {
                         id: c.id,
                         stream: c.stream,
                         settings: c.settings.clone(),
-                        pcm_tx: a.pcm_tx.clone(),
-                        pcm_pos: a.pcm_pos.clone(),
+                        sinks: m.sinks.clone(),
                     })
                 })
                 .collect();
@@ -1004,7 +1007,7 @@ impl Engine {
         lock_runtime(&old_runtime).stop();
         drop(old_runtime);
 
-        let mut dead: Vec<ChannelAudio> = Vec::new();
+        let mut dead: Vec<ChannelMedia> = Vec::new();
         for rebuild in rebuilds {
             self.rebuild_channel(ds, rebuild, rate, &mut dead);
         }
@@ -1138,7 +1141,7 @@ impl Engine {
                         DeviceSetStatus::Running
                     },
                     channels: Vec::new(),
-                    audio: HashMap::new(),
+                    media: HashMap::new(),
                     next_channel_id: 1,
                     error: pending.as_ref().map(ToString::to_string),
                     recording: None,
@@ -1335,12 +1338,11 @@ impl Engine {
                     .channels
                     .iter()
                     .filter_map(|c| {
-                        state.audio.get(&c.id).map(|a| RebuildEntry {
+                        state.media.get(&c.id).map(|m| RebuildEntry {
                             id: c.id,
                             stream: c.stream,
                             settings: c.settings.clone(),
-                            pcm_tx: a.pcm_tx.clone(),
-                            pcm_pos: a.pcm_pos.clone(),
+                            sinks: m.sinks.clone(),
                         })
                     })
                     .collect()
@@ -1350,7 +1352,7 @@ impl Engine {
             (settings, rate, rebuilds)
         };
         lock_runtime(&runtime).set_meta(&settings);
-        let mut dead: Vec<ChannelAudio> = Vec::new();
+        let mut dead: Vec<ChannelMedia> = Vec::new();
         for rebuild in rebuilds {
             self.rebuild_channel(ds, rebuild, rate, &mut dead);
         }
@@ -1380,14 +1382,13 @@ impl Engine {
         ds: u32,
         rebuild: RebuildEntry,
         rate: f64,
-        dead: &mut Vec<ChannelAudio>,
+        dead: &mut Vec<ChannelMedia>,
     ) {
         let RebuildEntry {
             id,
             stream,
             mut settings,
-            pcm_tx,
-            pcm_pos,
+            sinks,
         } = rebuild;
         let mut built_rate = rate;
         loop {
@@ -1397,8 +1398,7 @@ impl Engine {
                     ChannelHost::build(
                         built_rate,
                         &settings,
-                        pcm_tx.clone(),
-                        pcm_pos.clone(),
+                        sinks.clone(),
                         self.decoded_sink(ds, id),
                     )
                     .map_err(EngineError::from)
@@ -1430,7 +1430,7 @@ impl Engine {
                     // rather than leave a stale-rate pipeline running.
                     tracing::error!(ds, channel = id, error = %e, "channel rebuild failed after rate change; removing channel");
                     state.channels.retain(|c| c.id != id);
-                    dead.extend(state.audio.remove(&id));
+                    dead.extend(state.media.remove(&id));
                     state.send_dsp(stream, DspCommand::RemoveChannel { id });
                     inner.revision += 1;
                 }
@@ -1503,10 +1503,9 @@ impl Engine {
             state.next_channel_id += 1;
             (sample_rate_of(&state.settings), id)
         };
-        let created = ChannelAudio::new()?;
-        let pcm_tx = created.pcm_tx.clone();
-        let pcm_pos = created.pcm_pos.clone();
-        let mut audio = Some(created);
+        let created = ChannelMedia::new()?;
+        let sinks = created.sinks.clone();
+        let mut media = Some(created);
 
         // A rate patch racing between build and insert would leave a wrong-rate DDC, so the
         // rate is re-checked under the lock and the pipeline rebuilt if it moved. The
@@ -1517,8 +1516,7 @@ impl Engine {
                 ChannelHost::build(
                     device_rate,
                     &settings,
-                    pcm_tx.clone(),
-                    pcm_pos.clone(),
+                    sinks.clone(),
                     self.decoded_sink(ds, id),
                 )
                 .map_err(EngineError::from)
@@ -1546,8 +1544,8 @@ impl Engine {
                 stream,
                 settings: settings.clone(),
             });
-            if let Some(handle) = audio.take() {
-                state.audio.insert(id, handle);
+            if let Some(handle) = media.take() {
+                state.media.insert(id, handle);
             }
             state.send_dsp(stream, DspCommand::AddChannel { id, host });
             inner.revision += 1;
@@ -1556,9 +1554,9 @@ impl Engine {
         let id = match staged {
             Ok(id) => id,
             Err(e) => {
-                // The local sender clone must go first or the encoder join would wait on it.
-                drop(pcm_tx);
-                if let Some(handle) = audio.take() {
+                // The local sender clones must go first or the encoder join would wait on them.
+                drop(sinks);
+                if let Some(handle) = media.take() {
                     handle.shutdown();
                 }
                 return Err(e);
@@ -1582,7 +1580,7 @@ impl Engine {
         settings: ChannelSettings,
     ) -> Result<(), EngineError> {
         let descriptor = descriptor_for(&settings.params)?;
-        let (old, pcm_tx, pcm_pos, mut device_rate) = {
+        let (old, sinks, mut device_rate) = {
             let inner = self.lock();
             let state = inner
                 .device_sets
@@ -1594,13 +1592,12 @@ impl Engine {
                 .find(|c| c.id == ch)
                 .ok_or(EngineError::ChannelNotFound(ch, ds))?;
             let handle = state
-                .audio
+                .media
                 .get(&ch)
                 .ok_or(EngineError::ChannelNotFound(ch, ds))?;
             (
                 info.settings.clone(),
-                handle.pcm_tx.clone(),
-                handle.pcm_pos.clone(),
+                handle.sinks.clone(),
                 sample_rate_of(&state.settings),
             )
         };
@@ -1623,8 +1620,7 @@ impl Engine {
                 match ChannelHost::build(
                     device_rate,
                     &settings,
-                    pcm_tx.clone(),
-                    pcm_pos.clone(),
+                    sinks.clone(),
                     self.decoded_sink(ds, ch),
                 ) {
                     Ok(host) => Some(host),
@@ -1708,7 +1704,7 @@ impl Engine {
                 .map(|c| c.stream)
                 .ok_or(EngineError::ChannelNotFound(ch, ds))?;
             state.channels.retain(|c| c.id != ch);
-            let handle = state.audio.remove(&ch);
+            let handle = state.media.remove(&ch);
             // Queued under `inner` in the same critical section as the state removal: every
             // rebuild swap re-checks membership under `inner` before queueing, so nothing
             // can re-add the host after this — the DSP-side PCM sender is guaranteed to
@@ -1901,10 +1897,43 @@ impl Engine {
             .get(&ds)
             .ok_or(EngineError::DeviceSetNotFound(ds))?;
         let handle = state
-            .audio
+            .media
             .get(&ch)
             .ok_or(EngineError::ChannelNotFound(ch, ds))?;
         Ok(handle.audio_tx.subscribe())
+    }
+
+    /// Subscribe to a channel's picture stream (PLAN §5 SubscribeVideo). A channel whose type
+    /// scans out nothing is refused rather than handed a stream that would stay silent: a panel
+    /// waiting forever on a mode that has no video looks exactly like a broken receiver.
+    pub fn subscribe_video(
+        &self,
+        ds: u32,
+        ch: u32,
+    ) -> Result<broadcast::Receiver<VideoPacket>, EngineError> {
+        let inner = self.lock();
+        let state = inner
+            .device_sets
+            .get(&ds)
+            .ok_or(EngineError::DeviceSetNotFound(ds))?;
+        let info = state
+            .channels
+            .iter()
+            .find(|c| c.id == ch)
+            .ok_or(EngineError::ChannelNotFound(ch, ds))?;
+        let descriptor = descriptor_for(&info.settings.params)?;
+        if !descriptor.has_video {
+            return Err(ChannelError::InvalidSettings(format!(
+                "{} produces no video",
+                descriptor.name
+            ))
+            .into());
+        }
+        let handle = state
+            .media
+            .get(&ch)
+            .ok_or(EngineError::ChannelNotFound(ch, ds))?;
+        Ok(handle.sinks.video_tx.subscribe())
     }
 
     /// Every compiled-in channel type (PLAN §5 GET channel types). The registry lives in
@@ -2131,7 +2160,7 @@ fn teardown_set(mut removed: DeviceSetState) -> bool {
     }
     lock_runtime(&removed.runtime).stop();
     let finalized = removed.recording.take().map(RecordingState::join).is_some();
-    for (_, handle) in removed.audio.drain() {
+    for (_, handle) in removed.media.drain() {
         handle.shutdown();
     }
     finalized

--- a/crates/engine/src/runtime.rs
+++ b/crates/engine/src/runtime.rs
@@ -32,6 +32,7 @@ use tokio::sync::broadcast;
 use crate::{
     audio::{PcmBlock, PcmPayload},
     recording::RecorderTap,
+    video::VideoPacket,
 };
 
 /// FFT size for the spectrum tap (PLAN §9: 1k–64k configurable; M0 fixes one size).
@@ -125,12 +126,26 @@ impl DecodedSink {
     }
 }
 
-/// One hosted channel on the DSP thread: DDC → channel filter → squelch gate → demod → PCM
-/// broadcast. The filter confines both the squelch measurement and the demod input to the
-/// mode's occupied bandwidth, so the gate cannot open on adjacent-channel energy and the
+/// The per-channel stream identities a host writes into, and the shared positions that keep
+/// their timelines continuous across a pipeline rebuild. Carried as one value because a rebuild
+/// hands the replacement host exactly what the old one had — a subscriber must not be able to
+/// tell that the pipeline under it was swapped.
+#[derive(Clone)]
+pub(crate) struct ChannelSinks {
+    pub(crate) pcm_tx: broadcast::Sender<PcmBlock>,
+    /// 48 kHz-domain position of the channel's next PCM sample.
+    pub(crate) pcm_pos: Arc<AtomicU64>,
+    pub(crate) video_tx: broadcast::Sender<VideoPacket>,
+    /// Channel-rate samples this channel has demodulated, which stamps its pictures.
+    pub(crate) video_pos: Arc<AtomicU64>,
+}
+
+/// One hosted channel on the DSP thread: DDC → channel filter → squelch gate → demod → PCM and
+/// picture broadcasts. The filter confines both the squelch measurement and the demod input to
+/// the mode's occupied bandwidth, so the gate cannot open on adjacent-channel energy and the
 /// detector never sees it. Built control-side (construction may allocate and fail), then
 /// moved to the DSP thread, where `process` runs lock-free with only the documented bounded
-/// PCM hand-off (see the send site).
+/// hand-offs (see the send sites).
 pub(crate) struct ChannelHost {
     ddc: Ddc,
     filter: ChannelFilter,
@@ -148,12 +163,17 @@ pub(crate) struct ChannelHost {
     /// zero-fill stays duration-accurate (WFM decimates 5:1 inside the demod).
     pcm_per_input: f64,
     zero_carry: f64,
-    /// 48 kHz-domain position of the channel's next PCM sample. Shared through the
-    /// channel's audio identity so stamps stay continuous across pipeline rebuilds; only
-    /// the DSP thread advances it (hosts are swapped, never concurrent), so `Relaxed`
-    /// suffices — the stamps consumers act on travel inside the messages themselves.
-    pcm_pos: Arc<AtomicU64>,
-    pcm_tx: broadcast::Sender<PcmBlock>,
+    /// Where this channel's output goes. The positions inside are shared through the channel's
+    /// media identity so stamps stay continuous across pipeline rebuilds; only the DSP thread
+    /// advances them (hosts are swapped, never concurrent), so `Relaxed` suffices — the stamps
+    /// consumers act on travel inside the messages themselves.
+    sinks: ChannelSinks,
+    /// Whether this channel scans out pictures, which decides whether the video position is
+    /// worth advancing at all.
+    produces_video: bool,
+    /// Pictures sent by *this* host. Restarts with the host, unlike the position above: it
+    /// numbers frames for display and nothing downstream resynchronizes on it.
+    video_seq: u32,
     /// Offset from the device center, mirrored from the settings so decoder frames can be
     /// stamped with the absolute frequency they were heard on.
     offset_hz: f64,
@@ -170,8 +190,7 @@ impl ChannelHost {
     pub(crate) fn build(
         device_rate: f64,
         settings: &ChannelSettings,
-        pcm_tx: broadcast::Sender<PcmBlock>,
-        pcm_pos: Arc<AtomicU64>,
+        sinks: ChannelSinks,
         decoded: DecodedSink,
     ) -> Result<Box<Self>, ChannelError> {
         let type_id = settings.params.type_id();
@@ -207,8 +226,9 @@ impl ChannelHost {
             filtered: Vec::new(),
             pcm_per_input: f64::from(AUDIO_RATE) / input_rate,
             zero_carry: 0.0,
-            pcm_pos,
-            pcm_tx,
+            sinks,
+            produces_video: descriptor.has_video,
+            video_seq: 0,
             offset_hz: settings.offset_hz,
             decoded,
             emits_events: descriptor.decoder_kind.is_some(),
@@ -226,19 +246,22 @@ impl ChannelHost {
             Some(_) => self.squelch.process(&self.filtered),
             None => true,
         };
+        // A picture is stamped with how much of the channel's own stream has gone by, so the
+        // clock has to run whether or not the gate is open — a closed squelch is a gap in the
+        // video, and it has to read as one.
+        let video_pos = if self.produces_video {
+            self.sinks
+                .video_pos
+                .fetch_add(self.filtered.len() as u64, Ordering::Relaxed)
+                + self.filtered.len() as u64
+        } else {
+            0
+        };
         // send() only errors with no receivers (encoder mid-teardown) — expected and fine.
         if open {
             self.outputs.reset();
             self.rx.process(&self.filtered, &mut self.outputs);
-            // Decoder frames are rare (a handful per second even under ADS-B traffic), so
-            // draining owned events here costs the same bounded, documented deviation from
-            // PLAN §7's no-allocation letter as the PCM hand-off below.
-            if !self.outputs.events.is_empty() {
-                let freq_hz = center_hz + self.offset_hz;
-                for event in self.outputs.events.drain(..) {
-                    self.decoded.publish(freq_hz, event);
-                }
-            }
+            self.publish_frames(center_hz, video_pos);
             if !self.outputs.audio_pcm.is_empty() {
                 // Deliberate bounded deviation from PLAN §7's "no allocation/locks" letter:
                 // handing PCM to the encoder costs one Arc copy plus a tokio broadcast send
@@ -246,9 +269,10 @@ impl ChannelHost {
                 // ~25 ms block, and no other thread ever holds that lock across blocking
                 // work — the DSP thread cannot stall on it.
                 let stamp = self
+                    .sinks
                     .pcm_pos
                     .fetch_add(self.outputs.audio_pcm.len() as u64, Ordering::Relaxed);
-                let _ = self.pcm_tx.send(PcmBlock {
+                let _ = self.sinks.pcm_tx.send(PcmBlock {
                     start_sample: stamp,
                     payload: PcmPayload::Samples(Arc::from(self.outputs.audio_pcm.as_slice())),
                 });
@@ -266,12 +290,7 @@ impl ChannelHost {
                     .resize(self.filtered.len(), Complex::new(0.0, 0.0));
                 self.outputs.reset();
                 self.rx.process(&self.gated, &mut self.outputs);
-                if !self.outputs.events.is_empty() {
-                    let freq_hz = center_hz + self.offset_hz;
-                    for event in self.outputs.events.drain(..) {
-                        self.decoded.publish(freq_hz, event);
-                    }
-                }
+                self.publish_frames(center_hz, video_pos);
             }
             // A closed gate still emits (zeroed) audio so client jitter buffers stay alive;
             // silence travels as a bare length, so this path allocates nothing.
@@ -279,12 +298,38 @@ impl ChannelHost {
             let zeros = self.zero_carry as usize;
             if zeros > 0 {
                 self.zero_carry -= zeros as f64;
-                let stamp = self.pcm_pos.fetch_add(zeros as u64, Ordering::Relaxed);
-                let _ = self.pcm_tx.send(PcmBlock {
+                let stamp = self
+                    .sinks
+                    .pcm_pos
+                    .fetch_add(zeros as u64, Ordering::Relaxed);
+                let _ = self.sinks.pcm_tx.send(PcmBlock {
                     start_sample: stamp,
                     payload: PcmPayload::Silence(zeros),
                 });
             }
+        }
+    }
+
+    /// Hand whatever the channel just produced — decoder frames and pictures — to the control
+    /// plane. Shared by both squelch branches so a mode that produces both, and is fed silence
+    /// through a closed gate, cannot have half its output dropped by the next `reset`.
+    fn publish_frames(&mut self, center_hz: f64, video_pos: u64) {
+        // Decoder frames are rare (a handful per second even under ADS-B traffic) and a picture
+        // is one `Arc` fifty times a second, so draining owned output here costs the same
+        // bounded, documented deviation from PLAN §7's no-allocation letter as the PCM hand-off.
+        if !self.outputs.events.is_empty() {
+            let freq_hz = center_hz + self.offset_hz;
+            for event in self.outputs.events.drain(..) {
+                self.decoded.publish(freq_hz, event);
+            }
+        }
+        for picture in self.outputs.video.drain(..) {
+            let _ = self.sinks.video_tx.send(VideoPacket {
+                seq: self.video_seq,
+                timestamp: video_pos,
+                picture: Arc::new(picture),
+            });
+            self.video_seq = self.video_seq.wrapping_add(1);
         }
     }
 
@@ -714,13 +759,22 @@ mod tests {
         }
     }
 
+    /// A fresh media identity around `pcm_tx`, as the engine builds one per channel.
+    fn sinks(pcm_tx: broadcast::Sender<PcmBlock>, pcm_pos: Arc<AtomicU64>) -> ChannelSinks {
+        ChannelSinks {
+            pcm_tx,
+            pcm_pos,
+            video_tx: broadcast::channel(8).0,
+            video_pos: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
     fn host(settings: &ChannelSettings) -> (Box<ChannelHost>, broadcast::Receiver<PcmBlock>) {
         let (pcm_tx, pcm_rx) = broadcast::channel(4096);
         let host = ChannelHost::build(
             RATE,
             settings,
-            pcm_tx,
-            Arc::new(AtomicU64::new(0)),
+            sinks(pcm_tx, Arc::new(AtomicU64::new(0))),
             DecodedSink::null(),
         )
         .expect("host builds");
@@ -858,8 +912,7 @@ mod tests {
         let mut host = ChannelHost::build(
             RATE,
             &settings,
-            pcm_tx.clone(),
-            pos.clone(),
+            sinks(pcm_tx.clone(), pos.clone()),
             DecodedSink::null(),
         )
         .expect("host");
@@ -868,7 +921,7 @@ mod tests {
             host.process(chunk, 0.0);
         }
         // Swap in a fresh host the way a device rate change does.
-        let mut host = ChannelHost::build(RATE, &settings, pcm_tx, pos, DecodedSink::null())
+        let mut host = ChannelHost::build(RATE, &settings, sinks(pcm_tx, pos), DecodedSink::null())
             .expect("rebuilt host");
         for chunk in input.chunks(BLOCK) {
             host.process(chunk, 0.0);

--- a/crates/engine/src/video.rs
+++ b/crates/engine/src/video.rs
@@ -1,0 +1,28 @@
+//! Per-channel picture hand-off (PLAN §13: ATV). The counterpart of [`crate::audio`], and
+//! deliberately thinner: a picture is 8-bit luma a client draws straight into a canvas, so there
+//! is no encoder thread between the DSP plane and the socket — what the demodulator scanned out
+//! is what the WebSocket sends.
+
+use std::sync::Arc;
+
+use sdrmm_channels::VideoPicture;
+
+/// Fields arrive at 50–60 Hz and a picture is tens of kilobytes, so eight buffers is a sixth of
+/// a second of slack before the drop-oldest contract sheds the stale ones (PLAN §5). Deeper
+/// would only mean handing a client older pictures: nothing downstream wants anything but the
+/// newest one.
+pub(crate) const VIDEO_CHANNEL_CAP: usize = 8;
+
+/// One picture on its way to the clients watching a channel.
+#[derive(Clone, Debug)]
+pub struct VideoPacket {
+    /// Pictures since this pipeline started. Restarts when the pipeline is rebuilt (a params
+    /// type change, a device rate change) — it counts frames for display, and it is
+    /// [`VideoPacket::timestamp`] that stays continuous across the swap.
+    pub seq: u32,
+    /// Channel-rate sample count when the picture completed, which makes the gap between two
+    /// pictures legible as the time it really was.
+    pub timestamp: u64,
+    /// Shared rather than copied: one picture reaches every subscribed client.
+    pub picture: Arc<VideoPicture>,
+}

--- a/crates/engine/tests/video.rs
+++ b/crates/engine/tests/video.rs
@@ -1,0 +1,164 @@
+//! Video end-to-end (PLAN §13: ATV, §14: "engine end-to-end via `device-virtual`").
+//!
+//! Renders a standards-timed ATV transmission with `sdrmm_channels::testgen`, plants it as a
+//! SigMF pair, replays it through the `virtual:file:` playback device, and asserts a picture
+//! comes out of the engine's per-channel video broadcast with the geometry and the content that
+//! went in.
+//!
+//! The counterpart of `decode.rs` for the other output a channel can have: the ATV unit tests
+//! prove the demodulation, this proves a picture survives the DDC's rate conversion, the bounded
+//! hand-off off the DSP thread and the broadcast. The device therefore runs at 2.4 Msps against
+//! the mode's 2 Msps channel, so a real resampler is in the path.
+//!
+//! Hermetic: tempdir only, no fixture files, no hardware.
+
+// Tests may unwrap/expect (CLAUDE.md); clippy's `allow-unwrap-in-tests` only covers
+// `#[cfg(test)]` items, which an integration-test crate's helpers are not.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{sync::Arc, time::Duration};
+
+use sdrmm_device::DeviceRegistry;
+use sdrmm_device_virtual::VirtualDriver;
+use sdrmm_engine::Engine;
+use sdrmm_recorder::SigmfWriter;
+use sdrmm_wire::{
+    AtvModulation, AtvParams, AtvStandard, ChannelParams, ChannelSettings, NfmParams,
+};
+use tempfile::TempDir;
+
+/// Playback is real-time paced, and the receiver has to hunt sync before it scans anything out;
+/// the timeout covers a full loop pass plus scheduler slack on a loaded CI box.
+const VIDEO_TIMEOUT: Duration = Duration::from_secs(30);
+/// Deliberately not the mode's 2 Msps channel rate: the DDC has to decimate for this to prove
+/// anything about the plumbing.
+const DEVICE_RATE: f64 = 2_400_000.0;
+const CENTER_HZ: f64 = 434_250_000.0;
+const OFFSET_HZ: f64 = 200_000.0;
+
+fn atv_params() -> AtvParams {
+    AtvParams {
+        modulation: AtvModulation::Am,
+        standard: AtvStandard::Ccir625,
+        ..AtvParams::default()
+    }
+}
+
+#[tokio::test]
+async fn an_atv_transmission_reaches_the_video_stream_as_a_picture() {
+    let dir = TempDir::new().unwrap();
+    let mut registry = DeviceRegistry::new();
+    registry.register(
+        10,
+        Box::new(VirtualDriver::with_recordings(dir.path().to_path_buf())),
+    );
+    let engine = Arc::new(Engine::with_registry(
+        registry,
+        Some(dir.path().to_path_buf()),
+    ));
+
+    let params = atv_params();
+    let source = sdrmm_channels::testgen::atv::AtvSource::new(&params, DEVICE_RATE);
+    let mut iq = sdrmm_channels::testgen::atv::bars(&source, 8);
+    sdrmm_channels::testgen::shift(&mut iq, OFFSET_HZ, DEVICE_RATE);
+
+    let path = dir.path().join("atv");
+    let mut writer = SigmfWriter::create(&path, DEVICE_RATE, CENTER_HZ, "atv fixture").unwrap();
+    writer.write_block(&iq).unwrap();
+    writer.finalize().unwrap();
+    let device = format!("virtual:file:{}", path.display());
+
+    let ds = engine.create_device_set(&device).unwrap();
+    let ch = engine
+        .add_channel(
+            ds,
+            0,
+            ChannelSettings {
+                offset_hz: OFFSET_HZ,
+                squelch_db: None,
+                params: ChannelParams::Atv(params),
+            },
+        )
+        .unwrap();
+    let mut rx = engine.subscribe_video(ds, ch).unwrap();
+
+    let packet = tokio::time::timeout(VIDEO_TIMEOUT, async {
+        loop {
+            match rx.recv().await {
+                Ok(packet) => return packet,
+                // Drop-oldest is the contract for this stream; a starved runner may lag.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("video stream closed")
+                }
+            }
+        }
+    })
+    .await;
+    engine.remove_device_set(ds).unwrap();
+    let packet = packet.expect("a picture within the timeout");
+
+    let picture = &packet.picture;
+    assert_eq!(picture.height, 576, "CCIR 625 scans out 576 active lines");
+    assert_eq!(
+        picture.luma.len(),
+        usize::from(picture.width) * usize::from(picture.height),
+        "the payload must be exactly the geometry it claims"
+    );
+    assert!(
+        packet.timestamp > 0,
+        "the picture must be stamped with the channel's own sample clock"
+    );
+
+    // The bar pattern, read off a row well inside the picture: black on the left, white on the
+    // right. Rate-converted and replayed in real time, so this is the whole path's answer.
+    let width = usize::from(picture.width);
+    let row = 300 * width;
+    let mean = |from: usize, to: usize| {
+        let span = &picture.luma[row + from..row + to];
+        span.iter().map(|&v| u32::from(v)).sum::<u32>() / span.len() as u32
+    };
+    let black = mean(width / 20, width / 8);
+    let white = mean(width * 7 / 8, width * 19 / 20);
+    assert!(black < 60, "left bar should be black, got {black}");
+    assert!(white > 190, "right bar should be white, got {white}");
+}
+
+/// A mode that scans out nothing must refuse the subscription rather than open a stream that
+/// would stay silent — a panel waiting on it is indistinguishable from a dead receiver.
+#[tokio::test]
+async fn a_channel_without_video_refuses_the_subscription() {
+    let dir = TempDir::new().unwrap();
+    let mut registry = DeviceRegistry::new();
+    registry.register(
+        10,
+        Box::new(VirtualDriver::with_recordings(dir.path().to_path_buf())),
+    );
+    let engine = Arc::new(Engine::with_registry(
+        registry,
+        Some(dir.path().to_path_buf()),
+    ));
+
+    let ds = engine.create_device_set("virtual:siggen").unwrap();
+    let ch = engine
+        .add_channel(
+            ds,
+            0,
+            ChannelSettings {
+                offset_hz: 0.0,
+                squelch_db: None,
+                params: ChannelParams::Nfm(NfmParams::default()),
+            },
+        )
+        .unwrap();
+    let refused = engine.subscribe_video(ds, ch).unwrap_err();
+    assert!(refused.is_bad_request(), "{refused}");
+    assert!(
+        engine
+            .subscribe_video(ds, ch + 1)
+            .unwrap_err()
+            .is_not_found(),
+        "an unknown channel is a 404, not a bad request"
+    );
+    engine.remove_device_set(ds).unwrap();
+}

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -1,5 +1,5 @@
 //! WebSocket hub (PLAN §5): one socket per client carrying JSON events + client commands and
-//! binary spectrum/audio frames. A single writer task owns the sink; event and
+//! binary spectrum/audio/video frames. A single writer task owns the sink; event and
 //! per-subscription stream tasks feed it through a bounded mpsc. Stream tasks *await* that
 //! send: a full queue backpressures the task, its broadcast receiver lags, and tokio's
 //! broadcast sheds the oldest entries — drop-oldest per connection (PLAN §5). Control events
@@ -19,8 +19,10 @@ use axum::{
 };
 use futures::{SinkExt, StreamExt};
 use sdrmm_dsp::{decimate_max, quantize_db};
-use sdrmm_engine::{AudioPacket, Engine, SpectrumSnapshot, adaptive_db_window};
-use sdrmm_wire::{AudioFrame, ClientCommand, ServerEvent, SpectrumFrame, StateScope, StreamKind};
+use sdrmm_engine::{AudioPacket, Engine, SpectrumSnapshot, VideoPacket, adaptive_db_window};
+use sdrmm_wire::{
+    AudioFrame, ClientCommand, ServerEvent, SpectrumFrame, StateScope, StreamKind, VideoFrame,
+};
 use tokio::sync::{broadcast, mpsc};
 
 use crate::AppState;
@@ -31,15 +33,19 @@ const MAX_BINS: usize = 4096;
 const MAX_FPS: u16 = 60;
 /// `ch_layout` header byte for mono audio frames (PLAN §5 frame layout).
 const CH_LAYOUT_MONO: u8 = 1;
-/// Audio stream ids live in `AUDIO_ID_BASE..=u16::MAX` and spectrum ids in `0..AUDIO_ID_BASE`, so
-/// the two can never collide on one connection.
+/// Per-channel media ids — audio and video alike — live in `MEDIA_ID_BASE..=u16::MAX` and
+/// spectrum ids in `0..MEDIA_ID_BASE`, so no two streams on one connection can collide.
 ///
 /// A spectrum id used to *be* the device-set id, which a multi-stream radio broke: several lanes
-/// of one set can be watched at once, and they need ids of their own to be told apart. Both kinds
-/// are now allocated per connection and reported in the `…StreamStarted` event that answers the
+/// of one set can be watched at once, and they need ids of their own to be told apart. Every kind
+/// is now allocated per connection and reported in the `…StreamStarted` event that answers the
 /// subscribe.
-const AUDIO_ID_BASE: u16 = 0x8000;
-/// First spectrum id. Ids run `SPECTRUM_ID_BASE..AUDIO_ID_BASE`.
+///
+/// Audio and video share one range and one allocator rather than splitting it: a client keys a
+/// sink on `(kind, id)`, and one space is what lets a channel's picture and its sound be told
+/// apart from every other channel's without reasoning about which half of the range they fell in.
+const MEDIA_ID_BASE: u16 = 0x8000;
+/// First spectrum id. Ids run `SPECTRUM_ID_BASE..MEDIA_ID_BASE`.
 const SPECTRUM_ID_BASE: u16 = 0;
 
 pub(crate) async fn handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
@@ -134,9 +140,11 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     // of a multi-stream device, so a subscribe on one lane must not replace another's.
     let mut spectra: HashMap<(u32, u32), (u16, tokio::task::JoinHandle<()>)> = HashMap::new();
     let mut next_spectrum_id: u16 = SPECTRUM_ID_BASE;
-    // Audio streams keyed by (device_set, channel); resubscribing replaces the running task.
+    // Audio and video streams keyed by (device_set, channel); resubscribing replaces the
+    // running task. Ids come from one counter across both, so `(kind, id)` is unique per socket.
     let mut audio: HashMap<(u32, u32), (u16, tokio::task::JoinHandle<()>)> = HashMap::new();
-    let mut next_audio_id: u16 = AUDIO_ID_BASE;
+    let mut video: HashMap<(u32, u32), (u16, tokio::task::JoinHandle<()>)> = HashMap::new();
+    let mut next_media_id: u16 = MEDIA_ID_BASE;
 
     while let Some(Ok(msg)) = ws_rx.next().await {
         match msg {
@@ -176,7 +184,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                 let live = |id: u16| spectra.values().any(|(sid, _)| *sid == id);
                                 match alloc_stream_id(
                                     &mut next_spectrum_id,
-                                    SPECTRUM_ID_BASE..=AUDIO_ID_BASE - 1,
+                                    SPECTRUM_ID_BASE..=MEDIA_ID_BASE - 1,
                                     live,
                                 ) {
                                     Some(stream_id) => {
@@ -251,10 +259,10 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                     };
                                     let _ = out_tx.send(text_event(&stopped)).await;
                                 }
-                                let live = |id: u16| audio.values().any(|(sid, _)| *sid == id);
+                                let live = |id: u16| media_id_live(&audio, &video, id);
                                 match alloc_stream_id(
-                                    &mut next_audio_id,
-                                    AUDIO_ID_BASE..=u16::MAX,
+                                    &mut next_media_id,
+                                    MEDIA_ID_BASE..=u16::MAX,
                                     live,
                                 ) {
                                     Some(stream_id) => {
@@ -269,7 +277,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                     }
                                     None => {
                                         let err = ServerEvent::Error {
-                                            message: "no free audio stream ids on this connection"
+                                            message: "no free media stream ids on this connection"
                                                 .to_string(),
                                         };
                                         let _ = out_tx.send(text_event(&err)).await;
@@ -296,6 +304,74 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                             let _ = out_tx.send(text_event(&stopped)).await;
                         }
                     }
+                    Ok(ClientCommand::SubscribeVideo {
+                        device_set,
+                        channel,
+                    }) => {
+                        let subscribe = {
+                            let engine = engine.clone();
+                            tokio::task::spawn_blocking(move || {
+                                engine.subscribe_video(device_set, channel)
+                            })
+                            .await
+                        };
+                        match flatten_join(subscribe) {
+                            Ok(rx) => {
+                                // Replacing a running stream for this (ds, ch): stop the old id
+                                // loudly first, exactly as the audio path does.
+                                if let Some((old_id, old)) = video.remove(&(device_set, channel)) {
+                                    old.abort();
+                                    let stopped = ServerEvent::StreamStopped {
+                                        stream_id: old_id,
+                                        kind: StreamKind::Video,
+                                    };
+                                    let _ = out_tx.send(text_event(&stopped)).await;
+                                }
+                                let live = |id: u16| media_id_live(&audio, &video, id);
+                                match alloc_stream_id(
+                                    &mut next_media_id,
+                                    MEDIA_ID_BASE..=u16::MAX,
+                                    live,
+                                ) {
+                                    Some(stream_id) => {
+                                        let started = ServerEvent::VideoStreamStarted {
+                                            stream_id,
+                                            device_set,
+                                            channel,
+                                        };
+                                        let _ = out_tx.send(text_event(&started)).await;
+                                        let task = spawn_video(stream_id, rx, out_tx.clone());
+                                        video.insert((device_set, channel), (stream_id, task));
+                                    }
+                                    None => {
+                                        let err = ServerEvent::Error {
+                                            message: "no free media stream ids on this connection"
+                                                .to_string(),
+                                        };
+                                        let _ = out_tx.send(text_event(&err)).await;
+                                    }
+                                }
+                            }
+                            Err(message) => {
+                                let _ = out_tx
+                                    .send(text_event(&ServerEvent::Error { message }))
+                                    .await;
+                            }
+                        }
+                    }
+                    Ok(ClientCommand::UnsubscribeVideo {
+                        device_set,
+                        channel,
+                    }) => {
+                        if let Some((stream_id, task)) = video.remove(&(device_set, channel)) {
+                            task.abort();
+                            let stopped = ServerEvent::StreamStopped {
+                                stream_id,
+                                kind: StreamKind::Video,
+                            };
+                            let _ = out_tx.send(text_event(&stopped)).await;
+                        }
+                    }
                     Err(_) => {
                         let err = ServerEvent::Error {
                             message: "invalid command".to_string(),
@@ -313,6 +389,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         task.abort();
     }
     for (_, (_, task)) in audio {
+        task.abort();
+    }
+    for (_, (_, task)) in video {
         task.abort();
     }
     events.abort();
@@ -342,8 +421,8 @@ fn flatten_join<T>(
 /// live stream on this connection, so a long-lived socket can never hand a live id to a second
 /// stream. `None` only once every id in the range is live.
 ///
-/// One allocator for both kinds: spectrum and audio draw from disjoint ranges (see
-/// [`AUDIO_ID_BASE`]) but the rule is identical, and two copies of it would be two places for the
+/// One allocator for every kind: spectrum and the media streams draw from disjoint ranges (see
+/// [`MEDIA_ID_BASE`]) but the rule is identical, and two copies of it would be two places for the
 /// wrap to be wrong.
 fn alloc_stream_id(
     next: &mut u16,
@@ -617,6 +696,64 @@ fn spawn_audio(
     })
 }
 
+/// Whether `id` is bound to a live media stream of either kind on this connection. One check
+/// across both maps, because both draw from [`MEDIA_ID_BASE`].
+fn media_id_live(
+    audio: &HashMap<(u32, u32), (u16, tokio::task::JoinHandle<()>)>,
+    video: &HashMap<(u32, u32), (u16, tokio::task::JoinHandle<()>)>,
+    id: u16,
+) -> bool {
+    audio
+        .values()
+        .chain(video.values())
+        .any(|(sid, _)| *sid == id)
+}
+
+/// Per-subscription task: forward the channel's pictures as binary [`VideoFrame`]s with the same
+/// drop-oldest backpressure as [`spawn_audio`]. A shed picture is simply a frame the client never
+/// draws — unlike audio there is nothing to conceal a gap from, so the next one is the whole
+/// recovery.
+fn spawn_video(
+    stream_id: u16,
+    mut rx: broadcast::Receiver<VideoPacket>,
+    out_tx: mpsc::Sender<Message>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(packet) => {
+                    let frame = VideoFrame {
+                        stream_id,
+                        seq: packet.seq,
+                        timestamp: packet.timestamp,
+                        width: packet.picture.width,
+                        height: packet.picture.height,
+                        luma: &packet.picture.luma,
+                    }
+                    .encode();
+
+                    // Awaited on purpose: backpressure lags the broadcast receiver and the
+                    // oldest pictures are shed (drop-oldest, PLAN §5).
+                    if out_tx.send(Message::Binary(frame.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => {
+                    // The channel or its device set was removed. Tell the client the stream
+                    // ended (no silent termination, CLAUDE.md).
+                    let stopped = ServerEvent::StreamStopped {
+                        stream_id,
+                        kind: StreamKind::Video,
+                    };
+                    let _ = out_tx.send(text_event(&stopped)).await;
+                    break;
+                }
+            }
+        }
+    })
+}
+
 fn text_event(ev: &ServerEvent) -> Message {
     Message::Text(encode_event(ev))
 }
@@ -724,6 +861,111 @@ mod tests {
             offset_hz,
             squelch_db: None,
             params: ChannelParams::Nfm(NfmParams::default()),
+        }
+    }
+
+    fn atv_channel() -> ChannelSettings {
+        ChannelSettings {
+            offset_hz: 0.0,
+            squelch_db: None,
+            params: ChannelParams::Atv(sdrmm_wire::AtvParams::default()),
+        }
+    }
+
+    /// The video subscription's lifecycle, and the rule that keeps a panel honest: a channel that
+    /// scans out pictures gets an id from the same media range audio does — never one already in
+    /// use by an audio stream on this socket — and a channel that scans out nothing is refused
+    /// rather than handed a stream that would stay empty.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn video_lifecycle_shares_the_media_id_space_and_refuses_silent_channels() {
+        let engine = test_engine();
+        let ds = engine
+            .create_device_set("virtual:siggen")
+            .expect("device set");
+        let voice = engine
+            .add_channel(ds, 0, nfm_channel(0.0))
+            .expect("nfm channel");
+        let picture = engine
+            .add_channel(ds, 0, atv_channel())
+            .expect("atv channel");
+        let mut ws = connect(engine).await;
+
+        assert!(matches!(
+            next_event(&mut ws).await,
+            ServerEvent::Hello { .. }
+        ));
+
+        send(
+            &mut ws,
+            &ClientCommand::SubscribeAudio {
+                device_set: ds,
+                channel: voice,
+            },
+        )
+        .await;
+        let audio_id = match next_event(&mut ws).await {
+            ServerEvent::AudioStreamStarted { stream_id, .. } => stream_id,
+            other => panic!("expected AudioStreamStarted, got {other:?}"),
+        };
+
+        send(
+            &mut ws,
+            &ClientCommand::SubscribeVideo {
+                device_set: ds,
+                channel: picture,
+            },
+        )
+        .await;
+        let video_id = match next_event(&mut ws).await {
+            ServerEvent::VideoStreamStarted {
+                stream_id,
+                device_set,
+                channel,
+            } => {
+                assert!(
+                    stream_id >= MEDIA_ID_BASE,
+                    "video id {stream_id:#x} collides with the spectrum range"
+                );
+                assert_eq!((device_set, channel), (ds, picture));
+                stream_id
+            }
+            other => panic!("expected VideoStreamStarted, got {other:?}"),
+        };
+        assert_ne!(
+            video_id, audio_id,
+            "a live audio id must not be handed to a video stream"
+        );
+
+        send(
+            &mut ws,
+            &ClientCommand::UnsubscribeVideo {
+                device_set: ds,
+                channel: picture,
+            },
+        )
+        .await;
+        match next_event(&mut ws).await {
+            ServerEvent::StreamStopped { stream_id, kind } => {
+                assert_eq!(stream_id, video_id);
+                assert_eq!(kind, StreamKind::Video);
+            }
+            other => panic!("expected StreamStopped, got {other:?}"),
+        }
+
+        // A mode with no picture: the refusal has to name the mode, not just say no.
+        send(
+            &mut ws,
+            &ClientCommand::SubscribeVideo {
+                device_set: ds,
+                channel: voice,
+            },
+        )
+        .await;
+        match next_event(&mut ws).await {
+            ServerEvent::Error { message } => {
+                assert!(message.contains("no video"), "unhelpful: {message}");
+            }
+            other => panic!("expected a refusal, got {other:?}"),
         }
     }
 
@@ -870,7 +1112,7 @@ mod tests {
         send(
             &mut ws,
             &ClientCommand::SubscribeSpectrum {
-                device_set: u32::from(AUDIO_ID_BASE),
+                device_set: u32::from(MEDIA_ID_BASE),
                 fps: 30,
                 bins: 64,
                 stream: 0,
@@ -944,7 +1186,7 @@ mod tests {
                 channel,
             } => {
                 assert!(
-                    stream_id >= AUDIO_ID_BASE,
+                    stream_id >= MEDIA_ID_BASE,
                     "audio id {stream_id:#x} collides with spectrum range"
                 );
                 assert_eq!(device_set, ds);
@@ -968,7 +1210,7 @@ mod tests {
             other => panic!("expected AudioStreamStarted, got {other:?}"),
         };
         assert_ne!(second_id, first_id);
-        assert!(second_id >= AUDIO_ID_BASE);
+        assert!(second_id >= MEDIA_ID_BASE);
 
         send(
             &mut ws,
@@ -989,26 +1231,26 @@ mod tests {
 
     #[test]
     fn audio_id_allocator_wraps_within_range_and_skips_live_ids() {
-        let mut next = AUDIO_ID_BASE;
-        let live = [AUDIO_ID_BASE, AUDIO_ID_BASE + 1];
+        let mut next = MEDIA_ID_BASE;
+        let live = [MEDIA_ID_BASE, MEDIA_ID_BASE + 1];
         assert_eq!(
-            alloc_stream_id(&mut next, AUDIO_ID_BASE..=u16::MAX, |id| live.contains(&id)),
-            Some(AUDIO_ID_BASE + 2)
+            alloc_stream_id(&mut next, MEDIA_ID_BASE..=u16::MAX, |id| live.contains(&id)),
+            Some(MEDIA_ID_BASE + 2)
         );
 
         let mut next = u16::MAX;
         assert_eq!(
-            alloc_stream_id(&mut next, AUDIO_ID_BASE..=u16::MAX, |_| false),
+            alloc_stream_id(&mut next, MEDIA_ID_BASE..=u16::MAX, |_| false),
             Some(u16::MAX)
         );
         assert_eq!(
-            next, AUDIO_ID_BASE,
+            next, MEDIA_ID_BASE,
             "must wrap into the audio range, not to 0"
         );
 
-        let mut next = AUDIO_ID_BASE;
+        let mut next = MEDIA_ID_BASE;
         assert_eq!(
-            alloc_stream_id(&mut next, AUDIO_ID_BASE..=u16::MAX, |_| true),
+            alloc_stream_id(&mut next, MEDIA_ID_BASE..=u16::MAX, |_| true),
             None
         );
     }
@@ -1074,7 +1316,7 @@ mod tests {
     async fn audio_forwarder_sheds_oldest_and_delivers_newest() {
         let (tx, rx) = broadcast::channel::<AudioPacket>(4);
         let (out_tx, mut out_rx) = mpsc::channel::<Message>(1);
-        let task = spawn_audio(AUDIO_ID_BASE, rx, out_tx);
+        let task = spawn_audio(MEDIA_ID_BASE, rx, out_tx);
 
         let last_seq = 20u32;
         for seq in 0..=last_seq {

--- a/crates/wire/src/channel.rs
+++ b/crates/wire/src/channel.rs
@@ -24,6 +24,12 @@ pub struct ChannelDescriptor {
     /// uses it to pick the panel that renders the events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decoder_kind: Option<String>,
+    /// Whether the channel produces a picture, delivered as [`crate::VideoFrame`] binary frames
+    /// rather than as decoder events (ATV, PLAN §13). The client subscribes and mounts a video
+    /// panel on the channel's face when this is set. Defaults to `false`, which is every mode
+    /// that predates the video transport.
+    #[serde(default)]
+    pub has_video: bool,
     /// The type occupies its whole channel rate, so it runs only with the device tuned to
     /// exactly `input_rate_hz` — a resampling DDC has no guard band left to give it (PLAN §18).
     /// Reported so the canvas can refuse the wire where the operator draws it, naming the rate
@@ -73,6 +79,7 @@ impl Default for ChannelDescriptor {
             input_rate_hz: 0.0,
             has_audio: default_has_audio(),
             decoder_kind: None,
+            has_video: false,
             exact_rate_only: false,
             native_rate_max_hz: None,
             can_transmit: false,
@@ -482,6 +489,104 @@ impl Default for SubghzParams {
     }
 }
 
+/// How an analog television transmission carries its video, and with it the polarity the
+/// demodulated signal arrives in (PLAN §13: ATV).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AtvModulation {
+    /// Amplitude modulation, *negative*: peak carrier is the sync tip and white is the trough,
+    /// which is what broadcast television and 70 cm amateur ATV transmit.
+    #[default]
+    Am,
+    /// Frequency modulation, *positive*: sync sits at the low end of the deviation. The 23 cm
+    /// and up bands, and satellite ATV.
+    Fm,
+}
+
+/// Scanning standard the transmission follows: how many lines make a frame and how fast they
+/// go by. Everything else the demodulator needs — porch widths, active window, blanked lines —
+/// derives from these two numbers plus the standard's own timings.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AtvStandard {
+    /// 625 lines at 25 frames/s — CCIR System B/G geometry, 15 625 Hz lines.
+    #[default]
+    Ccir625,
+    /// 525 lines at 29.97 frames/s — EIA RS-170A, 15 734.264 Hz lines. Monochrome RS-170 runs
+    /// 15 750 Hz, a tenth of a percent away, which the sync tracker absorbs.
+    Eia525,
+    /// 405 lines at 25 frames/s — System A, and the narrow-band standard amateurs still use
+    /// where 625 lines will not fit the channel.
+    SystemA405,
+}
+
+impl AtvStandard {
+    /// Lines per frame, both fields together.
+    #[must_use]
+    pub fn lines(self) -> u16 {
+        match self {
+            Self::Ccir625 => 625,
+            Self::Eia525 => 525,
+            Self::SystemA405 => 405,
+        }
+    }
+
+    /// Line frequency in Hz — the rate horizontal sync arrives at.
+    #[must_use]
+    pub fn line_rate_hz(self) -> f64 {
+        match self {
+            Self::Ccir625 => 15_625.0,
+            Self::Eia525 => 15_734.264,
+            Self::SystemA405 => 10_125.0,
+        }
+    }
+
+    /// Frames per second, which is the line rate divided by the frame's lines.
+    #[must_use]
+    pub fn frame_rate_hz(self) -> f64 {
+        self.line_rate_hz() / f64::from(self.lines())
+    }
+}
+
+fn default_atv_bandwidth_hz() -> f64 {
+    1_500_000.0
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct AtvParams {
+    #[serde(default)]
+    pub modulation: AtvModulation,
+    #[serde(default)]
+    pub standard: AtvStandard,
+    /// Video channel width in Hz. This *is* the horizontal resolution — a picture cannot carry
+    /// more detail per line than the bandwidth that delivered it — so it is the one knob worth
+    /// opening up when the channel is clean, bounded by the mode's IQ rate.
+    #[serde(default = "default_atv_bandwidth_hz")]
+    pub bandwidth_hz: f64,
+    /// Invert the video polarity, for a transmission that keys the opposite way round from its
+    /// modulation's convention (see [`AtvModulation`]). A picture that comes out as a photographic
+    /// negative, with the sync tracker never locking, is what this fixes.
+    #[serde(default)]
+    pub invert: bool,
+    /// Weave the two fields into one frame at their real line positions. Off decodes each
+    /// vertical sync as a whole progressive frame, which is what non-interlaced amateur and
+    /// camera sources send.
+    #[serde(default = "default_true")]
+    pub interlace: bool,
+}
+
+impl Default for AtvParams {
+    fn default() -> Self {
+        Self {
+            modulation: AtvModulation::default(),
+            standard: AtvStandard::default(),
+            bandwidth_hz: default_atv_bandwidth_hz(),
+            invert: false,
+            interlace: true,
+        }
+    }
+}
+
 /// Type-discriminated demod parameters. Adjacently tagged so the generated TS is a
 /// discriminated union on `type`, and `{"type":"nfm","settings":{}}` deserializes with
 /// every field at its default.
@@ -501,6 +606,7 @@ pub enum ChannelParams {
     Navtex(NavtexParams),
     Acars(AcarsParams),
     Subghz(SubghzParams),
+    Atv(AtvParams),
 }
 
 impl ChannelParams {
@@ -521,6 +627,7 @@ impl ChannelParams {
             Self::Navtex(_) => "navtex",
             Self::Acars(_) => "acars",
             Self::Subghz(_) => "subghz",
+            Self::Atv(_) => "atv",
         }
     }
 }

--- a/crates/wire/src/frame.rs
+++ b/crates/wire/src/frame.rs
@@ -19,10 +19,20 @@
 //! AUDIO_OPUS payload:
 //!   u8  ch_layout       (1 = mono)
 //!   u8[] opus           (one Opus packet, to end of frame)
+//! VIDEO_GRAY payload:
+//!   u16 width
+//!   u16 height
+//!   u8[width·height] luma  (row-major from the top line, 0 = black)
 //! ```
 //!
 //! AUDIO_OPUS timestamps count 48 kHz-domain samples since the channel's audio started
 //! (PLAN §9: demods emit 48 kHz PCM before Opus encoding).
+//!
+//! VIDEO_GRAY timestamps count channel-rate IQ samples since the channel started, so a gap
+//! between pictures is legible as the time it really was. The picture is 8-bit luma and
+//! uncompressed: it is one frame per field of an analog scan, sized by what the channel's
+//! bandwidth resolved, and a codec between the demodulator and the canvas would cost more
+//! than the bytes it saved on a desktop link.
 
 /// Protocol version in every frame header. Bump on any layout change.
 pub const PROTOCOL_VERSION: u8 = 1;
@@ -37,6 +47,7 @@ pub enum FrameKind {
     Spectrum = 0,
     AudioOpus = 1,
     IqF32 = 2,
+    VideoGray = 3,
 }
 
 impl FrameKind {
@@ -46,6 +57,7 @@ impl FrameKind {
             0 => Some(Self::Spectrum),
             1 => Some(Self::AudioOpus),
             2 => Some(Self::IqF32),
+            3 => Some(Self::VideoGray),
             _ => None,
         }
     }
@@ -123,6 +135,41 @@ impl AudioFrame<'_> {
         buf.extend_from_slice(&self.timestamp.to_le_bytes());
         buf.push(self.ch_layout);
         buf.extend_from_slice(self.opus);
+        buf
+    }
+}
+
+/// One decoded picture ready to encode: 8-bit luma, row-major, `width · height` bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VideoFrame<'a> {
+    pub stream_id: u16,
+    pub seq: u32,
+    /// Channel-rate sample count when the picture completed.
+    pub timestamp: u64,
+    pub width: u16,
+    pub height: u16,
+    pub luma: &'a [u8],
+}
+
+impl VideoFrame<'_> {
+    /// Serialized length: header + the geometry + one byte per pixel.
+    #[must_use]
+    pub fn encoded_len(&self) -> usize {
+        HEADER_LEN + 2 + 2 + self.luma.len()
+    }
+
+    /// Encode into a fresh little-endian byte buffer.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.encoded_len());
+        buf.push(PROTOCOL_VERSION);
+        buf.push(FrameKind::VideoGray as u8);
+        buf.extend_from_slice(&self.stream_id.to_le_bytes());
+        buf.extend_from_slice(&self.seq.to_le_bytes());
+        buf.extend_from_slice(&self.timestamp.to_le_bytes());
+        buf.extend_from_slice(&self.width.to_le_bytes());
+        buf.extend_from_slice(&self.height.to_le_bytes());
+        buf.extend_from_slice(self.luma);
         buf
     }
 }
@@ -211,5 +258,45 @@ mod tests {
         assert_eq!(ts, 96_000);
         assert_eq!(layout, 1);
         assert_eq!(out, opus);
+    }
+
+    /// Decode just enough to prove the layout matches the documented offsets.
+    fn decode_video(buf: &[u8]) -> (u8, FrameKind, u16, u32, u64, u16, u16, Vec<u8>) {
+        let ver = buf[0];
+        let kind = FrameKind::from_u8(buf[1]).expect("known kind");
+        let stream_id = u16::from_le_bytes([buf[2], buf[3]]);
+        let seq = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let timestamp = u64::from_le_bytes(buf[8..16].try_into().unwrap());
+        let width = u16::from_le_bytes([buf[16], buf[17]]);
+        let height = u16::from_le_bytes([buf[18], buf[19]]);
+        let luma = buf[20..].to_vec();
+        (ver, kind, stream_id, seq, timestamp, width, height, luma)
+    }
+
+    #[test]
+    fn video_roundtrip() {
+        let luma: Vec<u8> = (0..(8u32 * 4)).map(|i| (i * 7) as u8).collect();
+        let frame = VideoFrame {
+            stream_id: 0x8001,
+            seq: 9,
+            timestamp: 2_000_000,
+            width: 8,
+            height: 4,
+            luma: &luma,
+        };
+        let buf = frame.encode();
+        assert_eq!(buf.len(), frame.encoded_len());
+
+        let (ver, kind, sid, seq, ts, width, height, out) = decode_video(&buf);
+        assert_eq!(ver, PROTOCOL_VERSION);
+        assert_eq!(kind, FrameKind::VideoGray);
+        assert_eq!(sid, 0x8001);
+        assert_eq!(seq, 9);
+        assert_eq!(ts, 2_000_000);
+        assert_eq!((width, height), (8, 4));
+        assert_eq!(out, luma);
+        // The payload length is what the geometry claims, so a client can size its ImageData
+        // from the header alone.
+        assert_eq!(out.len(), usize::from(width) * usize::from(height));
     }
 }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -20,10 +20,10 @@ pub mod workspace_state;
 pub mod ws;
 
 pub use channel::{
-    AcarsParams, AdsbParams, AisChannel, AisParams, AmParams, AprsMode, AprsParams,
-    ChannelDescriptor, ChannelInfo, ChannelParams, ChannelSettings, MorseParams, NavtexParams,
-    NfmParams, PocsagBaud, PocsagParams, RttyParams, RttyStopBits, Sideband, SsbParams,
-    SubghzModulation, SubghzParams, WfmParams,
+    AcarsParams, AdsbParams, AisChannel, AisParams, AmParams, AprsMode, AprsParams, AtvModulation,
+    AtvParams, AtvStandard, ChannelDescriptor, ChannelInfo, ChannelParams, ChannelSettings,
+    MorseParams, NavtexParams, NfmParams, PocsagBaud, PocsagParams, RttyParams, RttyStopBits,
+    Sideband, SsbParams, SubghzModulation, SubghzParams, WfmParams,
 };
 pub use decode::{
     AcarsMessage, AdsbMessage, AisMessage, AprsPacket, DecodedRecord, DecoderEvent, MorseText,
@@ -34,7 +34,7 @@ pub use device::{
     GainStage, GainValue, Range, StreamScope, StreamSettings,
 };
 pub use doctor::{CheckStatus, DoctorCheck, DoctorReport};
-pub use frame::{AudioFrame, FrameKind, HEADER_LEN, PROTOCOL_VERSION, SpectrumFrame};
+pub use frame::{AudioFrame, FrameKind, HEADER_LEN, PROTOCOL_VERSION, SpectrumFrame, VideoFrame};
 pub use patch::{
     ChannelNode, DeviceNode, DeviceRef, MAX_EDGES, MAX_NODES, MAX_STREAMS, NodeBody, NodeCategory,
     NodeTypeInfo, PatchCatalog, PatchEdge, PatchError, PatchGraph, PatchNode, PortBacking,

--- a/crates/wire/src/ws.rs
+++ b/crates/wire/src/ws.rs
@@ -39,15 +39,15 @@ pub enum StateScope {
     Workspaces,
 }
 
-/// Which binary stream a control event refers to. Spectrum stream ids are device-set ids
-/// (< 0x8000) and audio ids are connection-allocated from `0x8000..=0xFFFF`, but only the
-/// pair `(kind, stream_id)` identifies a stream — events must carry the kind or a spectrum
-/// stop is indistinguishable from an audio stop.
+/// Which binary stream a control event refers to. Every id is allocated per connection, from a
+/// range per class, but only the pair `(kind, stream_id)` identifies a stream — events must
+/// carry the kind or a spectrum stop is indistinguishable from an audio one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamKind {
     Spectrum,
     Audio,
+    Video,
 }
 
 /// Server → client push (PLAN §5). Adjacently tagged so unit variants stay compact.
@@ -74,6 +74,14 @@ pub enum ServerEvent {
     /// from the audio range (see [`StreamKind`]); clients demux binary frames by
     /// `(kind, stream_id)`.
     AudioStreamStarted {
+        stream_id: u16,
+        device_set: u32,
+        channel: u32,
+    },
+    /// A subscribed video stream is now active, carrying the channel's pictures as
+    /// [`crate::VideoFrame`]s. Ids come from the same per-connection media range audio uses, so
+    /// the client demuxes on `(kind, stream_id)` exactly as it does there.
+    VideoStreamStarted {
         stream_id: u16,
         device_set: u32,
         channel: u32,
@@ -146,4 +154,10 @@ pub enum ClientCommand {
     SubscribeAudio { device_set: u32, channel: u32 },
     /// Stop the audio stream for a channel.
     UnsubscribeAudio { device_set: u32, channel: u32 },
+    /// Start receiving pictures from a channel that produces them (`ChannelDescriptor.has_video`);
+    /// answered with `VideoStreamStarted`. A channel with no video refuses rather than opening a
+    /// stream that would never carry a frame.
+    SubscribeVideo { device_set: u32, channel: u32 },
+    /// Stop the video stream for a channel.
+    UnsubscribeVideo { device_set: u32, channel: u32 },
 }

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -7,8 +7,8 @@ ACARS, sub-GHz) after M6.
 
 ## What `cargo xtask fixtures` writes
 
-One pair per decoder, rendered by the same modulators the decoder unit tests and the engine
-end-to-end run use — a fixture can therefore never drift from what the decoders are tested
+One pair per decoder — and one per mode that scans out a picture — rendered by the same
+modulators the unit tests and the engine end-to-end run use — a fixture can therefore never drift from what the decoders are tested
 against. Most come from a `channels::testgen` encoder; a mode that ships a `ChannelTx` (APRS
 today) is keyed by that transmitter instead, at its own channel rate, and resampled to the
 device rate the fixture is written at. Each is meant to be *played*: open it as a `virtual:file:`
@@ -27,10 +27,12 @@ device, add the named channel at the stated offset, and the decoder log fills up
 | `navtex_518_48k` | 48 k | `navtex` @ +3 kHz | `DA07` navigational warning, `GALE WARNING` |
 | `acars_downlink_240k` | 240 k | `acars` @ −40 kHz | `D-AIBC` / `LH0400` `[H1]`, `SDR-- FIXTURE` |
 | `subghz_ev1527_500k` | 500 k | `subghz` @ +100 kHz | 24-bit PWM `0A1B23`, address `0A1B2`, button 3 |
+| `atv_ccir625_2m4` | 2.4 M | `atv` @ +200 kHz | 625/25 AM, five vertical bars black to white |
 
 ADS-B is the one fixture whose device rate is not negotiable: it fills its whole 2 MHz
 channel, so a resampling DDC cannot carry it and the engine refuses the channel at any other
-rate (PLAN §18).
+rate (PLAN §18). ATV is the one whose output is not a log line: play it, wire the channel's
+face into view, and the picture is on the face itself.
 
 Every fixture is a SigMF pair — `<stem>.sigmf-meta` + `<stem>.sigmf-data`, mono-channel
 `cf32_le` — readable by `sdrmm-recorder` and playable in-app as a `virtual:file:<stem>`

--- a/openapi.json
+++ b/openapi.json
@@ -2105,6 +2105,47 @@
           }
         }
       },
+      "AtvModulation": {
+        "type": "string",
+        "description": "How an analog television transmission carries its video, and with it the polarity the\ndemodulated signal arrives in (PLAN §13: ATV).",
+        "enum": [
+          "am",
+          "fm"
+        ]
+      },
+      "AtvParams": {
+        "type": "object",
+        "properties": {
+          "bandwidth_hz": {
+            "type": "number",
+            "format": "double",
+            "description": "Video channel width in Hz. This *is* the horizontal resolution — a picture cannot carry\nmore detail per line than the bandwidth that delivered it — so it is the one knob worth\nopening up when the channel is clean, bounded by the mode's IQ rate."
+          },
+          "interlace": {
+            "type": "boolean",
+            "description": "Weave the two fields into one frame at their real line positions. Off decodes each\nvertical sync as a whole progressive frame, which is what non-interlaced amateur and\ncamera sources send."
+          },
+          "invert": {
+            "type": "boolean",
+            "description": "Invert the video polarity, for a transmission that keys the opposite way round from its\nmodulation's convention (see [`AtvModulation`]). A picture that comes out as a photographic\nnegative, with the sync tracker never locking, is what this fixes."
+          },
+          "modulation": {
+            "$ref": "#/components/schemas/AtvModulation"
+          },
+          "standard": {
+            "$ref": "#/components/schemas/AtvStandard"
+          }
+        }
+      },
+      "AtvStandard": {
+        "type": "string",
+        "description": "Scanning standard the transmission follows: how many lines make a frame and how fast they\ngo by. Everything else the demodulator needs — porch widths, active window, blanked lines —\nderives from these two numbers plus the standard's own timings.",
+        "enum": [
+          "ccir625",
+          "eia525",
+          "system_a405"
+        ]
+      },
       "AuthInfo": {
         "type": "object",
         "description": "`GET /api/auth` — unauthenticated, so a client knows whether to ask for a token before\nits first real request (PLAN §12: optional single shared token).",
@@ -2269,6 +2310,10 @@
           "has_audio": {
             "type": "boolean",
             "description": "Whether the channel produces listenable audio. Data decoders (PLAN §13 wave 1) do\nnot, so the client hides their audio controls instead of offering a silent stream.\nDefaults to `true` so a snapshot from an older peer keeps the pre-M4 behaviour."
+          },
+          "has_video": {
+            "type": "boolean",
+            "description": "Whether the channel produces a picture, delivered as [`crate::VideoFrame`] binary frames\nrather than as decoder events (ATV, PLAN §13). The client subscribes and mounts a video\npanel on the channel's face when this is set. Defaults to `false`, which is every mode\nthat predates the video transport."
           },
           "input_rate_hz": {
             "type": "number",
@@ -2565,6 +2610,24 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/AtvParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "atv"
+                ]
+              }
+            }
           }
         ],
         "description": "Type-discriminated demod parameters. Adjacently tagged so the generated TS is a\ndiscriminated union on `type`, and `{\"type\":\"nfm\",\"settings\":{}}` deserializes with\nevery field at its default."
@@ -2773,6 +2836,78 @@
                 "type": "string",
                 "enum": [
                   "UnsubscribeAudio"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Start receiving pictures from a channel that produces them (`ChannelDescriptor.has_video`);\nanswered with `VideoStreamStarted`. A channel with no video refuses rather than opening a\nstream that would never carry a frame.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "Start receiving pictures from a channel that produces them (`ChannelDescriptor.has_video`);\nanswered with `VideoStreamStarted`. A channel with no video refuses rather than opening a\nstream that would never carry a frame.",
+                "required": [
+                  "device_set",
+                  "channel"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  },
+                  "device_set": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "SubscribeVideo"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Stop the video stream for a channel.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "Stop the video stream for a channel.",
+                "required": [
+                  "device_set",
+                  "channel"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  },
+                  "device_set": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "UnsubscribeVideo"
                 ]
               }
             }
@@ -5157,6 +5292,48 @@
           },
           {
             "type": "object",
+            "description": "A subscribed video stream is now active, carrying the channel's pictures as\n[`crate::VideoFrame`]s. Ids come from the same per-connection media range audio uses, so\nthe client demuxes on `(kind, stream_id)` exactly as it does there.",
+            "required": [
+              "data",
+              "type"
+            ],
+            "properties": {
+              "data": {
+                "type": "object",
+                "description": "A subscribed video stream is now active, carrying the channel's pictures as\n[`crate::VideoFrame`]s. Ids come from the same per-connection media range audio uses, so\nthe client demuxes on `(kind, stream_id)` exactly as it does there.",
+                "required": [
+                  "stream_id",
+                  "device_set",
+                  "channel"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  },
+                  "device_set": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  },
+                  "stream_id": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "VideoStreamStarted"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "A subscribed stream stopped; `kind` says which one, since spectrum and audio ids\ncome from different spaces.",
             "required": [
               "data",
@@ -5546,10 +5723,11 @@
       },
       "StreamKind": {
         "type": "string",
-        "description": "Which binary stream a control event refers to. Spectrum stream ids are device-set ids\n(< 0x8000) and audio ids are connection-allocated from `0x8000..=0xFFFF`, but only the\npair `(kind, stream_id)` identifies a stream — events must carry the kind or a spectrum\nstop is indistinguishable from an audio stop.",
+        "description": "Which binary stream a control event refers to. Every id is allocated per connection, from a\nrange per class, but only the pair `(kind, stream_id)` identifies a stream — events must\ncarry the kind or a spectrum stop is indistinguishable from an audio one.",
         "enum": [
           "spectrum",
-          "audio"
+          "audio",
+          "video"
         ]
       },
       "StreamScope": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,7 @@ import { pushToast } from "./lib/toasts";
 import type { PatchGraph, ServerEvent, StateScope } from "./lib/types";
 import { useChannelPatch } from "./lib/useChannelPatch";
 import { useDevicePatch } from "./lib/useDevicePatch";
+import { videoHub } from "./lib/video";
 import { SdrSocket } from "./lib/ws";
 
 /** Modes the `m` shortcut walks, in the order an operator sweeps them. Decoders are not in the
@@ -79,13 +80,16 @@ export function App() {
     s.addEventListener(useDecodedStore.getState().observe);
     // Scanner progress is its own high-rate event for the same reason (PLAN §13).
     s.addEventListener(useScannerStore.getState().observe);
-    // Spectrum is refcounted per device set so several scope faces share one stream.
+    // Spectrum and video are refcounted — per device set and per channel — so several faces
+    // watching the same thing share one stream instead of replacing each other's.
     spectrumHub.attach(s);
+    videoHub.attach(s);
     audioEngine.attach(s);
     setSocket(s);
     s.connect();
     return () => {
       spectrumHub.detach();
+      videoHub.detach();
       s.close();
     };
   }, []);

--- a/web/src/canvas/nodes/ChannelFace.tsx
+++ b/web/src/canvas/nodes/ChannelFace.tsx
@@ -6,11 +6,13 @@ import { ChannelControls } from "../../components/ChannelControls";
 import {
   channelDecoderKind,
   channelHasAudio,
+  channelHasVideo,
   rateMismatch,
 } from "../../components/channelSettings";
 import { BTN, BTN_PRIMARY } from "../../components/controls";
 import { DecoderView } from "../../components/DecoderPanels";
 import { formatMhz, formatSignedKhz } from "../../components/format";
+import { VideoView } from "../../components/VideoView";
 import type { DeviceSet, PatchNode } from "../../lib/types";
 import { forStream, useDevicePatch } from "../../lib/useDevicePatch";
 import { iqSourceOf, targetsOf } from "../binding";
@@ -45,6 +47,7 @@ export function ChannelFace({ node }: { node: PatchNode }) {
   const readout = centerHz === null ? formatSignedKhz(offsetHz) : formatMhz(centerHz + offsetHz);
   const wantedRate = rateMismatch(descriptor, set?.settings.sample_rate);
   const decoderKind = channelDecoderKind(descriptor);
+  const hasVideo = channelHasVideo(descriptor);
   // The face has no play button — audio belongs to the speaker the wire reaches — so a channel
   // that demodulates sound into nothing has to say so somewhere, and this is where it is looked
   // for.
@@ -80,14 +83,19 @@ export function ChannelFace({ node }: { node: PatchNode }) {
               spanHz={set.settings.sample_rate ?? null}
             />
             {audioUnwired && <p className="legend px-2 pb-2">audio out reaches no speaker</p>}
+            {/* Channel ids are allocated per device set, so two sets both have a channel 1;
+                scoping on the id alone would pour one set's output into this face. */}
             {decoderKind !== null && (
               <div className="border-t border-line">
-                {/* Channel ids are allocated per device set, so two sets both have a channel 1;
-                    scoping on the id alone would pour one set's frames into this face. */}
                 <DecoderView
                   kind={decoderKind}
                   scope={{ deviceSet: set.id, channel: channel.id }}
                 />
+              </div>
+            )}
+            {hasVideo && (
+              <div className="border-t border-line">
+                <VideoView scope={{ deviceSet: set.id, channel: channel.id }} />
               </div>
             )}
           </>

--- a/web/src/components/ChannelControls.tsx
+++ b/web/src/components/ChannelControls.tsx
@@ -46,6 +46,15 @@ const RTTY_STOP_BITS: Options<NonNullable<ChannelParamsOf<"rtty">["stop_bits"]>>
   { value: "one_and_half", label: "1.5" },
   { value: "two", label: "2" },
 ];
+const ATV_MODULATIONS: Options<NonNullable<ChannelParamsOf<"atv">["modulation"]>> = [
+  { value: "am", label: "AM" },
+  { value: "fm", label: "FM" },
+];
+const ATV_STANDARDS: Options<NonNullable<ChannelParamsOf<"atv">["standard"]>> = [
+  { value: "ccir625", label: "625 / 25" },
+  { value: "eia525", label: "525 / 30" },
+  { value: "system_a405", label: "405 / 25" },
+];
 const DEEMPHASIS_US: Options<number> = [
   { value: 50, label: "50 µs" },
   { value: 75, label: "75 µs" },
@@ -517,6 +526,54 @@ function ModeControls({
             />
             µs
           </label>
+        </>
+      );
+    case "atv":
+      return (
+        <>
+          <Segmented
+            label="Modulation"
+            value={params.settings.modulation ?? "am"}
+            options={ATV_MODULATIONS}
+            onChange={(modulation) =>
+              onParams({ type: "atv", settings: { ...params.settings, modulation } })
+            }
+          />
+          <label className={LABEL}>
+            Lines
+            <Select
+              label="Scanning standard"
+              value={params.settings.standard ?? "ccir625"}
+              options={ATV_STANDARDS}
+              onChange={(standard) =>
+                onParams({ type: "atv", settings: { ...params.settings, standard } })
+              }
+            />
+          </label>
+          <label className={LABEL}>
+            BW
+            <BandwidthSelect
+              valueHz={params.settings.bandwidth_hz ?? 1_500_000}
+              optionsHz={[500_000, 1_000_000, 1_500_000, 1_600_000]}
+              onCommit={(bandwidth_hz) =>
+                onParams({ type: "atv", settings: { ...params.settings, bandwidth_hz } })
+              }
+            />
+          </label>
+          <Toggle
+            label="Interlace"
+            checked={params.settings.interlace ?? true}
+            onChange={(interlace) =>
+              onParams({ type: "atv", settings: { ...params.settings, interlace } })
+            }
+          />
+          <Toggle
+            label="Invert"
+            checked={params.settings.invert ?? false}
+            onChange={(invert) =>
+              onParams({ type: "atv", settings: { ...params.settings, invert } })
+            }
+          />
         </>
       );
     default:

--- a/web/src/components/VideoView.tsx
+++ b/web/src/components/VideoView.tsx
@@ -1,0 +1,110 @@
+// The live picture from a video channel (PLAN §13: ATV), rendered as the lower half of that
+// channel's node face — the same place a decoder's output goes (CANVAS §8 phase ③).
+//
+// Pictures bypass React state entirely and go straight to the canvas (PLAN §10: high-rate streams
+// never touch TanStack Query). Only the readout — geometry and whether anything is arriving at
+// all — is state, and it changes at a human rate rather than a field rate.
+import { useEffect, useRef, useState } from "react";
+import type { VideoFrame } from "../lib/frame";
+import { videoHub } from "../lib/video";
+
+/** A raster is transmitted for a 4:3 screen, and what a channel samples out of it is however many
+ * pixels its bandwidth resolved along the line — far fewer than its 576 rows. So the canvas is
+ * drawn at the picture's own size and *displayed* at the shape it was scanned for; stretching in
+ * CSS is what keeps the source honest. */
+const DISPLAY_ASPECT = 4 / 3;
+
+/** No picture for this long and the readout says so. Longer than the gap between fields by a wide
+ * margin, so a momentary loss of sync does not flicker the label. */
+const STALE_MS = 2_000;
+
+interface Geometry {
+  width: number;
+  height: number;
+}
+
+/** Which channel's pictures to draw. A concrete pair, unlike a decoder view's `DecoderScope`,
+ * which is a filter over a shared store: a video stream is subscribed to, and there is no such
+ * thing as subscribing to "every channel". */
+export interface VideoScope {
+  deviceSet: number;
+  channel: number;
+}
+
+export function VideoView({ scope }: { scope: VideoScope }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [geometry, setGeometry] = useState<Geometry | null>(null);
+  const [live, setLive] = useState(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) {
+      return;
+    }
+    // `willReadFrequently` is deliberately absent: this context is written every field and never
+    // read back, which is the case the GPU-backed path is for.
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) {
+      return;
+    }
+    // Reused across frames: an ImageData per field would be a 60 kB allocation fifty times a
+    // second, and the geometry only changes when the standard does.
+    let image: ImageData | null = null;
+    let stale = 0;
+
+    const draw = (frame: VideoFrame): void => {
+      if (image === null || image.width !== frame.width || image.height !== frame.height) {
+        canvas.width = frame.width;
+        canvas.height = frame.height;
+        image = ctx.createImageData(frame.width, frame.height);
+        setGeometry({ width: frame.width, height: frame.height });
+      }
+      const rgba = image.data;
+      for (let i = 0; i < frame.luma.length; i += 1) {
+        const luma = frame.luma[i] ?? 0;
+        const at = i * 4;
+        rgba[at] = luma;
+        rgba[at + 1] = luma;
+        rgba[at + 2] = luma;
+        rgba[at + 3] = 255;
+      }
+      ctx.putImageData(image, 0, 0);
+      setLive(true);
+      clearTimeout(stale);
+      stale = window.setTimeout(() => setLive(false), STALE_MS);
+    };
+
+    // The last picture this channel sent, so a face that has just remounted opens on the raster
+    // it was showing rather than on a blank canvas for a field period.
+    const held = videoHub.latest(scope.deviceSet, scope.channel);
+    if (held !== null) {
+      draw(held);
+    }
+    const stop = videoHub.subscribe(scope.deviceSet, scope.channel, draw);
+    return () => {
+      stop();
+      clearTimeout(stale);
+    };
+  }, [scope.deviceSet, scope.channel]);
+
+  return (
+    <div className="flex flex-col gap-1 p-2">
+      <div
+        className="w-full overflow-hidden rounded-xs bg-black"
+        style={{ aspectRatio: DISPLAY_ASPECT }}
+      >
+        <canvas
+          ref={canvasRef}
+          aria-label="Decoded video"
+          className="h-full w-full"
+          style={{ imageRendering: "pixelated" }}
+        />
+      </div>
+      <p className="legend text-ink-faint">
+        {geometry === null
+          ? "waiting for sync"
+          : `${geometry.width} × ${geometry.height}${live ? "" : " · no sync"}`}
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/channelSettings.ts
+++ b/web/src/components/channelSettings.ts
@@ -35,6 +35,13 @@ export function channelDecoderKind(descriptor: ChannelDescriptor | undefined): s
   return descriptor?.decoder_kind ?? null;
 }
 
+/** Whether this channel scans out a picture, so its face mounts a video panel and subscribes.
+ * Absent (older server, or the type list not loaded yet) means no video, which is every mode
+ * that predates the transport. */
+export function channelHasVideo(descriptor: ChannelDescriptor | undefined): boolean {
+  return descriptor?.has_video ?? false;
+}
+
 /** How far the channel can be offset before its passband leaves the receiver's span: half the
  * span, less the half-bandwidth the channel itself occupies. `null` when the rate is unknown —
  * the offset field is then left unbounded rather than clamped to a guess. */

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -663,6 +663,42 @@ export interface components {
             mode?: components["schemas"]["AprsMode"];
         };
         /**
+         * @description How an analog television transmission carries its video, and with it the polarity the
+         *     demodulated signal arrives in (PLAN §13: ATV).
+         * @enum {string}
+         */
+        AtvModulation: "am" | "fm";
+        AtvParams: {
+            /**
+             * Format: double
+             * @description Video channel width in Hz. This *is* the horizontal resolution — a picture cannot carry
+             *     more detail per line than the bandwidth that delivered it — so it is the one knob worth
+             *     opening up when the channel is clean, bounded by the mode's IQ rate.
+             */
+            bandwidth_hz?: number;
+            /**
+             * @description Weave the two fields into one frame at their real line positions. Off decodes each
+             *     vertical sync as a whole progressive frame, which is what non-interlaced amateur and
+             *     camera sources send.
+             */
+            interlace?: boolean;
+            /**
+             * @description Invert the video polarity, for a transmission that keys the opposite way round from its
+             *     modulation's convention (see [`AtvModulation`]). A picture that comes out as a photographic
+             *     negative, with the sync tracker never locking, is what this fixes.
+             */
+            invert?: boolean;
+            modulation?: components["schemas"]["AtvModulation"];
+            standard?: components["schemas"]["AtvStandard"];
+        };
+        /**
+         * @description Scanning standard the transmission follows: how many lines make a frame and how fast they
+         *     go by. Everything else the demodulator needs — porch widths, active window, blanked lines —
+         *     derives from these two numbers plus the standard's own timings.
+         * @enum {string}
+         */
+        AtvStandard: "ccir625" | "eia525" | "system_a405";
+        /**
          * @description `GET /api/auth` — unauthenticated, so a client knows whether to ask for a token before
          *     its first real request (PLAN §12: optional single shared token).
          */
@@ -754,6 +790,13 @@ export interface components {
              *     Defaults to `true` so a snapshot from an older peer keeps the pre-M4 behaviour.
              */
             has_audio?: boolean;
+            /**
+             * @description Whether the channel produces a picture, delivered as [`crate::VideoFrame`] binary frames
+             *     rather than as decoder events (ATV, PLAN §13). The client subscribes and mounts a video
+             *     panel on the channel's face when this is set. Defaults to `false`, which is every mode
+             *     that predates the video transport.
+             */
+            has_video?: boolean;
             /**
              * Format: double
              * @description IQ rate the demod expects from the DDC, in Hz.
@@ -852,6 +895,10 @@ export interface components {
             settings: components["schemas"]["SubghzParams"];
             /** @enum {string} */
             type: "subghz";
+        } | {
+            settings: components["schemas"]["AtvParams"];
+            /** @enum {string} */
+            type: "atv";
         };
         /** @description Per-channel settings: where the channel sits and how it demodulates. */
         ChannelSettings: {
@@ -941,6 +988,30 @@ export interface components {
             };
             /** @enum {string} */
             type: "UnsubscribeAudio";
+        } | {
+            /**
+             * @description Start receiving pictures from a channel that produces them (`ChannelDescriptor.has_video`);
+             *     answered with `VideoStreamStarted`. A channel with no video refuses rather than opening a
+             *     stream that would never carry a frame.
+             */
+            data: {
+                /** Format: int32 */
+                channel: number;
+                /** Format: int32 */
+                device_set: number;
+            };
+            /** @enum {string} */
+            type: "SubscribeVideo";
+        } | {
+            /** @description Stop the video stream for a channel. */
+            data: {
+                /** Format: int32 */
+                channel: number;
+                /** Format: int32 */
+                device_set: number;
+            };
+            /** @enum {string} */
+            type: "UnsubscribeVideo";
         };
         /**
          * @description `GET /api/clients` — how many clients share this server right now (PLAN §16 M5
@@ -1961,6 +2032,22 @@ export interface components {
             type: "AudioStreamStarted";
         } | {
             /**
+             * @description A subscribed video stream is now active, carrying the channel's pictures as
+             *     [`crate::VideoFrame`]s. Ids come from the same per-connection media range audio uses, so
+             *     the client demuxes on `(kind, stream_id)` exactly as it does there.
+             */
+            data: {
+                /** Format: int32 */
+                channel: number;
+                /** Format: int32 */
+                device_set: number;
+                /** Format: int32 */
+                stream_id: number;
+            };
+            /** @enum {string} */
+            type: "VideoStreamStarted";
+        } | {
+            /**
              * @description A subscribed stream stopped; `kind` says which one, since spectrum and audio ids
              *     come from different spaces.
              */
@@ -2098,13 +2185,12 @@ export interface components {
             revision: number;
         };
         /**
-         * @description Which binary stream a control event refers to. Spectrum stream ids are device-set ids
-         *     (< 0x8000) and audio ids are connection-allocated from `0x8000..=0xFFFF`, but only the
-         *     pair `(kind, stream_id)` identifies a stream — events must carry the kind or a spectrum
-         *     stop is indistinguishable from an audio stop.
+         * @description Which binary stream a control event refers to. Every id is allocated per connection, from a
+         *     range per class, but only the pair `(kind, stream_id)` identifies a stream — events must
+         *     carry the kind or a spectrum stop is indistinguishable from an audio one.
          * @enum {string}
          */
-        StreamKind: "spectrum" | "audio";
+        StreamKind: "spectrum" | "audio" | "video";
         /**
          * @description Which device settings each receive stream holds on its own, rather than sharing with the rest
          *     of the radio. All-false — the default, and what every capability set from before this field

--- a/web/src/lib/frame.test.ts
+++ b/web/src/lib/frame.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from "vitest";
 import {
   decodeAudio,
   decodeSpectrum,
+  decodeVideo,
   FRAME_KIND_AUDIO_OPUS,
   FRAME_KIND_SPECTRUM,
+  FRAME_KIND_VIDEO_GRAY,
   frameKind,
   PROTOCOL_VERSION,
 } from "./frame";
@@ -37,6 +39,15 @@ function audioBuffer(opus: Uint8Array): ArrayBuffer {
   const view = header(buf, FRAME_KIND_AUDIO_OPUS, 3, 512, 96_000n);
   view.setUint8(16, 1);
   new Uint8Array(buf, 17).set(opus);
+  return buf;
+}
+
+function videoBuffer(width: number, height: number, luma: Uint8Array): ArrayBuffer {
+  const buf = new ArrayBuffer(16 + 4 + luma.length);
+  const view = header(buf, FRAME_KIND_VIDEO_GRAY, 0x8001, 9, 2_000_000n);
+  view.setUint16(16, width, true);
+  view.setUint16(18, height, true);
+  new Uint8Array(buf, 20).set(luma);
   return buf;
 }
 
@@ -105,5 +116,36 @@ describe("decodeAudio", () => {
     const wrongVersion = audioBuffer(new Uint8Array(8));
     new DataView(wrongVersion).setUint8(0, PROTOCOL_VERSION + 1);
     expect(decodeAudio(wrongVersion)).toBeNull();
+  });
+});
+
+describe("decodeVideo", () => {
+  it("decodes every field exactly", () => {
+    const luma = Uint8Array.from({ length: 8 * 4 }, (_, i) => (i * 7) & 0xff);
+    const frame = decodeVideo(videoBuffer(8, 4, luma));
+    expect(frame).not.toBeNull();
+    expect(frame?.streamId).toBe(0x8001);
+    expect(frame?.seq).toBe(9);
+    expect(frame?.timestamp).toBe(2_000_000n);
+    expect(frame?.width).toBe(8);
+    expect(frame?.height).toBe(4);
+    expect(Array.from(frame?.luma ?? [])).toEqual(Array.from(luma));
+  });
+
+  // A canvas sized from the header and filled from a short payload would draw whatever the
+  // buffer happened to hold, so the geometry and the payload have to agree or nothing is drawn.
+  it("rejects a payload that is shorter than its geometry, and an empty one", () => {
+    const luma = new Uint8Array(8 * 4);
+    expect(decodeVideo(videoBuffer(8, 4, luma).slice(0, 20 + 31))).toBeNull();
+    expect(decodeVideo(videoBuffer(0, 0, new Uint8Array(0)))).toBeNull();
+  });
+
+  it("rejects other kinds and wrong versions", () => {
+    expect(decodeVideo(audioBuffer(new Uint8Array(8)))).toBeNull();
+    expect(decodeAudio(videoBuffer(2, 2, new Uint8Array(4)))).toBeNull();
+
+    const wrongVersion = videoBuffer(2, 2, new Uint8Array(4));
+    new DataView(wrongVersion).setUint8(0, PROTOCOL_VERSION + 1);
+    expect(decodeVideo(wrongVersion)).toBeNull();
   });
 });

--- a/web/src/lib/frame.ts
+++ b/web/src/lib/frame.ts
@@ -4,6 +4,7 @@
 export const PROTOCOL_VERSION = 1;
 export const FRAME_KIND_SPECTRUM = 0;
 export const FRAME_KIND_AUDIO_OPUS = 1;
+export const FRAME_KIND_VIDEO_GRAY = 3;
 const HEADER_LEN = 16;
 
 /** The `kind` header byte, or null if the buffer can't be a frame we understand. */
@@ -79,4 +80,39 @@ export function decodeAudio(buffer: ArrayBuffer): AudioFrame | null {
   const chLayout = view.getUint8(16);
   const opus = new Uint8Array(buffer, HEADER_LEN + 1);
   return { streamId, seq, timestamp, chLayout, opus };
+}
+
+export interface VideoFrame {
+  streamId: number;
+  seq: number;
+  /** Channel-rate sample count when the picture completed (PLAN §5). */
+  timestamp: bigint;
+  width: number;
+  height: number;
+  /** 8-bit luma, row-major from the top line, exactly `width · height` bytes. */
+  luma: Uint8Array;
+}
+
+/** Decode a VIDEO_GRAY frame, or return null if the buffer is not one we understand. */
+export function decodeVideo(buffer: ArrayBuffer): VideoFrame | null {
+  if (buffer.byteLength < HEADER_LEN + 4) {
+    return null;
+  }
+  const view = new DataView(buffer);
+  if (view.getUint8(0) !== PROTOCOL_VERSION || view.getUint8(1) !== FRAME_KIND_VIDEO_GRAY) {
+    return null;
+  }
+  const streamId = view.getUint16(2, true);
+  const seq = view.getUint32(4, true);
+  const timestamp = view.getBigUint64(8, true);
+  const width = view.getUint16(16, true);
+  const height = view.getUint16(18, true);
+  // Geometry and payload must agree: a canvas sized from the header and filled from a short
+  // payload would draw the previous picture's tail as this one's bottom rows.
+  const pixels = width * height;
+  if (pixels === 0 || buffer.byteLength < HEADER_LEN + 4 + pixels) {
+    return null;
+  }
+  const luma = new Uint8Array(buffer, HEADER_LEN + 4, pixels);
+  return { streamId, seq, timestamp, width, height, luma };
 }

--- a/web/src/lib/video.test.ts
+++ b/web/src/lib/video.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VideoFrame } from "./frame";
+import type { ClientCommand, ServerEvent } from "./types";
+import { VideoHub, type VideoSocket } from "./video";
+
+function fakeSocket() {
+  const sent: ClientCommand[] = [];
+  let frames: ((frame: VideoFrame) => void) | null = null;
+  let status: ((connected: boolean) => void) | null = null;
+  let events: ((event: ServerEvent) => void) | null = null;
+  const socket: VideoSocket = {
+    send: (command) => sent.push(command),
+    addVideoListener: (listener) => {
+      frames = listener;
+    },
+    removeVideoListener: () => {
+      frames = null;
+    },
+    addStatusListener: (listener) => {
+      status = listener;
+    },
+    removeStatusListener: () => {
+      status = null;
+    },
+    addEventListener: (listener) => {
+      events = listener;
+    },
+    removeEventListener: () => {
+      events = null;
+    },
+  };
+  return {
+    socket,
+    sent,
+    /** What the server sends when it answers a subscribe: the id it allocated for that channel. */
+    started: (streamId: number, deviceSet: number, channel: number) =>
+      events?.({
+        type: "VideoStreamStarted",
+        data: { stream_id: streamId, device_set: deviceSet, channel },
+      }),
+    stopped: (streamId: number) =>
+      events?.({
+        type: "StreamStopped",
+        data: { stream_id: streamId, kind: "video" },
+      }),
+    push: (streamId: number, width = 4, height = 2) =>
+      frames?.({
+        streamId,
+        seq: 0,
+        timestamp: 0n,
+        width,
+        height,
+        luma: new Uint8Array(width * height),
+      }),
+    reconnect: () => status?.(true),
+    attached: () => frames !== null,
+  };
+}
+
+const subscribes = (sent: ClientCommand[]) => sent.filter((c) => c.type === "SubscribeVideo");
+const unsubscribes = (sent: ClientCommand[]) => sent.filter((c) => c.type === "UnsubscribeVideo");
+
+/** Past the release grace, whatever it is set to. */
+const waitOutGrace = () => vi.advanceTimersByTime(60_000);
+
+describe("VideoHub", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("subscribes once for many watchers of one channel and stops on the last one", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+
+    const first = hub.subscribe(1, 2, () => {});
+    const second = hub.subscribe(1, 2, () => {});
+    expect(subscribes(fake.sent)).toHaveLength(1);
+
+    first();
+    waitOutGrace();
+    expect(unsubscribes(fake.sent)).toHaveLength(0);
+    second();
+    waitOutGrace();
+    expect(unsubscribes(fake.sent)).toHaveLength(1);
+  });
+
+  it("remounting inside the grace keeps the stream instead of replacing it", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+
+    const stop = hub.subscribe(1, 2, () => {});
+    stop();
+    vi.advanceTimersByTime(100);
+    hub.subscribe(1, 2, () => {});
+    waitOutGrace();
+
+    // One subscribe, and no unsubscribe: the server's stream — and with it the receiver's sync
+    // lock — survived the face being remounted.
+    expect(subscribes(fake.sent)).toHaveLength(1);
+    expect(unsubscribes(fake.sent)).toHaveLength(0);
+  });
+
+  it("routes frames by the id the server allocated, and to that channel only", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+
+    const one: number[] = [];
+    const two: number[] = [];
+    hub.subscribe(1, 7, (frame) => one.push(frame.width));
+    hub.subscribe(1, 8, (frame) => two.push(frame.width));
+    fake.started(0x8000, 1, 7);
+    fake.started(0x8001, 1, 8);
+
+    fake.push(0x8000, 104);
+    fake.push(0x8001, 164);
+    // An id the server never announced belongs to nobody; it must not fan out to everyone.
+    fake.push(0x9999, 8);
+
+    expect(one).toEqual([104]);
+    expect(two).toEqual([164]);
+  });
+
+  it("keeps the last picture so a remounted face is not blank", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+    hub.subscribe(1, 2, () => {});
+    fake.started(0x8000, 1, 2);
+
+    expect(hub.latest(1, 2)).toBeNull();
+    fake.push(0x8000, 104, 576);
+    expect(hub.latest(1, 2)?.height).toBe(576);
+    expect(hub.latest(9, 9)).toBeNull();
+  });
+
+  it("re-subscribes everything still watched after a reconnect", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+    hub.subscribe(1, 2, () => {});
+    hub.subscribe(3, 4, () => {});
+    expect(subscribes(fake.sent)).toHaveLength(2);
+
+    // Ids from the old connection are meaningless on the new one, so a frame carrying one must
+    // not be delivered until the new StreamStarted names it.
+    fake.started(0x8000, 1, 2);
+    fake.reconnect();
+    const after: number[] = [];
+    hub.subscribe(1, 2, (frame) => after.push(frame.width));
+    fake.push(0x8000);
+    expect(after).toEqual([]);
+
+    expect(subscribes(fake.sent)).toHaveLength(4);
+    fake.started(0x8000, 1, 2);
+    fake.push(0x8000);
+    expect(after).toHaveLength(1);
+  });
+
+  it("forgets an id the server says has stopped", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+    const seen: number[] = [];
+    hub.subscribe(1, 2, (frame) => seen.push(frame.width));
+    fake.started(0x8000, 1, 2);
+    fake.push(0x8000);
+    fake.stopped(0x8000);
+    fake.push(0x8000);
+    expect(seen).toHaveLength(1);
+  });
+
+  it("detaches from the socket it leaves", () => {
+    const fake = fakeSocket();
+    const hub = new VideoHub();
+    hub.attach(fake.socket);
+    expect(fake.attached()).toBe(true);
+    hub.detach();
+    expect(fake.attached()).toBe(false);
+  });
+});

--- a/web/src/lib/video.ts
+++ b/web/src/lib/video.ts
@@ -1,0 +1,179 @@
+// One video subscription per (device set, channel), however many faces watch it.
+//
+// The same shape as `spectrum.ts` and for the same three reasons: two faces on one channel must
+// not each send a `SubscribeVideo` (the server answers the second by replacing the first's
+// stream, and either unmount would stop the other's feed); subscriptions are per-connection, so a
+// reconnect has to re-send everything still wanted; and a face is remounted by things that have
+// nothing to do with its radio — switching between the patch and the rack is the everyday one.
+//
+// What it does *not* keep is a history. A raster is redrawn fifty times a second and a picture is
+// only ever the newest one, so one frame is held per channel — enough that a face which has just
+// mounted shows the last picture instead of an empty canvas while it waits for the next.
+
+import type { VideoFrame } from "./frame";
+import type { ClientCommand, ServerEvent } from "./types";
+
+/** What the hub needs of a socket — structural, so the unit tests need no WebSocket. */
+export interface VideoSocket {
+  send(command: ClientCommand): void;
+  addVideoListener(listener: (frame: VideoFrame) => void): void;
+  removeVideoListener(listener: (frame: VideoFrame) => void): void;
+  addStatusListener(listener: (connected: boolean) => void): void;
+  removeStatusListener(listener: (connected: boolean) => void): void;
+  addEventListener(listener: (event: ServerEvent) => void): void;
+  removeEventListener(listener: (event: ServerEvent) => void): void;
+}
+
+/** How long a channel's stream outlives its last watcher. A view switch unmounts every face and
+ * mounts it again in the same commit; stopping the server's stream on the way through would cost
+ * the receiver its sync lock, which the operator reads as a picture that fell apart. */
+const RELEASE_GRACE_MS = 5_000;
+
+/** One watched channel. */
+export interface VideoChannel {
+  deviceSet: number;
+  channel: number;
+}
+
+/** Map key for a channel. Channel ids are allocated per device set, so two sets both have a
+ * channel 1 and the id alone would pour one set's pictures into the other's face. */
+function channelKey(deviceSet: number, channel: number): string {
+  return `${deviceSet}:${channel}`;
+}
+
+interface Watched {
+  listeners: Set<(frame: VideoFrame) => void>;
+  latest: VideoFrame | null;
+  /** A pending stop, or 0 — non-zero is precisely "subscribed, but nothing is watching". */
+  release: number;
+}
+
+export class VideoHub {
+  private socket: VideoSocket | null = null;
+  private readonly channels = new Map<string, Watched>();
+  /** Server-allocated stream id → channel key, from `VideoStreamStarted`. Frames carry only the
+   * id, so losing this mapping silently blanks every picture. */
+  private readonly ids = new Map<number, string>();
+
+  private readonly onFrame = (frame: VideoFrame): void => {
+    const key = this.ids.get(frame.streamId);
+    const watched = key === undefined ? undefined : this.channels.get(key);
+    if (watched === undefined) {
+      return;
+    }
+    watched.latest = frame;
+    for (const listener of watched.listeners) {
+      listener(frame);
+    }
+  };
+
+  private readonly onEvent = (event: ServerEvent): void => {
+    if (event.type === "VideoStreamStarted") {
+      const { stream_id, device_set, channel } = event.data;
+      this.ids.set(stream_id, channelKey(device_set, channel));
+    } else if (event.type === "StreamStopped" && event.data.kind === "video") {
+      this.ids.delete(event.data.stream_id);
+    }
+  };
+
+  // A reconnect starts with no subscriptions at all, so every channel still being watched has to
+  // ask again. The ids from the old connection are meaningless on the new one.
+  private readonly onStatus = (connected: boolean): void => {
+    if (!connected) {
+      return;
+    }
+    this.ids.clear();
+    for (const watched of this.watched()) {
+      this.send(watched, true);
+    }
+  };
+
+  /** Take over the socket's video frames. Idempotent; attaching a second socket detaches the
+   * first. */
+  attach(socket: VideoSocket): void {
+    if (this.socket === socket) {
+      return;
+    }
+    this.detach();
+    this.socket = socket;
+    socket.addVideoListener(this.onFrame);
+    socket.addStatusListener(this.onStatus);
+    socket.addEventListener(this.onEvent);
+    this.ids.clear();
+    for (const watched of this.watched()) {
+      this.send(watched, true);
+    }
+  }
+
+  detach(): void {
+    const socket = this.socket;
+    this.socket = null;
+    if (socket === null) {
+      return;
+    }
+    socket.removeVideoListener(this.onFrame);
+    socket.removeStatusListener(this.onStatus);
+    socket.removeEventListener(this.onEvent);
+  }
+
+  /** Watch one channel's pictures. Returns the unsubscribe; the stream stops a grace period after
+   * the last watcher lets go. */
+  subscribe(deviceSet: number, channel: number, listener: (frame: VideoFrame) => void): () => void {
+    const key = channelKey(deviceSet, channel);
+    let watched = this.channels.get(key);
+    if (watched === undefined) {
+      watched = { listeners: new Set(), latest: null, release: 0 };
+      this.channels.set(key, watched);
+      this.send({ deviceSet, channel }, true);
+    } else if (watched.release !== 0) {
+      // Inside the grace the stream never stopped, so this is a cancelled stop and not a second
+      // subscribe: sending one would have the server replace the stream already feeding us.
+      clearTimeout(watched.release);
+      watched.release = 0;
+    }
+    watched.listeners.add(listener);
+    return () => this.release(key, { deviceSet, channel }, listener);
+  }
+
+  /** The channel's most recent picture — what a mounting face draws before one of its own
+   * arrives. */
+  latest(deviceSet: number, channel: number): VideoFrame | null {
+    return this.channels.get(channelKey(deviceSet, channel))?.latest ?? null;
+  }
+
+  /** Channels the server is streaming: every watched one, and any still inside its release
+   * grace. The test seam, and what a reconnect re-sends. */
+  watched(): VideoChannel[] {
+    return [...this.channels.keys()].map((key) => {
+      const [deviceSet, channel] = key.split(":");
+      return { deviceSet: Number(deviceSet), channel: Number(channel) };
+    });
+  }
+
+  private release(key: string, channel: VideoChannel, listener: (frame: VideoFrame) => void): void {
+    const watched = this.channels.get(key);
+    if (watched === undefined) {
+      return;
+    }
+    watched.listeners.delete(listener);
+    if (watched.listeners.size > 0 || watched.release !== 0) {
+      return;
+    }
+    watched.release = setTimeout(() => {
+      this.channels.delete(key);
+      this.send(channel, false);
+    }, RELEASE_GRACE_MS);
+  }
+
+  private send(channel: VideoChannel, on: boolean): void {
+    // A `send` while the socket is closed is dropped by design; the reconnect path re-sends.
+    this.socket?.send({
+      type: on ? "SubscribeVideo" : "UnsubscribeVideo",
+      data: { device_set: channel.deviceSet, channel: channel.channel },
+    });
+  }
+}
+
+/** The hub the shell attaches to its socket, module-level like the spectrum one so a face
+ * remounting never drops a stream another face is still watching. */
+export const videoHub = new VideoHub();

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -3,20 +3,23 @@
 // (`onEvent`/`onStatus`/`onAudio`); subsystems that must observe the same events without
 // stealing those use the add/remove listener methods.
 //
-// Spectrum is a listener *set*, not a handler: a canvas can carry several scope faces (CANVAS
-// §1), and a single slot meant the last one mounted silently starved the others and cleared
-// their feed on unmount. Frames carry the device-set id as their stream id, so each listener
-// filters for its own.
+// Spectrum and video are listener *sets*, not handlers: a canvas can carry several scope faces
+// and several channel faces (CANVAS §1), and a single slot meant the last one mounted silently
+// starved the others and cleared their feed on unmount. Each listener filters on the stream id
+// the server allocated for its own subscription.
 
 import { withToken } from "./auth";
 import {
   type AudioFrame,
   decodeAudio,
   decodeSpectrum,
+  decodeVideo,
   FRAME_KIND_AUDIO_OPUS,
   FRAME_KIND_SPECTRUM,
+  FRAME_KIND_VIDEO_GRAY,
   frameKind,
   type SpectrumFrame,
+  type VideoFrame,
 } from "./frame";
 import type { ClientCommand, ServerEvent } from "./types";
 
@@ -35,6 +38,7 @@ export class SdrSocket {
   private readonly eventListeners = new Set<(event: ServerEvent) => void>();
   private readonly statusListeners = new Set<(connected: boolean) => void>();
   private readonly spectrumListeners = new Set<(frame: SpectrumFrame) => void>();
+  private readonly videoListeners = new Set<(frame: VideoFrame) => void>();
 
   onEvent: (event: ServerEvent) => void = () => {};
   onStatus: (connected: boolean) => void = () => {};
@@ -80,6 +84,14 @@ export class SdrSocket {
 
   removeSpectrumListener(listener: (frame: SpectrumFrame) => void): void {
     this.spectrumListeners.delete(listener);
+  }
+
+  addVideoListener(listener: (frame: VideoFrame) => void): void {
+    this.videoListeners.add(listener);
+  }
+
+  removeVideoListener(listener: (frame: VideoFrame) => void): void {
+    this.videoListeners.delete(listener);
   }
 
   addStatusListener(listener: (connected: boolean) => void): void {
@@ -169,6 +181,15 @@ export class SdrSocket {
         const frame = decodeAudio(buffer);
         if (frame) {
           this.onAudio(frame);
+        }
+        break;
+      }
+      case FRAME_KIND_VIDEO_GRAY: {
+        const frame = decodeVideo(buffer);
+        if (frame) {
+          for (const listener of this.videoListeners) {
+            listener(frame);
+          }
         }
         break;
       }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -606,6 +606,22 @@ fn decoder_fixtures() -> Vec<Fixture> {
         note: "subghz channel at +100 kHz -> 24-bit PWM 0A1B23, address 0A1B2 button 3".to_string(),
     });
 
+    // Wider and longer than the rest: a raster needs the device above the mode's 2 Msps channel,
+    // and a receiver has to hunt sync before it scans anything out, so two frames is the least
+    // that shows a picture on replay.
+    const ATV_RATE: f64 = 2_400_000.0;
+    let atv_params = sdrmm_wire::AtvParams::default();
+    out.push(Fixture {
+        stem: "atv_ccir625_2m4".to_string(),
+        iq: at(
+            testgen::atv::bars(&testgen::atv::AtvSource::new(&atv_params, ATV_RATE), 2),
+            200_000.0,
+            ATV_RATE,
+        ),
+        rate: ATV_RATE,
+        note: "atv channel at +200 kHz -> 625/25 AM, five vertical bars black to white".to_string(),
+    });
+
     out
 }
 


### PR DESCRIPTION
Adds the `atv` channel type — and, with it, the picture transport this codebase did not have. FEATURES.md said WEFAX was blocked on "an `IMAGE` binary frame kind, a server-side page store and a canvas panel … a transport decision and not a decoder". Two thirds of that now exist.

## Demodulator — `crates/channels/src/atv.rs`

Envelope (AM) or discriminator (FM) → sync-tip/peak-white level tracking → sync separation by pulse width → per-line resampling into 8-bit luma, one picture per field.

A raster is a clock-recovery problem wearing a picture: its only framing is the shape of its own blanking, so everything hangs off classifying low pulses by width. A short one is a line, a long one is a field, a half-width one is an equalizing pulse that must be ignored or every line comes out twice as fast.

- **625/25 (CCIR B/G), 525/30 (EIA RS-170A), 405/25 (System A)**, each from its own timing table — porches and active window as fractions of the line the *source* is actually sending, not of the nominal.
- **Flywheel** with a ±8 % acceptance window and a 1.15-line coast, so a burst of noise costs one torn line instead of the rest of the field.
- **Interlace** recovered from the half-line offset of the field's vertical sync — that displacement is the whole of what tells the two fields apart. `interlace: false` decodes a progressive source.
- **Black clamped per line** off its own back porch rather than assuming the 30 % blanking level, which is what holds brightness steady through a fade.
- **Nothing reaches the picture until the line clock locks.** A free-running flywheel over an empty channel would scan out a raster the decoder invented; an empty channel produces no picture at all.

2 Msps channel rate: the lowest that resolves a 625-line raster (128 samples to a line) and the highest every receiver on the shelf can feed — an RTL-SDR runs 2.048 or 2.4 Msps and the DDC decimates onto it exactly.

## Transport

`VIDEO_GRAY` binary WS frame kind (`u16 width, u16 height, u8[]` luma, additive — no protocol bump), `SubscribeVideo` → `VideoStreamStarted`, per-connection ids from the same media range audio uses (`AUDIO_ID_BASE` → `MEDIA_ID_BASE`, one allocator, `(kind, id)` unique per socket). A channel with no video is refused rather than handed a stream that would stay empty.

The engine's per-channel `ChannelAudio` becomes `ChannelMedia` carrying a `ChannelSinks` bundle, so a pipeline rebuild preserves the picture stream exactly as it already preserved the audio one. `ChannelHost::build` takes the bundle instead of a growing argument list.

Client: `videoHub`, refcounted per `(device set, channel)` with the same release grace, reconnect resubscribe and id-learning contract as `spectrumHub`; a `VideoView` canvas panel on the channel's own face, drawn at the picture's native size and displayed at 4:3.

## Deliberate limits — decisions, not omissions

- **Luma only.** Chroma (PAL/NTSC/SECAM alike) rides inside the video band and is left there; at SDR-channel bandwidths it would be noise on the luma rather than a second picture. The sound subcarrier is untouched. Both are listed `[planned]` in FEATURES.md §8.
- **Symmetric channel filter** about the carrier, over a broadcast signal that is vestigial-sideband. It costs a lift below the vestige's corner — a soft low-frequency contrast boost, not a lost picture — and it is what an envelope detector wants either way. Documented at `occupied_band`.
- **Uncompressed, field-rate transport.** ~104×576 at 50 fields/s ≈ 3 MB/s per subscriber. Desktop-only target, localhost link; a codec between the demodulator and the canvas would cost more than the bytes it saved.
- **The picture freezes under a closed squelch** (default is open). Audio-only demods keep the cheap skip; feeding ATV zero-fill at 2 Msps would spend the CPU the gate exists to save.
- **`seq` restarts on a pipeline rebuild**, `timestamp` does not — the sample position is the continuous clock and `seq` numbers frames for display.
- Note for a future mode that produces *both* decoder events and pictures: both branches of the squelch now publish through one `publish_frames`, so a gated picture can't be silently dropped by the next `reset()`. Nothing has both today.

## Tests

- **Reference modulator** (`testgen/atv.rs`) written from the standards' timing tables in absolute microseconds and their field structure in half-lines — independent of the decoder in method (it lays a raster out in time; the decoder recovers one by classifying pulse widths). Its own tests assert the frame closes on exactly one frame period, the fields differ by exactly half a line, the levels sit where the standards put them, and AM keys sync to peak carrier.
- **Decoder**: bar geometry and luma on 625/25; ascending bars across all three standards × both modulations; `invert` undoing a reversed transmission; progressive fill; a noisy channel keeping contrast; silence producing nothing; `apply` changing geometry mid-scan; bandwidth/rate refusals.
- **Performance gate** (CLAUDE.md): the demod must stay ahead of real time in an unoptimized build — it beats it by ~3× today, so the gate trips on an order-of-magnitude regression.
- **Engine end-to-end** through `device-virtual` at 2.4 Msps (so a real resampler is in the path): a planted SigMF ATV recording comes back as a 576-row picture with black on the left and white on the right, plus the refusal path for a channel with no video.
- **Server**: WS lifecycle — id disjoint from a live audio stream, stop on unsubscribe, refusal naming the mode.
- **Web**: `decodeVideo` including the geometry-vs-payload check, and the hub's refcount / grace / reconnect / id-routing behaviour.
- `cargo xtask fixtures` gains `atv_ccir625_2m4`; `fixtures/README.md` updated.

**Specification-proven only** — it scans the synthesized raster and has never seen a real transmission. FEATURES.md says so, in line with the standing convention for the other decoders.

## Gate

`cargo fmt`, `cargo clippy --all-targets -D warnings`, `biome ci`, `oxlint --type-aware`, `tsgo --noEmit` all clean; codegen re-run against the commit shows no drift. Tests were run per crate (`channels` 271, `wire` 86, `engine` incl. the new e2e, `server`, web 336) rather than as one sweep — the full suite, `pnpm build` and the Playwright smoke flow are left to CI.