### PR TITLE
Digital voice: DMR, D-Star, YSF, NXDN, P25, dPMR and M17 framing decoders

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -149,10 +149,51 @@ Nothing here is built; the dial and the plot were built so it can hang off them 
 
 ## 9. Digital voice
 
-- **[planned]** DMR, D-Star, YSF, NXDN, P25, dPMR
-- **[planned]** M17, FreeDV
-- **[planned]** Trunking following — P25 / DMR Tier III control channel decode with auto-steered voice channels
+**These decode the call, not the voice.** Every mode below but M17 carries an AMBE-family
+vocoder, and this build ships none — no digital-voice channel produces audio. What they do
+recover is the signalling around the payload, which is what a scanner log is made of: who
+transmitted, to which talkgroup or callsign, on which colour code or network, encrypted or not.
+
+- **[shipped]** Shared C4FM front end — discriminator, root-raised-cosine matched filter, Gardner
+  symbol clock, and decision levels *measured* rather than assumed, so an under-deviated
+  transmitter decodes and one front end serves the ±1944 Hz 12.5 kHz modes and the ±1050 Hz
+  6.25 kHz ones alike
+- **[shipped]** DMR — all eight sync patterns, Golay(20,8) slot type, BPTC(196,96) signalling:
+  voice LC header, terminator, CSBK and data header, each confirmed by the Reed-Solomon or CRC
+  mask that names its own frame type. Talkgroup, radio ID, colour code, group/private,
+  encryption flag. **Late entry**: the BPTC(128,77) embedded link control is reassembled from
+  bursts B–E of a voice superframe, so a call joined in progress names itself within 240 ms
+- **[shipped]** M17 — the one mode that names both parties in the clear: link setup frame through
+  derandomiser, quadratic interleaver, P1 depuncturing, Viterbi and CRC-16, with base-40
+  callsigns, encryption flag and end-of-transmission
+- **[shipped]** System Fusion (YSF) — FICH through its interleaver, Viterbi, four Golay(24,12,8)
+  blocks and CRC-16: frame type, data mode and DG-ID, one log line per call rather than ten a
+  second
+- **[shipped]** P25 Phase 1 — frame sync, status-symbol stripping and the BCH(63,16,23) network
+  identifier: NAC and data unit id, so headers, calls, terminators and trunking blocks are
+  distinguished and a system is identified by its NAC
+- **[shipped]** dPMR — FS1/FS3/FS4 framing and the full header information field (descrambled,
+  de-interleaved, CRC-8 checked): called and calling IDs, colour code, individual versus group
+- **[shipped]** NXDN — frame sync word and link information channel at both channel widths
+  (6.25 kHz at 2400 symbols/s, 12.5 kHz at 4800): channel type, direction, frame shape
+- **[shipped]** D-Star — GMSK receiver plus the slow-data channel, which is how a receiver that
+  joined a call in progress gets the header: URCALL, MYCALL, repeater and the text message, all
+  behind the header's own CRC
+- **[shipped]** Every mode verified against its specification via a reference modulator that
+  encodes the real framing (the same BPTC, Golay, convolutional and CRC layers, in reverse), fed
+  through the decoder in ragged block splits, plus a noise-decodes-to-nothing test per mode.
+  **None has yet decoded a real signal** — the same caveat the ADS-B/AIS/ACARS/NAVTEX decoders
+  carry, and the constants most likely to be wrong are named in each module's header comment
+- **[planned]** Vocoder audio — AMBE+2/IMBE for the six, Codec2 for M17. The framing above is
+  what a vocoder would plug into
+- **[planned]** P25 link control and trunking blocks (LDU1 link control, TSBK), NXDN SACCH/FACCH
+  addressing, YSF callsigns, M17 stream LICH late entry — the layers below each mode's framing
+- **[planned]** FreeDV
+- **[planned]** Trunking following — P25 / DMR Tier III control channel decode with auto-steered
+  voice channels. Needs the control-channel payloads above first
 - **[planned]** Hardware AMBE dongle/server support
+- **[planned]** DMR repeater slot numbering — the CACH that names the timeslot is not decoded, so
+  a slot is reported only where the sync pattern itself names it (direct mode)
 
 ## 10. Aviation & marine
 

--- a/crates/channels/src/dv/dmr.rs
+++ b/crates/channels/src/dv/dmr.rs
@@ -1,0 +1,652 @@
+//! DMR Tier II/III decoder (ETSI TS 102 361-1): 4FSK at 4800 symbols per second in 12.5 kHz,
+//! two 30 ms TDMA slots on one carrier.
+//!
+//! A burst is 264 bits: 108 payload, a 48-bit sync or embedded signalling field, 108 payload.
+//! Which of the eight sync patterns matched says whether the burst is voice or data and whether
+//! it came from a repeater, a radio, or a direct-mode radio naming its own slot. From there:
+//!
+//! * **Data bursts** carry a Golay(20,8) slot type split either side of the sync — colour code
+//!   and data type — and 196 bits of BPTC(196,96) product code around it, which unpacks into a
+//!   voice LC header, a terminator, a CSBK or a data header. The link control's Reed-Solomon
+//!   (12,9) parity is masked per frame type, so verifying it also *confirms* the frame type.
+//! * **Voice bursts** carry a QR(16,7,6) embedded signalling field instead of a sync, and
+//!   bursts B to E of a superframe carry one quarter each of a BPTC(128,77) embedded link
+//!   control. That is the late-entry path: a receiver that joins a call in progress learns who
+//!   is talking within 240 ms rather than waiting for the next transmission.
+//!
+//! Only burst A of a voice superframe has a sync to find, so B to E are located by counting:
+//! the superframe is six 60 ms slots, 264 symbols apart in the slot the sync arrived on.
+//!
+//! **Repeater slot numbering is not decoded.** A repeater names the slot in the CACH that
+//! precedes each burst, which this does not read yet; direct-mode transmissions name their slot
+//! in the sync pattern itself and are reported with it.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{Bptc128, Bptc196, CyclicCode, Fsk4Demod, crc16_msb, rs129_parity};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DmrParams, DvFrame,
+    DvFrameKind, DvMode,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow, bits_to_u32, pack_bytes};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+const BAUD: f64 = 4_800.0;
+/// Outer-symbol deviation of a 12.5 kHz C4FM transmitter (ETSI TS 102 361-1 §4.2.2).
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+const BANDWIDTH_HZ: f64 = 12_500.0;
+
+const BURST_BITS: usize = 264;
+const BURST_SYMBOLS: usize = BURST_BITS / 2;
+const SYNC_BITS: u32 = 48;
+/// Bits of the burst before the sync field, and so symbols still to arrive when it matches.
+const HALF_PAYLOAD_BITS: usize = 108;
+const TRAILING_SYMBOLS: usize = HALF_PAYLOAD_BITS / 2;
+
+/// One 60 ms TDMA cycle: this burst, then the other slot's. Bursts B to E of a voice
+/// superframe are found by counting these out from burst A rather than by a sync search.
+const SUPERFRAME_STRIDE: usize = BURST_SYMBOLS * 2;
+
+/// Bit errors tolerated in a 48-bit sync. Four is under a tenth of the pattern and well inside
+/// what its distance from the other seven allows.
+const SYNC_TOLERANCE: u32 = 4;
+
+/// Data types carried in the slot type (ETSI TS 102 361-1 §9.3.6).
+const DT_PI_HEADER: u8 = 0x0;
+const DT_VOICE_LC_HEADER: u8 = 0x1;
+const DT_TERMINATOR_WITH_LC: u8 = 0x2;
+const DT_CSBK: u8 = 0x3;
+const DT_DATA_HEADER: u8 = 0x6;
+
+/// CRC masks that make a frame type part of its own integrity check (§B.3.11).
+const VOICE_LC_HEADER_MASK: [u8; 3] = [0x96, 0x96, 0x96];
+const TERMINATOR_LC_MASK: [u8; 3] = [0x99, 0x99, 0x99];
+const CSBK_MASK: u16 = 0xA5A5;
+const DATA_HEADER_MASK: u16 = 0xCCCC;
+
+/// Full link control: 72 bits of addressing plus 24 of Reed-Solomon parity.
+const LC_BITS: usize = 72;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "dmr".to_owned(),
+    name: "DMR".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+/// A sync pattern and what matching it tells the decoder.
+struct Sync {
+    bits: u64,
+    voice: bool,
+    /// Direct-mode patterns name their timeslot; the repeater and radio ones do not, because
+    /// there the slot lives in the CACH.
+    slot: Option<u8>,
+}
+
+/// ETSI TS 102 361-1 §9.1.1, as the 48 bits each occupies.
+const SYNCS: [Sync; 8] = [
+    Sync {
+        bits: 0x755F_D7DF_75F7,
+        voice: true,
+        slot: None,
+    },
+    Sync {
+        bits: 0xDFF5_7D75_DF5D,
+        voice: false,
+        slot: None,
+    },
+    Sync {
+        bits: 0x7F7D_5DD5_7DFD,
+        voice: true,
+        slot: None,
+    },
+    Sync {
+        bits: 0xD5D7_F77F_D757,
+        voice: false,
+        slot: None,
+    },
+    Sync {
+        bits: 0x5D57_7F77_57FF,
+        voice: true,
+        slot: Some(1),
+    },
+    Sync {
+        bits: 0xF7FD_D5DD_FD55,
+        voice: false,
+        slot: Some(1),
+    },
+    Sync {
+        bits: 0x7DFF_D5F5_5D5F,
+        voice: true,
+        slot: Some(2),
+    },
+    Sync {
+        bits: 0xD755_7F5F_F7F5,
+        voice: false,
+        slot: Some(2),
+    },
+];
+
+pub struct DmrChannel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&DmrParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Dmr(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "dmr channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for DmrChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        let p = *params(&settings)?;
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, BAUD, DEVIATION_HZ, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(p),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        self.decoder.params = *params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+/// What the decoder is waiting for.
+#[derive(Clone, Copy)]
+enum Pending {
+    /// Nothing; hunting for a sync.
+    None,
+    /// A burst whose sync has been seen, waiting for its trailing payload.
+    Burst { voice: bool, slot: Option<u8> },
+    /// A voice burst located by counting from the superframe's burst A.
+    VoiceFollower { slot: Option<u8> },
+}
+
+struct Decoder {
+    params: DmrParams,
+    window: SymbolWindow,
+    pending: Pending,
+    /// Symbols still to arrive before the pending burst is complete.
+    countdown: usize,
+    /// Voice bursts of the current superframe still expected (B to F).
+    followers: u8,
+    bits: Vec<bool>,
+    bytes: Vec<u8>,
+    /// Embedded link control fragments collected across bursts B to E.
+    embedded: Vec<bool>,
+    /// Bit errors repaired in the frames that built the embedded link control.
+    embedded_errors: u32,
+}
+
+impl Decoder {
+    fn new(params: DmrParams) -> Self {
+        Self {
+            params,
+            window: SymbolWindow::new(BURST_SYMBOLS),
+            pending: Pending::None,
+            countdown: 0,
+            followers: 0,
+            bits: Vec::with_capacity(BURST_BITS),
+            bytes: Vec::with_capacity(BURST_BITS / 8),
+            embedded: Vec::with_capacity(Bptc128::CODED_BITS),
+            embedded_errors: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.pending = Pending::None;
+        self.countdown = 0;
+        self.followers = 0;
+        self.embedded.clear();
+        self.embedded_errors = 0;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown > 0 {
+                return;
+            }
+            match std::mem::replace(&mut self.pending, Pending::None) {
+                Pending::None => {}
+                Pending::Burst { voice, slot } => self.burst(voice, slot, out),
+                Pending::VoiceFollower { slot } => self.voice_burst(slot, out),
+            }
+            return;
+        }
+        self.hunt();
+    }
+
+    /// Look for a sync pattern ending at the symbol just pushed.
+    fn hunt(&mut self) {
+        for sync in &SYNCS {
+            if self.window.sync_distance(sync.bits, SYNC_BITS) <= SYNC_TOLERANCE {
+                self.pending = Pending::Burst {
+                    voice: sync.voice,
+                    slot: sync.slot,
+                };
+                self.countdown = TRAILING_SYMBOLS;
+                // A sync means the superframe restarted; whatever fragments were being
+                // collected belong to a call that has ended.
+                self.embedded.clear();
+                self.embedded_errors = 0;
+                return;
+            }
+        }
+    }
+
+    /// A burst whose last symbol has just arrived.
+    fn burst(&mut self, voice: bool, slot: Option<u8>, out: &mut ChannelOutputs) {
+        if voice {
+            // Burst A of a voice superframe: no signalling of its own, but it anchors the
+            // five that follow, which carry the embedded link control.
+            self.followers = 5;
+            self.schedule_follower(slot);
+            return;
+        }
+        self.followers = 0;
+        self.window.bits(0, BURST_SYMBOLS, &mut self.bits);
+        let Some(frame) = self.data_burst(slot) else {
+            return;
+        };
+        self.emit(frame, out);
+    }
+
+    fn schedule_follower(&mut self, slot: Option<u8>) {
+        if self.followers == 0 {
+            return;
+        }
+        self.followers -= 1;
+        self.pending = Pending::VoiceFollower { slot };
+        self.countdown = SUPERFRAME_STRIDE;
+    }
+
+    /// A voice burst B to F, located by counting rather than by a sync.
+    fn voice_burst(&mut self, slot: Option<u8>, out: &mut ChannelOutputs) {
+        self.window.bits(0, BURST_SYMBOLS, &mut self.bits);
+        if let Some(frame) = self.embedded_signalling(slot) {
+            self.emit(frame, out);
+        }
+        self.schedule_follower(slot);
+    }
+
+    fn emit(&self, frame: DvFrame, out: &mut ChannelOutputs) {
+        if frame
+            .slot
+            .is_none_or(|slot| self.params.slots.accepts(slot))
+        {
+            out.events.push(DecoderEvent::Dv(frame));
+        }
+    }
+
+    /// Slot type and BPTC payload of a data burst.
+    fn data_burst(&mut self, slot: Option<u8>) -> Option<DvFrame> {
+        let slot_type = u64::from(bits_to_u32(&self.bits, 98, 10)) << 10
+            | u64::from(bits_to_u32(&self.bits, 156, 10));
+        let (info, slot_errors) = CyclicCode::GOLAY_20_8.decode(slot_type)?;
+        let colour = (info >> 4) as u16 & 0x0F;
+        let data_type = info as u8 & 0x0F;
+
+        let mut coded = [false; Bptc196::CODED_BITS];
+        for (slot, &bit) in coded
+            .iter_mut()
+            .zip(self.bits[0..98].iter().chain(&self.bits[166..264]))
+        {
+            *slot = bit;
+        }
+        let (payload, payload_errors) = Bptc196::decode(&coded)?;
+        let errors = slot_errors + payload_errors;
+
+        let mut frame = match data_type {
+            DT_VOICE_LC_HEADER => self.link_control(&payload, VOICE_LC_HEADER_MASK)?,
+            DT_TERMINATOR_WITH_LC => {
+                let mut frame = self.link_control(&payload, TERMINATOR_LC_MASK)?;
+                frame.kind = DvFrameKind::Terminator;
+                frame
+            }
+            DT_CSBK => self.csbk(&payload)?,
+            DT_DATA_HEADER => {
+                let mut frame = self.checked_block(&payload, DATA_HEADER_MASK)?;
+                frame.kind = DvFrameKind::Data;
+                frame
+            }
+            // A privacy indicator header says the payload that follows is encrypted, and
+            // nothing else this decoder can read — its own fields are encrypted too.
+            DT_PI_HEADER => {
+                let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Header);
+                frame.encrypted = Some(true);
+                frame
+            }
+            // Rate 1/2, 3/4 and full-rate data blocks, MBC continuations and idle: framed
+            // correctly, but nothing that names a call.
+            _ => return None,
+        };
+        frame.slot = slot;
+        frame.color_code = Some(colour);
+        frame.errors_corrected = errors;
+        Some(frame)
+    }
+
+    /// A 96-bit block whose last 16 bits are a mask-XORed CRC-16 over the rest.
+    fn checked_block(&mut self, payload: &[bool; 96], mask: u16) -> Option<DvFrame> {
+        pack_bytes(&payload[..80], &mut self.bytes);
+        let expected = dmr_crc16(&self.bytes) ^ mask;
+        let found = bits_to_u32(payload, 80, 16) as u16;
+        (expected == found).then(|| DvFrame::new(DvMode::Dmr, DvFrameKind::Control))
+    }
+
+    /// A full link control: 72 bits of addressing under Reed-Solomon(12,9) parity, masked by
+    /// frame type so a header cannot be read as a terminator.
+    fn link_control(&mut self, payload: &[bool; 96], mask: [u8; 3]) -> Option<DvFrame> {
+        pack_bytes(payload, &mut self.bytes);
+        let (lc, parity) = self.bytes.split_at(LC_BITS / 8);
+        let mut received = [parity[0], parity[1], parity[2]];
+        for (byte, m) in received.iter_mut().zip(mask) {
+            *byte ^= m;
+        }
+        if rs129_parity(lc) != received {
+            return None;
+        }
+        Some(decode_lc(payload))
+    }
+
+    /// A control signalling block: opcode, feature set id, and the two addresses most of the
+    /// opcodes carry in the same place.
+    fn csbk(&mut self, payload: &[bool; 96]) -> Option<DvFrame> {
+        let mut frame = self.checked_block(payload, CSBK_MASK)?;
+        let opcode = bits_to_u32(payload, 2, 6) as u8;
+        frame.opcode = Some(csbk_opcode_name(opcode).to_owned());
+        // Preamble, and the call setup/teardown opcodes, all carry destination then source in
+        // the last 48 bits of the block. The ones that do not are named but not read.
+        if matches!(
+            opcode,
+            0x03 | 0x04 | 0x05 | 0x26 | 0x27 | 0x28 | 0x38 | 0x3D
+        ) {
+            frame.destination = Some(bits_to_u32(payload, 32, 24));
+            frame.source = Some(bits_to_u32(payload, 56, 24));
+        }
+        Some(frame)
+    }
+
+    /// The embedded signalling field of a voice burst: colour code and the link control
+    /// fragment index, and — once four fragments have arrived — the link control itself.
+    fn embedded_signalling(&mut self, slot: Option<u8>) -> Option<DvFrame> {
+        let emb = u64::from(bits_to_u32(&self.bits, 108, 8)) << 8
+            | u64::from(bits_to_u32(&self.bits, 148, 8));
+        let (info, errors) = CyclicCode::QR_16_7.decode(emb)?;
+        let colour = (info >> 3) as u16 & 0x0F;
+        let encrypted = info >> 2 & 1 == 1;
+        let lcss = info & 0b11;
+
+        // 00 is a single-fragment reverse-channel word this decoder has no use for; the other
+        // three are the quarters of an embedded link control, in order.
+        match lcss {
+            0b01 => {
+                self.embedded.clear();
+                self.embedded_errors = 0;
+            }
+            // A continuation or last fragment with nothing before it belongs to a superframe
+            // this receiver did not hear the start of.
+            0b10 | 0b11 if !self.embedded.is_empty() => {}
+            _ => return None,
+        }
+        self.embedded.extend(self.bits[116..148].iter().copied());
+        self.embedded_errors += errors;
+
+        if lcss != 0b10 {
+            return None;
+        }
+        let coded: [bool; Bptc128::CODED_BITS] = self.embedded.as_slice().try_into().ok()?;
+        let (data, bptc_errors) = Bptc128::decode(&coded)?;
+        self.embedded.clear();
+
+        // The 77 bits are the 72-bit link control with a five-bit checksum threaded through
+        // column 10 of rows 2 to 6.
+        let mut lc = [false; LC_BITS];
+        let mut checksum = 0u32;
+        let mut written = 0;
+        for (i, &bit) in data.iter().enumerate() {
+            if i >= 22 && i % 11 == 10 {
+                checksum = checksum << 1 | u32::from(bit);
+            } else {
+                lc[written] = bit;
+                written += 1;
+            }
+        }
+        pack_bytes(&lc, &mut self.bytes);
+        let sum = self.bytes.iter().map(|&b| u32::from(b)).sum::<u32>() % 31;
+        if sum != checksum {
+            return None;
+        }
+        let mut frame = decode_lc(&lc);
+        frame.kind = DvFrameKind::Voice;
+        frame.slot = slot;
+        frame.color_code = Some(colour);
+        frame.encrypted = Some(encrypted);
+        frame.errors_corrected = self.embedded_errors + bptc_errors;
+        Some(frame)
+    }
+}
+
+/// The addressing a full link control carries, whichever path it arrived by (ETSI §9.1.6).
+fn decode_lc(lc: &[bool]) -> DvFrame {
+    let flco = bits_to_u32(lc, 2, 6);
+    let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Header);
+    // FLCO 0 is a group call, 3 a call to one radio; the rest are talker alias and GPS
+    // blocks, which carry no addresses of their own.
+    match flco {
+        0 | 3 => {
+            frame.group_call = Some(flco == 0);
+            frame.destination = Some(bits_to_u32(lc, 24, 24));
+            frame.source = Some(bits_to_u32(lc, 48, 24));
+            // Service options bit 6 is the encryption flag.
+            frame.encrypted = Some(lc[17]);
+        }
+        _ => frame.opcode = Some(format!("FLCO {flco}")),
+    }
+    frame
+}
+
+fn csbk_opcode_name(opcode: u8) -> &'static str {
+    match opcode {
+        0x00 => "BS outbound activation",
+        0x03 => "unit-to-unit voice service request",
+        0x04 => "unit-to-unit voice service answer",
+        0x05 => "channel timing",
+        0x06 => "negative acknowledge response",
+        0x07 => "call alert",
+        0x08 => "call alert acknowledge",
+        0x24 => "ALOHA",
+        0x26 => "unit registration request",
+        0x27 => "unit registration response",
+        0x28 => "group voice channel grant",
+        0x2A => "private voice channel grant",
+        0x30 => "protect",
+        0x38 => "preamble",
+        0x3D => "talkgroup voice channel grant",
+        _ => "CSBK",
+    }
+}
+
+/// DMR's CRC-16 (ETSI TS 102 361-1 §B.3.10): the un-reflected CCITT register, initialised to
+/// zero and inverted at the end, sent high byte first. Not the reflected X-25 variant the HDLC
+/// modes use, and the difference is not detectable by inspection — only by a frame that fails.
+fn dmr_crc16(data: &[u8]) -> u16 {
+    !crc16_msb(0x1021, 0, data)
+}
+
+#[cfg(test)]
+mod tests {
+    use sdrmm_wire::DmrSlots;
+
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::dmr as tx, testutil::settings};
+
+    fn channel(slots: DmrSlots) -> DmrChannel {
+        DmrChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Dmr(DmrParams { slots })),
+        )
+        .expect("dmr channel")
+    }
+
+    /// The whole path: a direct-mode call's header, the embedded link control its voice
+    /// superframe repeats, and its terminator.
+    #[test]
+    fn decodes_a_call_from_header_to_terminator() {
+        let call = tx::Call::default();
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+
+        let header = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Header)
+            .expect("voice LC header");
+        assert_eq!(header.mode, DvMode::Dmr);
+        assert_eq!(header.slot, Some(1));
+        assert_eq!(header.color_code, Some(u16::from(call.color_code)));
+        assert_eq!(header.group_call, Some(true));
+        assert_eq!(header.destination, Some(call.destination));
+        assert_eq!(header.source, Some(call.source));
+        assert_eq!(header.errors_corrected, 0);
+
+        // Late entry: the same addressing, recovered from the voice superframe alone.
+        let embedded = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Voice)
+            .expect("embedded link control");
+        assert_eq!(embedded.destination, Some(call.destination));
+        assert_eq!(embedded.source, Some(call.source));
+        assert_eq!(embedded.color_code, Some(u16::from(call.color_code)));
+
+        assert!(
+            frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
+            "no terminator: {frames:?}"
+        );
+    }
+
+    #[test]
+    fn decodes_a_private_call_header() {
+        let call = tx::Call {
+            group: false,
+            destination: 2_621_002,
+            ..tx::Call::default()
+        };
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+        let header = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Header)
+            .expect("voice LC header");
+        assert_eq!(header.group_call, Some(false));
+        assert_eq!(header.destination, Some(call.destination));
+    }
+
+    #[test]
+    fn decodes_a_csbk() {
+        let iq = tx::csbk(3, 0x38, 505, 2_621_001, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+        let csbk = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Control)
+            .expect("csbk");
+        assert_eq!(csbk.color_code, Some(3));
+        assert_eq!(csbk.opcode.as_deref(), Some("preamble"));
+        assert_eq!(csbk.destination, Some(505));
+        assert_eq!(csbk.source, Some(2_621_001));
+    }
+
+    /// The slot filter drops what the operator asked not to see, and the generator transmits
+    /// slot 1 only.
+    #[test]
+    fn the_slot_filter_selects_what_is_reported() {
+        let iq = tx::transmission(&tx::Call::default(), INPUT_RATE_HZ);
+        assert!(!decode(&mut channel(DmrSlots::One), &iq).is_empty());
+        assert!(decode(&mut channel(DmrSlots::Two), &iq).is_empty());
+    }
+
+    /// Noise is not a call. Nothing may reach the log from a channel carrying only noise, at
+    /// any level — the product code and the Reed-Solomon parity exist to make that true.
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(9, 0.5, 400_000);
+        assert!(decode(&mut channel(DmrSlots::Both), &noise).is_empty());
+    }
+
+    /// A retune abandons the transmitter the decoder was following: whatever it had collected
+    /// describes a call on the frequency it just left.
+    #[test]
+    fn retuning_forgets_the_call_in_progress() {
+        let call = tx::Call::default();
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let mut chan = channel(DmrSlots::Both);
+        let mut out = ChannelOutputs::default();
+        // Half a transmission, then a retune, then the rest: the embedded link control that
+        // spans the cut must not be assembled out of both halves.
+        chan.process(&iq[..iq.len() / 2], &mut out);
+        chan.retuned();
+        out.reset();
+        chan.process(&iq[iq.len() / 2..], &mut out);
+        let frames: Vec<&DvFrame> = out
+            .events
+            .iter()
+            .map(|event| {
+                let DecoderEvent::Dv(frame) = event else {
+                    panic!("unexpected event")
+                };
+                frame
+            })
+            .collect();
+        assert!(
+            frames.iter().all(|f| f.kind != DvFrameKind::Voice),
+            "an embedded link control was assembled across the retune: {frames:?}"
+        );
+    }
+}

--- a/crates/channels/src/dv/dpmr.rs
+++ b/crates/channels/src/dv/dpmr.rs
@@ -1,0 +1,337 @@
+//! dPMR decoder (ETSI TS 102 490): 4FSK at 2400 symbols per second in 6.25 kHz — the licence-
+//! free 446 MHz digital radios and their commercial cousins.
+//!
+//! Four frame sync words separate the four things a transmission can be doing (§6.1), and the
+//! header behind two of them carries the addressing in the clear:
+//!
+//! * **FS1** (48 bits) opens a voice or short-data header, twice over: two copies of the same
+//!   72-bit header information either side of the colour code, so a receiver that misses one
+//!   still has the other.
+//! * **FS4** (48 bits) opens a packet-data header, laid out the same way.
+//! * **FS3** (24 bits) marks the end frame. The superframe's own FS2 marker is not hunted
+//!   for: 24 bits with no payload check behind them match noise several times a minute, and
+//!   the header already says a call is running.
+//!
+//! Header information is CRC-8 checked, split into ten bytes, each carried by a shortened
+//! Hamming(12,8), interleaved 12 × 10 and scrambled with `x⁹ + x⁵ + 1` (§7.7). The Hamming code
+//! is systematic, so the information comes straight out of the first eight bits of each block —
+//! this decoder detects errors with the CRC rather than correcting them with the Hamming
+//! parity, which is what the doubled header is for.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::Fsk4Demod;
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DpmrParams, DvFrame,
+    DvFrameKind, DvMode,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow, bits_to_u32};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+/// 4800 bit/s over 2400 symbols, at half the deviation of the 12.5 kHz modes.
+const BAUD: f64 = 2_400.0;
+const DEVIATION_HZ: f64 = 1_050.0;
+const RRC_ALPHA: f64 = 0.2;
+const BANDWIDTH_HZ: f64 = 6_250.0;
+
+/// ETSI TS 102 490 §6.1.
+const FS1: u64 = 0x57FF_5F75_D577;
+const FS4: u64 = 0xFD55_F5DF_7FDD;
+const FS3: u64 = 0x7D_DFF5;
+const LONG_SYNC_BITS: u32 = 48;
+const SHORT_SYNC_BITS: u32 = 24;
+const LONG_TOLERANCE: u32 = 4;
+/// Half the tolerance for half the pattern: 24 bits at four errors is a pattern noise matches
+/// several times a minute, and a superframe marker has no payload check behind it to catch that.
+const SHORT_TOLERANCE: u32 = 2;
+
+/// Header information: 72 bits under a CRC-8, ten Hamming(12,8) blocks on the wire.
+const HI_BITS: usize = 72;
+const HI_CODED_BITS: usize = 120;
+const HI_BLOCKS: usize = 10;
+const HI_SYMBOLS: usize = HI_CODED_BITS / 2;
+/// The colour code between the two header copies: twelve bits, each sent as a di-bit (§6.1.5).
+const CC_SYMBOLS: usize = 12;
+/// Everything the header frame carries after FS1: HI0, the colour code, HI1.
+const HEADER_SYMBOLS: usize = HI_SYMBOLS * 2 + CC_SYMBOLS;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "dpmr".to_owned(),
+    name: "dPMR".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct DpmrChannel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&DpmrParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Dpmr(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "dpmr channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for DpmrChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        params(&settings)?;
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, BAUD, DEVIATION_HZ, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+struct Decoder {
+    window: SymbolWindow,
+    countdown: usize,
+    /// Set while a header's payload is arriving; carries whether it was a packet-data header.
+    pending_packet: Option<bool>,
+    bits: Vec<bool>,
+    /// True while a superframe is being received, so its repeated sync marks nothing new.
+    in_call: bool,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            window: SymbolWindow::new(HEADER_SYMBOLS),
+            countdown: 0,
+            pending_packet: None,
+            bits: Vec::with_capacity(HEADER_SYMBOLS * 2),
+            in_call: false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.countdown = 0;
+        self.pending_packet = None;
+        self.in_call = false;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown == 0
+                && let Some(packet) = self.pending_packet.take()
+                && let Some(frame) = self.header(packet)
+            {
+                out.events.push(DecoderEvent::Dv(frame));
+            }
+            return;
+        }
+        if self.pending_packet.is_some() {
+            return;
+        }
+        for (sync, packet) in [(FS1, false), (FS4, true)] {
+            if self.window.sync_distance(sync, LONG_SYNC_BITS) <= LONG_TOLERANCE {
+                self.pending_packet = Some(packet);
+                self.countdown = HEADER_SYMBOLS;
+                self.in_call = true;
+                return;
+            }
+        }
+        // Both superframe markers are only believed inside a call: nothing behind either of
+        // them can be checked, and the header that opened the call is what vouches for them.
+        // A call joined after its header has passed is therefore not reported (FEATURES §9).
+        if !self.in_call {
+            return;
+        }
+        if self.window.sync_distance(FS3, SHORT_SYNC_BITS) <= SHORT_TOLERANCE {
+            self.in_call = false;
+            out.events.push(DecoderEvent::Dv(DvFrame::new(
+                DvMode::Dpmr,
+                DvFrameKind::Terminator,
+            )));
+        }
+    }
+
+    /// The two header copies and the colour code between them.
+    fn header(&mut self, packet: bool) -> Option<DvFrame> {
+        self.window.bits(0, HEADER_SYMBOLS, &mut self.bits);
+        let colour = colour_code(&self.bits[HI_CODED_BITS..HI_CODED_BITS + CC_SYMBOLS * 2]);
+        // Either copy will do; the second exists because the first may not survive.
+        let hi = header_info(&self.bits[..HI_CODED_BITS])
+            .or_else(|| header_info(&self.bits[HI_CODED_BITS + CC_SYMBOLS * 2..]))?;
+
+        let mut frame = DvFrame::new(
+            DvMode::Dpmr,
+            if packet {
+                DvFrameKind::Data
+            } else {
+                DvFrameKind::Header
+            },
+        );
+        frame.color_code = colour;
+        frame.destination = Some(bits_to_u32(&hi, 4, 24));
+        frame.source = Some(bits_to_u32(&hi, 28, 24));
+        // Communication mode 0 is an individual call; the rest are group and all-call modes.
+        frame.group_call = Some(bits_to_u32(&hi, 52, 3) != 0);
+        Some(frame)
+    }
+}
+
+/// Twelve colour-code bits, each sent as the di-bit `01` for zero and `11` for one (§6.1.5).
+/// Any other di-bit means the field did not survive, and a wrong colour code is worse than
+/// none.
+fn colour_code(bits: &[bool]) -> Option<u16> {
+    let mut value = 0;
+    for &[first, second] in bits.as_chunks::<2>().0 {
+        if !second {
+            return None;
+        }
+        value = value << 1 | u16::from(first);
+    }
+    Some(value)
+}
+
+/// Undo scrambling, interleaving and the systematic Hamming blocks, and check the CRC-8.
+fn header_info(coded: &[bool]) -> Option<Vec<bool>> {
+    let mut descrambled = [false; HI_CODED_BITS];
+    let mut register = 0x1FFu16;
+    for (i, slot) in descrambled.iter_mut().enumerate() {
+        let feedback = (register >> 8 ^ register >> 4) & 1;
+        register = (register << 1 | feedback) & 0x1FF;
+        *slot = coded[i] ^ (feedback == 1);
+    }
+    // The interleaver writes the ten 12-bit blocks down the columns of a 12 × 10 matrix and
+    // reads the rows out, so the transmitted bit at row r, column c is block c bit r.
+    let mut blocks = [false; HI_CODED_BITS];
+    for r in 0..12 {
+        for c in 0..HI_BLOCKS {
+            blocks[c * 12 + r] = descrambled[r * HI_BLOCKS + c];
+        }
+    }
+    // Hamming(12,8) is systematic: the byte is the first eight bits of its block.
+    let mut bytes = [0u8; HI_BLOCKS];
+    let mut info = Vec::with_capacity(HI_BITS);
+    for (block, byte) in bytes.iter_mut().enumerate() {
+        for bit in 0..8 {
+            let value = blocks[block * 12 + bit];
+            *byte = *byte << 1 | u8::from(value);
+            if block * 8 + bit < HI_BITS {
+                info.push(value);
+            }
+        }
+    }
+    (crc8(&bytes[..9]) == bytes[9]).then_some(info)
+}
+
+/// CRC-8 with polynomial `x⁸ + x² + x + 1` (§7.2).
+fn crc8(data: &[u8]) -> u8 {
+    let mut crc = 0u8;
+    for &byte in data {
+        crc ^= byte;
+        for _ in 0..8 {
+            crc = if crc & 0x80 != 0 {
+                crc << 1 ^ 0x07
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::dpmr as tx, testutil::settings};
+
+    fn channel() -> DpmrChannel {
+        DpmrChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Dpmr(DpmrParams::default())),
+        )
+        .expect("dpmr channel")
+    }
+
+    #[test]
+    fn decodes_a_header_and_its_end_frame() {
+        let call = tx::Call::default();
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+
+        let header = frames.first().expect("a decoded frame");
+        assert_eq!(header.mode, DvMode::Dpmr);
+        assert_eq!(header.kind, DvFrameKind::Header);
+        assert_eq!(header.color_code, Some(call.colour_code));
+        assert_eq!(header.destination, Some(call.called));
+        assert_eq!(header.source, Some(call.own));
+        assert_eq!(header.group_call, Some(true));
+        assert!(
+            frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
+            "no end frame: {frames:?}"
+        );
+    }
+
+    #[test]
+    fn decodes_an_individual_call() {
+        let call = tx::Call {
+            mode: 0,
+            called: 0x00_00FF,
+            ..tx::Call::default()
+        };
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+        let header = frames.first().expect("a decoded frame");
+        assert_eq!(header.group_call, Some(false));
+        assert_eq!(header.destination, Some(call.called));
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(69, 0.5, 400_000);
+        assert!(decode(&mut channel(), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/dv/dstar.rs
+++ b/crates/channels/src/dv/dstar.rs
@@ -1,0 +1,341 @@
+//! D-Star decoder: GMSK at 4800 bit/s in 6.25 kHz — the one two-level mode of the seven, so it
+//! demodulates the way AIS does rather than through the four-level front end.
+//!
+//! A transmission opens with a header the receiver almost never gets to read: it is sent once,
+//! convolutionally coded, interleaved and scrambled, and a receiver that joins late has missed
+//! it. D-Star's answer is to send it again — every voice frame carries three bytes of slow
+//! data, and the header is repeated through that channel over twenty frames. This decoder reads
+//! the slow data, which means it recovers the callsigns of a call it joined in the middle, and
+//! the text message that rides in the same channel.
+//!
+//! Slow data is scrambled with the fixed sequence 0x70 0x4F 0x93 and framed as a type nibble
+//! and a length, in pairs of frames (six bytes at a time). The reassembled header is checked
+//! against its own CRC-16 before any callsign reaches the log.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{
+    BitSync, DcBlocker, FmDemod, RealDecimator, crc16_x25, design_gaussian, hamming_distance,
+};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DstarParams, DvFrame,
+    DvFrameKind, DvMode,
+};
+
+use super::INPUT_RATE_HZ;
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+const BAUD: f64 = 4_800.0;
+/// GMSK at ±1200 Hz with a 0.5 bandwidth-time product, which is what an ICOM radio transmits.
+const DEVIATION_HZ: f64 = 1_200.0;
+const BT: f64 = 0.5;
+const MATCHED_SPAN: usize = 3;
+const BANDWIDTH_HZ: f64 = 6_250.0;
+
+/// The 24-bit frame sync a transmission repeats every 21 voice frames: 0x552D16, sent low bit
+/// first like every other byte in this mode.
+const SYNC: u32 = 0x0055_2D16;
+const SYNC_BITS: u32 = 24;
+const SYNC_TOLERANCE: u32 = 2;
+
+/// A voice frame: 72 bits of vocoder payload and 24 bits of data.
+const FRAME_BITS: usize = 96;
+const DATA_BITS: usize = 24;
+/// Frames between one sync and the next.
+const FRAMES_PER_SUPERFRAME: usize = 21;
+
+/// The slow-data scrambling sequence, applied byte by byte.
+const SCRAMBLER: [u8; 3] = [0x70, 0x4F, 0x93];
+
+/// Slow-data packet types, in the high nibble of the first byte.
+const TYPE_TEXT: u8 = 0x4;
+const TYPE_HEADER: u8 = 0x5;
+
+/// The header a transmission names itself with: flags, four callsigns, a suffix and a CRC.
+const HEADER_BYTES: usize = 41;
+const CALLSIGN_LEN: usize = 8;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "dstar".to_owned(),
+    name: "D-STAR".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct DstarChannel {
+    demod: FmDemod,
+    matched: RealDecimator,
+    dc: DcBlocker,
+    sync: BitSync,
+    decoder: Decoder,
+    demod_buf: Vec<f32>,
+    filtered: Vec<f32>,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&DstarParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Dstar(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "dstar channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for DstarChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        params(&settings)?;
+        let sps = ctx.input_rate / BAUD;
+        Ok(Self {
+            demod: FmDemod::new(ctx.input_rate, DEVIATION_HZ),
+            matched: RealDecimator::new(&design_gaussian(sps, BT, MATCHED_SPAN), 1),
+            dc: DcBlocker::new(),
+            sync: BitSync::new(ctx.input_rate, BAUD),
+            decoder: Decoder::new(),
+            demod_buf: Vec::new(),
+            filtered: Vec::new(),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.sync.reset();
+        self.dc = DcBlocker::new();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        self.demod.process(iq, &mut self.demod_buf);
+        self.dc.process(&mut self.demod_buf);
+        self.matched.process(&self.demod_buf, &mut self.filtered);
+        for &sample in &self.filtered {
+            if let Some(bit) = self.sync.push(sample) {
+                self.decoder.push(bit, out);
+            }
+        }
+    }
+}
+
+struct Decoder {
+    register: u32,
+    /// Bits into the current voice frame, once a sync has been found.
+    bit: usize,
+    /// Frames since the last sync; the sync itself is frame 0 of a superframe.
+    frame: usize,
+    synced: bool,
+    /// The 24 data bits of the frame being received.
+    data: u32,
+    /// Slow data of the current frame pair; a packet spans two frames.
+    packet: Vec<u8>,
+    /// Header bytes reassembled from the slow-data channel.
+    header: Vec<u8>,
+    text: [u8; 20],
+    /// The call last reported, so a header repeated every second is logged once.
+    reported: Option<String>,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            register: 0,
+            bit: 0,
+            frame: 0,
+            synced: false,
+            data: 0,
+            packet: Vec::with_capacity(6),
+            header: Vec::with_capacity(HEADER_BYTES),
+            text: [b' '; 20],
+            reported: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.register = 0;
+        self.synced = false;
+        self.bit = 0;
+        self.frame = 0;
+        self.packet.clear();
+        self.header.clear();
+        self.reported = None;
+    }
+
+    fn push(&mut self, bit: bool, out: &mut ChannelOutputs) {
+        self.register = self.register << 1 | u32::from(bit);
+        if !self.synced {
+            let mask = (1u32 << SYNC_BITS) - 1;
+            if hamming_distance(u64::from(self.register & mask), u64::from(SYNC & mask))
+                <= SYNC_TOLERANCE
+            {
+                self.synced = true;
+                self.bit = 0;
+                self.frame = 1;
+                self.packet.clear();
+            }
+            return;
+        }
+        self.bit += 1;
+        if self.bit > FRAME_BITS - DATA_BITS {
+            self.data = self.data << 1 | u32::from(bit);
+        }
+        if self.bit < FRAME_BITS {
+            return;
+        }
+        self.bit = 0;
+        let frame = self.frame;
+        self.frame += 1;
+        if self.frame >= FRAMES_PER_SUPERFRAME {
+            // The next frame is a sync frame; hunt for it rather than assuming it.
+            self.synced = false;
+        }
+        // The sync frame's data field is the sync itself, not slow data.
+        if !frame.is_multiple_of(FRAMES_PER_SUPERFRAME) {
+            self.slow_data(frame, out);
+        }
+    }
+
+    /// Three descrambled bytes per frame, two frames per packet.
+    fn slow_data(&mut self, frame: usize, out: &mut ChannelOutputs) {
+        for (i, mask) in SCRAMBLER.into_iter().enumerate() {
+            self.packet.push((self.data >> (16 - i * 8)) as u8 ^ mask);
+        }
+        // Packets start on odd frames, so a complete one is six bytes gathered from a pair.
+        if frame.is_multiple_of(2) && self.packet.len() >= 6 {
+            let packet: Vec<u8> = self.packet.drain(..6).collect();
+            self.packet.clear();
+            self.packet_complete(&packet, out);
+        } else if self.packet.len() > 6 {
+            self.packet.clear();
+        }
+    }
+
+    fn packet_complete(&mut self, packet: &[u8], out: &mut ChannelOutputs) {
+        let kind = packet[0] >> 4;
+        let length = usize::from(packet[0] & 0x0F).min(packet.len() - 1);
+        match kind {
+            TYPE_HEADER => {
+                // Header segments arrive in order and restart at the first one; anything else
+                // is a segment from a transmission this receiver did not hear the start of.
+                if self.header.len() + length > HEADER_BYTES {
+                    self.header.clear();
+                }
+                self.header.extend_from_slice(&packet[1..=length]);
+                if self.header.len() == HEADER_BYTES
+                    && let Some(frame) = self.header_frame()
+                {
+                    out.events.push(DecoderEvent::Dv(frame));
+                }
+            }
+            TYPE_TEXT => {
+                // Four characters per packet, at the offset the low nibble names.
+                let slot = usize::from(packet[0] & 0x03) * 5;
+                for (i, &byte) in packet[1..5].iter().enumerate() {
+                    if slot + i < self.text.len() {
+                        self.text[slot + i] = byte;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// The reassembled 41-byte header, once its CRC agrees.
+    fn header_frame(&mut self) -> Option<DvFrame> {
+        let header = std::mem::take(&mut self.header);
+        let (body, crc) = header.split_at(HEADER_BYTES - 2);
+        if crc16_x25(body) != u16::from_le_bytes([crc[0], crc[1]]) {
+            return None;
+        }
+        let call = |offset: usize, len: usize| {
+            let text = String::from_utf8_lossy(&header[offset..offset + len])
+                .trim()
+                .to_owned();
+            (!text.is_empty()).then_some(text)
+        };
+        let source = call(27, CALLSIGN_LEN);
+        // The same call, sent every second for the length of the transmission.
+        if self.reported == source && source.is_some() {
+            return None;
+        }
+        self.reported.clone_from(&source);
+
+        let mut frame = DvFrame::new(DvMode::Dstar, DvFrameKind::Header);
+        frame.destination_call = call(19, CALLSIGN_LEN);
+        frame.source_call = source;
+        frame.via = call(3, CALLSIGN_LEN);
+        frame.group_call = Some(frame.destination_call.as_deref() == Some("CQCQCQ"));
+        let text = String::from_utf8_lossy(&self.text).trim().to_owned();
+        frame.text = (!text.is_empty()).then_some(text);
+        Some(frame)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::dstar as tx, testutil::settings};
+
+    fn channel() -> DstarChannel {
+        DstarChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Dstar(DstarParams::default())),
+        )
+        .expect("dstar channel")
+    }
+
+    /// The late-entry path: no header transmission is heard at all, and the callsigns come out
+    /// of the slow-data channel that carries the header again while the call runs.
+    #[test]
+    fn decodes_the_callsigns_from_the_slow_data_channel() {
+        let call = tx::Call::default();
+        let iq = tx::transmission(&call, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+
+        let header = frames.first().expect("a decoded frame");
+        assert_eq!(header.mode, DvMode::Dstar);
+        assert_eq!(header.kind, DvFrameKind::Header);
+        assert_eq!(header.source_call.as_deref(), Some(call.mycall.as_str()));
+        assert_eq!(
+            header.destination_call.as_deref(),
+            Some(call.urcall.as_str())
+        );
+        assert_eq!(header.via.as_deref(), Some(call.repeater.as_str()));
+        assert_eq!(header.group_call, Some(true));
+    }
+
+    /// The header repeats for as long as the transmission lasts; the log gets one line.
+    #[test]
+    fn a_repeated_header_is_reported_once() {
+        let iq = tx::transmission(&tx::Call::default(), INPUT_RATE_HZ);
+        assert_eq!(decode(&mut channel(), &iq).len(), 1);
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(81, 0.5, 400_000);
+        assert!(decode(&mut channel(), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/dv/m17.rs
+++ b/crates/channels/src/dv/m17.rs
@@ -1,0 +1,415 @@
+//! M17 decoder (M17 specification, 2024): C4FM at 4800 symbols per second, root-raised-cosine
+//! shaped at 0.5, in 9 kHz.
+//!
+//! The one open mode of the seven, and the only one whose call setup is fully readable: a link
+//! setup frame carries both callsigns in the clear, base-40 encoded into 48 bits each, under a
+//! convolutional code and a CRC. This decodes them.
+//!
+//! A frame is a 16-bit sync burst and 368 payload bits. Which sync arrived says what the frame
+//! is — link setup, stream, packet, or the end-of-transmission marker. The link setup payload
+//! is undone in the order the transmitter applied it: derandomise with the specification's
+//! 46-byte sequence, deinterleave by the quadratic permutation, restore the bits the puncturing
+//! pattern removed, then Viterbi-decode and check the CRC.
+//!
+//! The Codec2 payload of a stream frame is not decoded (FEATURES §9) — that is a vocoder, and
+//! this build has none — so a stream frame is reported only through its link setup.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{
+    Fsk4Demod, Viterbi5, crc16_msb,
+    fec::conv::{ERASURE, Soft},
+};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DvFrame, DvFrameKind, DvMode,
+    M17Params,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+const BAUD: f64 = 4_800.0;
+/// M17 deviates ±2400 Hz on its outer symbols and shapes with α = 0.5.
+const DEVIATION_HZ: f64 = 2_400.0;
+const RRC_ALPHA: f64 = 0.5;
+const BANDWIDTH_HZ: f64 = 9_000.0;
+
+/// The four sync bursts, 16 bits each (M17 spec §2.5).
+const SYNC_LSF: u64 = 0x55F7;
+const SYNC_STREAM: u64 = 0xFF5D;
+const SYNC_PACKET: u64 = 0x75FF;
+const SYNC_EOT: u64 = 0x555D;
+const SYNC_BITS: u32 = 16;
+/// Two bit errors in a 16-bit burst; the four bursts are far enough apart for that.
+const SYNC_TOLERANCE: u32 = 2;
+
+/// Payload of every frame: 184 symbols, 368 bits.
+const PAYLOAD_SYMBOLS: usize = 184;
+const PAYLOAD_BITS: usize = 368;
+/// The link setup frame before puncturing: 240 information bits plus four flush bits, at rate
+/// 1/2.
+const LSF_CODED_BITS: usize = 488;
+const LSF_BITS: usize = 240;
+const LSF_BYTES: usize = LSF_BITS / 8;
+
+/// P1, the puncturing pattern a link setup frame is thinned with: 46 of every 61 coded bits are
+/// transmitted, which is exactly 368 of 488.
+const PUNCTURE_1: [bool; 61] = {
+    let mut pattern = [true; 61];
+    let mut i = 2;
+    while i < 61 {
+        pattern[i] = false;
+        i += 4;
+    }
+    pattern
+};
+
+/// The randomiser: 368 bits of the specification's fixed sequence, XORed over the payload so a
+/// long run of one symbol never reaches the air.
+const RANDOMIZER: [u8; 46] = [
+    0xD6, 0xB5, 0xE2, 0x30, 0x82, 0xFF, 0x84, 0x62, 0xBA, 0x4E, 0x96, 0x90, 0xD8, 0x98, 0xDD, 0x5D,
+    0x0C, 0xC8, 0x52, 0x43, 0x91, 0x1D, 0xF8, 0x6E, 0x68, 0x2F, 0x35, 0xDA, 0x14, 0xEA, 0xCD, 0x76,
+    0x19, 0x8D, 0xD5, 0x80, 0xD1, 0x33, 0x87, 0x13, 0x57, 0x18, 0x2D, 0x29, 0x78, 0xC3,
+];
+
+/// M17's CRC: polynomial 0x5935 with an all-ones register.
+const CRC_POLY: u16 = 0x5935;
+const CRC_INIT: u16 = 0xFFFF;
+
+/// The interleaver, as the quadratic permutation the specification defines rather than the
+/// table it prints: bit `i` of the interleaved payload is bit `(45·i + 92·i²) mod 368`.
+fn interleave_index(i: usize) -> usize {
+    (45 * i + 92 * i * i) % PAYLOAD_BITS
+}
+
+/// Callsign alphabet: index 0 is the space that pads a short callsign (M17 spec §2.3.1).
+const CALLSIGN_ALPHABET: &[u8; 40] = b" ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "m17".to_owned(),
+    name: "M17".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct M17Channel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&M17Params, ChannelError> {
+    match &settings.params {
+        ChannelParams::M17(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "m17 channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for M17Channel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        params(&settings)?;
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, BAUD, DEVIATION_HZ, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+/// What the sync burst said the frame is.
+#[derive(Clone, Copy, PartialEq)]
+enum FrameType {
+    LinkSetup,
+    Stream,
+    Packet,
+}
+
+struct Decoder {
+    window: SymbolWindow,
+    viterbi: Viterbi5,
+    pending: Option<FrameType>,
+    countdown: usize,
+    soft: Vec<Soft>,
+    coded: Vec<Soft>,
+    info: Vec<bool>,
+    /// A stream carries its link setup once and then repeats it in fragments; reporting the
+    /// same call every 40 ms would drown the log.
+    in_stream: bool,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            window: SymbolWindow::new(PAYLOAD_SYMBOLS),
+            viterbi: Viterbi5::new(),
+            pending: None,
+            countdown: 0,
+            soft: Vec::with_capacity(PAYLOAD_BITS),
+            coded: Vec::with_capacity(LSF_CODED_BITS),
+            info: Vec::with_capacity(LSF_BITS + 4),
+            in_stream: false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.pending = None;
+        self.countdown = 0;
+        self.in_stream = false;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown == 0
+                && let Some(kind) = self.pending.take()
+                && let Some(frame) = self.payload(kind)
+            {
+                out.events.push(DecoderEvent::Dv(frame));
+            }
+            return;
+        }
+        if self.pending.is_some() {
+            return;
+        }
+        // The end-of-transmission marker is a sync burst with no payload behind it, so the
+        // only thing vouching for it is the call it ends: without one it is indistinguishable
+        // from the sixteen bits of noise that match it several times a second.
+        if self.in_stream && self.window.sync_distance(SYNC_EOT, SYNC_BITS) <= SYNC_TOLERANCE {
+            self.in_stream = false;
+            out.events.push(DecoderEvent::Dv(DvFrame::new(
+                DvMode::M17,
+                DvFrameKind::Terminator,
+            )));
+            return;
+        }
+        for (sync, kind) in [
+            (SYNC_LSF, FrameType::LinkSetup),
+            (SYNC_STREAM, FrameType::Stream),
+            (SYNC_PACKET, FrameType::Packet),
+        ] {
+            if self.window.sync_distance(sync, SYNC_BITS) <= SYNC_TOLERANCE {
+                self.pending = Some(kind);
+                self.countdown = PAYLOAD_SYMBOLS;
+                return;
+            }
+        }
+    }
+
+    fn payload(&mut self, kind: FrameType) -> Option<DvFrame> {
+        match kind {
+            FrameType::LinkSetup => {
+                let frame = self.link_setup();
+                // A frame that failed its CRC says nothing — including nothing about whether
+                // the call this decoder was following has ended. Sixteen bits of sync match
+                // noise often enough that treating a failure as an end would lose the call.
+                self.in_stream |= frame.is_some();
+                frame
+            }
+            // A stream frame carries a sixth of the link setup — six of them rebuild it, which
+            // is how a receiver joins a call in progress — and a Codec2 payload. Neither is
+            // decoded yet (FEATURES §9), and a sync burst on its own is 16 bits: too little to
+            // report on, since noise clears that bar several times a second.
+            FrameType::Stream => None,
+            FrameType::Packet => self
+                .in_stream
+                .then(|| DvFrame::new(DvMode::M17, DvFrameKind::Data)),
+        }
+    }
+
+    /// Undo the transmitter's payload chain and read the link setup out of it.
+    fn link_setup(&mut self) -> Option<DvFrame> {
+        self.window.soft_bits(0, PAYLOAD_SYMBOLS, &mut self.soft);
+        // Derandomise: the sequence flips bits, which for a soft value is a sign change.
+        for (i, value) in self.soft.iter_mut().enumerate() {
+            if RANDOMIZER[i / 8] >> (7 - i % 8) & 1 == 1 {
+                *value = -*value;
+            }
+        }
+        // Deinterleave, then put an erasure back wherever the puncturing pattern removed a
+        // coded bit — a position the decoder must weigh as evidence for neither branch.
+        let mut deinterleaved = [ERASURE; PAYLOAD_BITS];
+        for (i, &value) in self.soft.iter().enumerate() {
+            deinterleaved[interleave_index(i)] = value;
+        }
+        self.coded.clear();
+        let mut read = 0;
+        for i in 0..LSF_CODED_BITS {
+            if PUNCTURE_1[i % PUNCTURE_1.len()] {
+                self.coded.push(deinterleaved[read]);
+                read += 1;
+            } else {
+                self.coded.push(ERASURE);
+            }
+        }
+        self.info.clear();
+        self.viterbi.decode(&self.coded, &mut self.info);
+
+        let mut lsf = [0u8; LSF_BYTES];
+        for (i, byte) in lsf.iter_mut().enumerate() {
+            *byte = self.info[i * 8..i * 8 + 8]
+                .iter()
+                .fold(0u8, |acc, &b| acc << 1 | u8::from(b));
+        }
+        // The CRC covers the whole frame including its own two bytes, so a good frame leaves a
+        // zero register.
+        if crc16_msb(CRC_POLY, CRC_INIT, &lsf) != 0 {
+            return None;
+        }
+
+        let mut frame = DvFrame::new(DvMode::M17, DvFrameKind::Header);
+        frame.destination_call = callsign(u64::from_be_bytes([
+            0, 0, lsf[0], lsf[1], lsf[2], lsf[3], lsf[4], lsf[5],
+        ]));
+        frame.source_call = callsign(u64::from_be_bytes([
+            0, 0, lsf[6], lsf[7], lsf[8], lsf[9], lsf[10], lsf[11],
+        ]));
+        let stream_type = u16::from_be_bytes([lsf[12], lsf[13]]);
+        frame.group_call = Some(frame.destination_call.as_deref() == Some("ALL"));
+        frame.encrypted = Some(stream_type >> 3 & 0b11 != 0);
+        frame.opcode = Some(
+            if stream_type & 1 == 1 {
+                "stream"
+            } else {
+                "packet"
+            }
+            .to_owned(),
+        );
+        Some(frame)
+    }
+}
+
+/// Base-40 callsign decoding (M17 spec §2.3.1). `0xFFFFFFFFFF` is the broadcast address, which
+/// every radio answers to and which no base-40 value can collide with.
+fn callsign(address: u64) -> Option<String> {
+    if address == 0 {
+        return None;
+    }
+    if address == 0xFFFF_FFFF_FFFF {
+        return Some("ALL".to_owned());
+    }
+    if address > 40u64.pow(9) {
+        return None;
+    }
+    let mut value = address;
+    let mut call = Vec::new();
+    while value > 0 {
+        call.push(CALLSIGN_ALPHABET[(value % 40) as usize]);
+        value /= 40;
+    }
+    String::from_utf8(call).ok().map(|s| s.trim().to_owned())
+}
+
+/// Base-40 encoding of a callsign: the inverse of [`callsign`], which is what makes the
+/// round-trip test below a test of the decoding and not of a shared table.
+#[cfg(test)]
+fn encode_callsign(call: &str) -> u64 {
+    if call == "ALL" {
+        return 0xFFFF_FFFF_FFFF;
+    }
+    call.bytes()
+        .rev()
+        .filter_map(|c| CALLSIGN_ALPHABET.iter().position(|&a| a == c))
+        .fold(0u64, |acc, index| acc * 40 + index as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::m17 as tx, testutil::settings};
+
+    fn channel() -> M17Channel {
+        M17Channel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::M17(M17Params::default())),
+        )
+        .expect("m17 channel")
+    }
+
+    /// The mode that can say who is talking without a vocoder, saying it.
+    #[test]
+    fn decodes_the_callsigns_of_a_link_setup_frame() {
+        let iq = tx::transmission("ALL", "DL1ABC", INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+
+        let lsf = frames.first().expect("a decoded frame");
+        assert_eq!(lsf.mode, DvMode::M17);
+        assert_eq!(lsf.kind, DvFrameKind::Header);
+        assert_eq!(lsf.source_call.as_deref(), Some("DL1ABC"));
+        assert_eq!(lsf.destination_call.as_deref(), Some("ALL"));
+        assert_eq!(lsf.group_call, Some(true));
+        assert_eq!(lsf.encrypted, Some(false));
+        assert_eq!(lsf.opcode.as_deref(), Some("stream"));
+        assert!(
+            frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
+            "no end of transmission: {frames:?}"
+        );
+    }
+
+    #[test]
+    fn decodes_a_call_between_two_stations() {
+        let iq = tx::transmission("DL9XYZ", "M0ABC", INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+        let lsf = frames.first().expect("a decoded frame");
+        assert_eq!(lsf.destination_call.as_deref(), Some("DL9XYZ"));
+        assert_eq!(lsf.source_call.as_deref(), Some("M0ABC"));
+        assert_eq!(lsf.group_call, Some(false));
+    }
+
+    #[test]
+    fn callsigns_round_trip_through_base_40() {
+        for call in ["DL1ABC", "M0ABC", "SP5WWP", "N0CALL", "ALL"] {
+            assert_eq!(callsign(encode_callsign(call)).as_deref(), Some(call));
+        }
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(45, 0.5, 400_000);
+        assert!(decode(&mut channel(), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/dv/mod.rs
+++ b/crates/channels/src/dv/mod.rs
@@ -1,0 +1,178 @@
+//! Digital-voice decoders (PLAN §13 wave 3): DMR, D-Star, System Fusion, NXDN, P25 Phase 1,
+//! dPMR and M17.
+//!
+//! **These decode the call, not the voice.** Every mode but M17 carries an AMBE-family vocoder
+//! (AMBE+2, IMBE, AMBE2+ under its various names) and this build ships no vocoder, so no
+//! digital-voice channel produces audio — `has_audio` is false for all seven. What they do
+//! produce is the signalling around the payload: who transmitted, to which talkgroup or
+//! callsign, on which colour code or network, through which repeater, encrypted or not. That is
+//! what a scanner log is made of, and it is decodable without a vocoder.
+//!
+//! Six of the seven share a front end — [`sdrmm_dsp::Fsk4Demod`], four-level FSK at 4800 or
+//! 2400 symbols per second — and differ only in their sync patterns, framing and error coding.
+//! D-Star is the exception: it is two-level GMSK and demodulates like AIS does.
+//!
+//! Each mode is a module here with its own `type_id`, because they occupy different bandwidths
+//! and an operator picks a mode by name. They all emit the same [`DvFrame`](sdrmm_wire::DvFrame)
+//! so one panel, one log filter and (later) one trunking follower serve all of them.
+
+pub(crate) mod dmr;
+pub(crate) mod dpmr;
+pub(crate) mod dstar;
+pub(crate) mod m17;
+pub(crate) mod nxdn;
+pub(crate) mod p25;
+pub(crate) mod ysf;
+
+use std::collections::VecDeque;
+
+pub use dmr::DmrChannel;
+pub use dpmr::DpmrChannel;
+pub use dstar::DstarChannel;
+pub use m17::M17Channel;
+pub use nxdn::NxdnChannel;
+pub use p25::P25Channel;
+use sdrmm_dsp::{Decimator, design_lowpass, fsk4};
+pub use ysf::YsfChannel;
+
+use crate::ChannelFilter;
+
+/// Every C4FM mode here runs at this rate: 10 samples per symbol at 4800 baud, 20 at 2400.
+pub(crate) const INPUT_RATE_HZ: f64 = 48_000.0;
+
+/// Channel-selection filter for a digital-voice mode of `bandwidth_hz`. Long enough to reject
+/// the adjacent channel at 12.5 kHz spacing, which is where these modes live.
+pub(crate) fn channel_filter(bandwidth_hz: f64) -> ChannelFilter {
+    const TAPS: usize = 129;
+    ChannelFilter::Symmetric(Decimator::new(
+        &design_lowpass(TAPS, bandwidth_hz / 2.0 / INPUT_RATE_HZ),
+        1,
+    ))
+}
+
+/// A rolling window of the most recent soft symbols, with the same window's hard dibits packed
+/// into a shift register for sync-word matching.
+///
+/// Sync patterns are matched against the register; a burst is then read back out of the soft
+/// history, because the error-correcting codes above want soft bits and the sync search wants
+/// hard ones. Index 0 is always the most recent symbol.
+pub(crate) struct SymbolWindow {
+    soft: VecDeque<f32>,
+    register: u64,
+    capacity: usize,
+}
+
+impl SymbolWindow {
+    /// `capacity` is the longest look-back any caller will ask for, in symbols.
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            soft: VecDeque::with_capacity(capacity),
+            register: 0,
+            capacity,
+        }
+    }
+
+    pub(crate) fn push(&mut self, symbol: f32) {
+        if self.soft.len() == self.capacity {
+            self.soft.pop_front();
+        }
+        self.soft.push_back(symbol);
+        self.register = self.register << 2 | u64::from(fsk4::slice(symbol));
+    }
+
+    /// Bit distance between the last `bits` bits shifted in and `pattern`.
+    pub(crate) fn sync_distance(&self, pattern: u64, bits: u32) -> u32 {
+        let mask = if bits >= 64 {
+            u64::MAX
+        } else {
+            (1 << bits) - 1
+        };
+        sdrmm_dsp::hamming_distance(self.register & mask, pattern & mask)
+    }
+
+    /// The soft symbol `back` symbols ago; 0 is the most recent. Zero past the history, which
+    /// is a symbol no slicer prefers either way.
+    pub(crate) fn soft(&self, back: usize) -> f32 {
+        let len = self.soft.len();
+        if back >= len {
+            return 0.0;
+        }
+        self.soft[len - 1 - back]
+    }
+
+    /// Hard bits of the `symbols` symbols ending `end_back` symbols ago, oldest first, two
+    /// bits per symbol.
+    pub(crate) fn bits(&self, end_back: usize, symbols: usize, out: &mut Vec<bool>) {
+        out.clear();
+        for i in (0..symbols).rev() {
+            let dibit = fsk4::slice(self.soft(end_back + i));
+            out.push(dibit & 0b10 != 0);
+            out.push(dibit & 0b01 != 0);
+        }
+    }
+
+    /// Soft bit values of the same span, for the convolutional decoders.
+    pub(crate) fn soft_bits(&self, end_back: usize, symbols: usize, out: &mut Vec<i16>) {
+        out.clear();
+        for i in (0..symbols).rev() {
+            out.extend_from_slice(&fsk4::soft_bits(self.soft(end_back + i)));
+        }
+    }
+
+    /// Forget everything: the channel moved, and a sync half-matched across the retune would
+    /// frame a burst out of two different transmitters.
+    pub(crate) fn reset(&mut self) {
+        self.soft.clear();
+        self.register = 0;
+    }
+}
+
+/// Read `len` bits from `bits` starting at `offset`, MSB first, as an integer.
+pub(crate) fn bits_to_u32(bits: &[bool], offset: usize, len: usize) -> u32 {
+    bits[offset..offset + len]
+        .iter()
+        .fold(0u32, |acc, &b| acc << 1 | u32::from(b))
+}
+
+/// Pack `bits` MSB-first into bytes, discarding a trailing partial byte.
+pub(crate) fn pack_bytes(bits: &[bool], out: &mut Vec<u8>) {
+    out.clear();
+    for chunk in bits.as_chunks::<8>().0 {
+        out.push(chunk.iter().fold(0u8, |acc, &b| acc << 1 | u8::from(b)));
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod testutil {
+    use num_complex::Complex;
+    use sdrmm_wire::{DecoderEvent, DvFrame};
+
+    use crate::{ChannelOutputs, ChannelRx};
+
+    /// Feed a generated transmission through a channel in deliberately ragged blocks and
+    /// collect the frames it decoded. The block sizes are the point: every decoder here carries
+    /// timing, sync and reassembly state across calls, and a burst split across two blocks must
+    /// decode the same as one that is not.
+    pub(crate) fn decode(chan: &mut dyn ChannelRx, iq: &[Complex<f32>]) -> Vec<DvFrame> {
+        let mut out = ChannelOutputs::default();
+        let mut frames = Vec::new();
+        let mut pos = 0;
+        for len in [997usize, 1, 4_096, 65, 2_048, 7].iter().cycle() {
+            if pos >= iq.len() {
+                break;
+            }
+            let end = (pos + len).min(iq.len());
+            out.reset();
+            chan.process(&iq[pos..end], &mut out);
+            assert!(out.audio_pcm.is_empty(), "a vocoder-less mode made audio");
+            for event in out.events.drain(..) {
+                match event {
+                    DecoderEvent::Dv(frame) => frames.push(frame),
+                    other => panic!("unexpected {} event", other.kind()),
+                }
+            }
+            pos = end;
+        }
+        frames
+    }
+}

--- a/crates/channels/src/dv/nxdn.rs
+++ b/crates/channels/src/dv/nxdn.rs
@@ -1,0 +1,269 @@
+//! NXDN decoder: 4FSK in 6.25 kHz at 2400 symbols per second, or 12.5 kHz at 4800.
+//!
+//! Every frame opens with a 20-bit frame sync word and a 16-bit link information channel. The
+//! LICH says what the frame is — a control channel, a traffic channel, whether it is inbound or
+//! outbound, and whether the voice slots have been stolen for signalling — and carries an odd
+//! parity bit that this decoder checks before believing any of it.
+//!
+//! The addresses live one layer further in, in the SACCH and FACCH, behind a punctured
+//! convolutional code and an interleaver this does not implement (FEATURES §9). What is
+//! reported is therefore the frame's shape, not its parties: enough to see a system, its
+//! direction and when it is busy.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::Fsk4Demod;
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DvFrame, DvFrameKind, DvMode,
+    NxdnBandwidth, NxdnParams,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow, bits_to_u32};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+/// Frame sync word 0xCDF59, 20 bits.
+const FSW: u64 = 0x000C_DF59;
+const FSW_BITS: u32 = 20;
+const SYNC_TOLERANCE: u32 = 2;
+
+/// The LICH is the 16 bits after the sync.
+const LICH_BITS: usize = 16;
+const LICH_SYMBOLS: usize = LICH_BITS / 2;
+
+const RRC_ALPHA: f64 = 0.2;
+
+/// Descriptors differ only in the channel width, and the width picks the symbol rate: 6.25 kHz
+/// NXDN is 2400 symbols per second at ±1050 Hz, 12.5 kHz is 4800 at ±1944 Hz.
+fn shape(bandwidth: NxdnBandwidth) -> (f64, f64, f64) {
+    match bandwidth {
+        NxdnBandwidth::Narrow => (2_400.0, 1_050.0, 6_250.0),
+        NxdnBandwidth::Wide => (4_800.0, 1_944.0, 12_500.0),
+    }
+}
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "nxdn".to_owned(),
+    name: "NXDN".to_owned(),
+    bandwidth_hz: 6_250.0,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct NxdnChannel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+    bandwidth: NxdnBandwidth,
+    input_rate: f64,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&NxdnParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Nxdn(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "nxdn channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band(p: &NxdnParams) -> (f64, f64) {
+    let (_, _, bandwidth) = shape(p.bandwidth);
+    (-bandwidth / 2.0, bandwidth / 2.0)
+}
+
+pub(crate) fn channel_filter(p: &NxdnParams) -> ChannelFilter {
+    let (_, _, bandwidth) = shape(p.bandwidth);
+    super::channel_filter(bandwidth)
+}
+
+impl ChannelRx for NxdnChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        let p = *params(&settings)?;
+        let (baud, deviation, _) = shape(p.bandwidth);
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, baud, deviation, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(),
+            bandwidth: p.bandwidth,
+            input_rate: ctx.input_rate,
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        let p = *params(&settings)?;
+        if p.bandwidth != self.bandwidth {
+            // A width change is a different symbol rate, so the front end is rebuilt rather
+            // than retuned; nothing it has learned about the old signal applies.
+            let (baud, deviation, _) = shape(p.bandwidth);
+            self.demod = Fsk4Demod::new(self.input_rate, baud, deviation, RRC_ALPHA);
+            self.decoder.reset();
+            self.bandwidth = p.bandwidth;
+        }
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+struct Decoder {
+    window: SymbolWindow,
+    countdown: usize,
+    hunting: bool,
+    bits: Vec<bool>,
+    last_kind: Option<DvFrameKind>,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            window: SymbolWindow::new(LICH_SYMBOLS),
+            countdown: 0,
+            hunting: true,
+            bits: Vec::with_capacity(LICH_BITS),
+            last_kind: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.countdown = 0;
+        self.hunting = true;
+        self.last_kind = None;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown == 0 {
+                self.hunting = true;
+                if let Some(frame) = self.lich() {
+                    out.events.push(DecoderEvent::Dv(frame));
+                }
+            }
+            return;
+        }
+        if self.hunting && self.window.sync_distance(FSW, FSW_BITS) <= SYNC_TOLERANCE {
+            self.hunting = false;
+            self.countdown = LICH_SYMBOLS;
+        }
+    }
+
+    fn lich(&mut self) -> Option<DvFrame> {
+        self.window.bits(0, LICH_SYMBOLS, &mut self.bits);
+        // RF channel type, functional channel type, option, direction, then odd parity over
+        // the seven bits before it.
+        let information = &self.bits[..8];
+        if information.iter().filter(|b| **b).count() % 2 == 0 {
+            return None;
+        }
+        let rf_channel = bits_to_u32(information, 0, 2);
+        let functional = bits_to_u32(information, 2, 2);
+        let outbound = information[6];
+
+        let kind = match functional {
+            // A non-superframe SACCH opens or closes a transmission; the rest are traffic.
+            0 => DvFrameKind::Header,
+            1 => DvFrameKind::Data,
+            _ if rf_channel == 0 => DvFrameKind::Control,
+            _ => DvFrameKind::Voice,
+        };
+        if kind == DvFrameKind::Voice && self.last_kind == Some(DvFrameKind::Voice) {
+            return None;
+        }
+        self.last_kind = Some(kind);
+
+        let mut frame = DvFrame::new(DvMode::Nxdn, kind);
+        frame.opcode = Some(format!(
+            "{} {}",
+            channel_name(rf_channel),
+            if outbound { "outbound" } else { "inbound" }
+        ));
+        Some(frame)
+    }
+}
+
+fn channel_name(rf_channel: u32) -> &'static str {
+    match rf_channel {
+        0 => "control channel",
+        1 => "traffic channel",
+        2 => "composite channel",
+        _ => "traffic channel (composite control)",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::nxdn as tx, testutil::settings};
+
+    fn channel(bandwidth: NxdnBandwidth) -> NxdnChannel {
+        NxdnChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Nxdn(NxdnParams { bandwidth })),
+        )
+        .expect("nxdn channel")
+    }
+
+    #[test]
+    fn decodes_the_link_information_channel_of_a_traffic_channel() {
+        let iq = tx::transmission(&tx::Shape::default(), 1, true, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(NxdnBandwidth::Narrow), &iq);
+        let first = frames.first().expect("a decoded frame");
+        assert_eq!(first.mode, DvMode::Nxdn);
+        assert_eq!(first.kind, DvFrameKind::Header);
+        assert_eq!(
+            first.opcode.as_deref(),
+            Some("traffic channel outbound"),
+            "{frames:?}"
+        );
+    }
+
+    /// The wide variant is a different radio to the front end: twice the symbol rate and twice
+    /// the deviation, and the same framing above it.
+    #[test]
+    fn decodes_the_twelve_and_a_half_kilohertz_variant() {
+        let shape = tx::Shape {
+            baud: 4_800.0,
+            deviation_hz: 1_944.0,
+        };
+        let iq = tx::transmission(&shape, 0, false, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(NxdnBandwidth::Wide), &iq);
+        let control = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Control)
+            .expect("control channel frame");
+        assert_eq!(control.opcode.as_deref(), Some("control channel inbound"));
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(57, 0.5, 400_000);
+        assert!(decode(&mut channel(NxdnBandwidth::Narrow), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/dv/p25.rs
+++ b/crates/channels/src/dv/p25.rs
@@ -1,0 +1,289 @@
+//! P25 Phase 1 decoder (TIA-102.BAAA): C4FM at 4800 symbols per second in 12.5 kHz.
+//!
+//! Every frame — header, voice, terminator, trunking block — opens with the same 48-bit sync
+//! and a 64-bit network identifier: the 12-bit network access code that separates one system
+//! from the next on a shared frequency, and the 4-bit data unit id that says what the frame is.
+//! The NID is a BCH(63,16,23) codeword with a parity bit, so eleven bit errors still decode.
+//!
+//! That is what this reports: the NAC, and the shape of the transmission — header, call in
+//! progress, terminator, trunking. The link control inside a voice frame, and the trunking
+//! blocks inside a TSDU, are not unpacked (FEATURES §9): both need the frame's own interleaver
+//! and, for the trunking blocks, the rate-1/2 trellis code, and neither can be verified here
+//! against anything but itself.
+//!
+//! Status symbols complicate the framing: the transmitter inserts a dibit of its own after
+//! every 35 payload dibits, starting at bit 70 of the frame, and they have to come out before
+//! the NID is a codeword again.
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{CyclicCode, Fsk4Demod};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DvFrame, DvFrameKind, DvMode,
+    P25Params,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+const BANDWIDTH_HZ: f64 = 12_500.0;
+
+/// Frame sync: 0x5575F5FF77FF, 48 bits.
+const SYNC: u64 = 0x5575_F5FF_77FF;
+const SYNC_BITS: u32 = 48;
+const SYNC_TOLERANCE: u32 = 4;
+
+/// First status symbol of a frame, and how often one follows (TIA-102.BAAA §7.1).
+const STATUS_START: usize = 70;
+const STATUS_STRIDE: usize = 72;
+
+/// The NID is 64 bits, and the two status bits sitting inside it make 66 on the wire.
+const NID_BITS: usize = 64;
+const NID_SYMBOLS: usize = (NID_BITS + 2) / 2;
+
+/// Data unit ids (TIA-102.BAAA §7.3).
+const DUID_HEADER: u8 = 0x0;
+const DUID_TERMINATOR: u8 = 0x3;
+const DUID_LDU1: u8 = 0x5;
+const DUID_TSDU: u8 = 0x7;
+const DUID_LDU2: u8 = 0xA;
+const DUID_PDU: u8 = 0xC;
+const DUID_TERMINATOR_LC: u8 = 0xF;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "p25".to_owned(),
+    name: "P25 Phase 1".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct P25Channel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&P25Params, ChannelError> {
+    match &settings.params {
+        ChannelParams::P25(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "p25 channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for P25Channel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        params(&settings)?;
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, BAUD, DEVIATION_HZ, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+struct Decoder {
+    window: SymbolWindow,
+    countdown: usize,
+    hunting: bool,
+    bits: Vec<bool>,
+    /// The data unit id last reported, so the six voice frames of a transmission produce one
+    /// "call in progress" line rather than one every 180 ms.
+    last_duid: Option<u8>,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            window: SymbolWindow::new(NID_SYMBOLS),
+            countdown: 0,
+            hunting: true,
+            bits: Vec::with_capacity(NID_BITS + 2),
+            last_duid: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.countdown = 0;
+        self.hunting = true;
+        self.last_duid = None;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown == 0 {
+                self.hunting = true;
+                if let Some(frame) = self.nid() {
+                    out.events.push(DecoderEvent::Dv(frame));
+                }
+            }
+            return;
+        }
+        if self.hunting && self.window.sync_distance(SYNC, SYNC_BITS) <= SYNC_TOLERANCE {
+            self.hunting = false;
+            self.countdown = NID_SYMBOLS;
+        }
+    }
+
+    /// Decode the network identifier that follows the sync.
+    fn nid(&mut self) -> Option<DvFrame> {
+        self.window.bits(0, NID_SYMBOLS, &mut self.bits);
+        // The sync ended at frame bit 48, so the status dibit at frame bits 70 and 71 sits at
+        // offset 22 of what follows.
+        let mut word = 0u64;
+        for (i, &bit) in self.bits.iter().enumerate() {
+            let frame_bit = SYNC_BITS as usize + i;
+            if frame_bit >= STATUS_START && (frame_bit - STATUS_START) % STATUS_STRIDE < 2 {
+                continue;
+            }
+            word = word << 1 | u64::from(bit);
+        }
+        let (info, errors) = CyclicCode::BCH_63_16.decode(word)?;
+        let nac = (info >> 4) as u16 & 0x0FFF;
+        let duid = info as u8 & 0x0F;
+
+        let kind = match duid {
+            DUID_HEADER => DvFrameKind::Header,
+            DUID_TERMINATOR | DUID_TERMINATOR_LC => DvFrameKind::Terminator,
+            DUID_TSDU => DvFrameKind::Control,
+            DUID_PDU => DvFrameKind::Data,
+            _ => DvFrameKind::Voice,
+        };
+        // Voice frames repeat; everything else is an event in its own right.
+        if kind == DvFrameKind::Voice && self.last_duid.is_some_and(is_voice) {
+            self.last_duid = Some(duid);
+            return None;
+        }
+        self.last_duid = Some(duid);
+
+        let mut frame = DvFrame::new(DvMode::P25, kind);
+        frame.color_code = Some(nac);
+        frame.errors_corrected = errors;
+        frame.opcode = Some(duid_name(duid).to_owned());
+        Some(frame)
+    }
+}
+
+fn is_voice(duid: u8) -> bool {
+    matches!(duid, DUID_LDU1 | DUID_LDU2)
+}
+
+fn duid_name(duid: u8) -> &'static str {
+    match duid {
+        DUID_HEADER => "header",
+        DUID_TERMINATOR => "terminator",
+        DUID_LDU1 => "voice (LDU1)",
+        DUID_TSDU => "trunking block",
+        DUID_LDU2 => "voice (LDU2)",
+        DUID_PDU => "packet data",
+        DUID_TERMINATOR_LC => "terminator with link control",
+        _ => "reserved",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::p25 as tx, testutil::settings};
+
+    fn channel() -> P25Channel {
+        P25Channel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::P25(P25Params::default())),
+        )
+        .expect("p25 channel")
+    }
+
+    /// The status symbols the transmitter interleaves into the frame are what make this test
+    /// worth having: leave them in and the network identifier is not a codeword at all.
+    #[test]
+    fn decodes_the_network_identifier_of_a_transmission() {
+        let iq = tx::transmission(0x293, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+
+        let header = frames.first().expect("a decoded frame");
+        assert_eq!(header.mode, DvMode::P25);
+        assert_eq!(header.kind, DvFrameKind::Header);
+        assert_eq!(header.color_code, Some(0x293));
+        assert_eq!(header.errors_corrected, 0);
+        assert!(
+            frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
+            "no terminator: {frames:?}"
+        );
+        // Two voice frames, one line.
+        assert_eq!(
+            frames
+                .iter()
+                .filter(|f| f.kind == DvFrameKind::Voice)
+                .count(),
+            1,
+            "{frames:?}"
+        );
+    }
+
+    #[test]
+    fn decodes_a_trunking_block() {
+        let iq = tx::trunking(0x4D2, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+        let control = frames
+            .iter()
+            .find(|f| f.kind == DvFrameKind::Control)
+            .expect("trunking block");
+        assert_eq!(control.color_code, Some(0x4D2));
+        assert_eq!(control.opcode.as_deref(), Some("trunking block"));
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(33, 0.5, 400_000);
+        assert!(decode(&mut channel(), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/dv/ysf.rs
+++ b/crates/channels/src/dv/ysf.rs
@@ -1,0 +1,294 @@
+//! System Fusion (YSF) decoder: C4FM at 4800 symbols per second in 12.5 kHz, 100 ms frames.
+//!
+//! Every frame opens with the same 40-bit sync and a 100-symbol frame information channel. The
+//! FICH is the part worth decoding without a vocoder: it says whether the frame is a header, a
+//! communication frame or a terminator, which of the four data modes it carries, and where it
+//! sits in the transmission — so a log gets one line when a call starts and one when it ends,
+//! rather than ten a second.
+//!
+//! The FICH is protected three times over: a rate-1/2 convolutional code, four Golay(24,12,8)
+//! blocks over its 48 bits, and a CRC-16 across the result. All three have to agree, which is
+//! what makes it safe to report a frame from a mode that carries no addresses in the clear.
+//!
+//! Callsigns travel in the data channel alongside the vocoder frames and are not decoded here:
+//! they need the payload de-interleaver and the same Viterbi pass per sub-block, which is
+//! follow-up work (FEATURES §9).
+
+use std::sync::LazyLock;
+
+use num_complex::Complex;
+use sdrmm_dsp::{CyclicCode, Fsk4Demod, Viterbi5, crc16_msb};
+use sdrmm_wire::{
+    ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DvFrame, DvFrameKind, DvMode,
+    YsfParams,
+};
+
+use super::{INPUT_RATE_HZ, SymbolWindow};
+use crate::{ChannelCtx, ChannelError, ChannelFilter, ChannelOutputs, ChannelRx, check_input_rate};
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+const BANDWIDTH_HZ: f64 = 12_500.0;
+
+/// The sync every frame opens with: 0xD471C9634D, 40 bits.
+const SYNC: u64 = 0x00D4_71C9_634D;
+const SYNC_BITS: u32 = 40;
+const SYNC_TOLERANCE: u32 = 3;
+
+/// The FICH occupies the 100 symbols after the sync.
+const FICH_SYMBOLS: usize = 100;
+/// Its 200 coded bits carry 96 after the convolutional code, and 48 after the Golay blocks.
+const FICH_CODED_BITS: usize = 200;
+const FICH_INFO_BITS: usize = 96;
+const FICH_BYTES: usize = 6;
+
+static DESCRIPTOR: LazyLock<ChannelDescriptor> = LazyLock::new(|| ChannelDescriptor {
+    type_id: "ysf".to_owned(),
+    name: "System Fusion".to_owned(),
+    bandwidth_hz: BANDWIDTH_HZ,
+    input_rate_hz: INPUT_RATE_HZ,
+    has_audio: false,
+    decoder_kind: Some("dv".to_owned()),
+    ..ChannelDescriptor::default()
+});
+
+pub struct YsfChannel {
+    demod: Fsk4Demod,
+    symbols: Vec<f32>,
+    decoder: Decoder,
+}
+
+fn params(settings: &ChannelSettings) -> Result<&YsfParams, ChannelError> {
+    match &settings.params {
+        ChannelParams::Ysf(p) => Ok(p),
+        other => Err(ChannelError::InvalidSettings(format!(
+            "ysf channel got {} params",
+            other.type_id()
+        ))),
+    }
+}
+
+/// Occupied RF band relative to the channel offset, in Hz.
+pub(crate) fn occupied_band() -> (f64, f64) {
+    (-BANDWIDTH_HZ / 2.0, BANDWIDTH_HZ / 2.0)
+}
+
+pub(crate) fn channel_filter() -> ChannelFilter {
+    super::channel_filter(BANDWIDTH_HZ)
+}
+
+impl ChannelRx for YsfChannel {
+    fn descriptor() -> &'static ChannelDescriptor {
+        &DESCRIPTOR
+    }
+
+    fn new(ctx: ChannelCtx, settings: ChannelSettings) -> Result<Self, ChannelError> {
+        check_input_rate(ctx, &DESCRIPTOR)?;
+        params(&settings)?;
+        Ok(Self {
+            demod: Fsk4Demod::new(ctx.input_rate, BAUD, DEVIATION_HZ, RRC_ALPHA),
+            symbols: Vec::new(),
+            decoder: Decoder::new(),
+        })
+    }
+
+    fn apply(&mut self, settings: ChannelSettings) -> Result<(), ChannelError> {
+        params(&settings)?;
+        Ok(())
+    }
+
+    fn retuned(&mut self) {
+        self.demod.reset();
+        self.decoder.reset();
+    }
+
+    fn process(&mut self, iq: &[Complex<f32>], out: &mut ChannelOutputs) {
+        // The front end appends, as every streaming primitive in `dsp` does; the symbols of
+        // the last block have already been decoded.
+        self.symbols.clear();
+        self.demod.process(iq, &mut self.symbols);
+        for &symbol in &self.symbols {
+            self.decoder.push(symbol, out);
+        }
+    }
+}
+
+struct Decoder {
+    window: SymbolWindow,
+    viterbi: Viterbi5,
+    /// Symbols still to arrive before the FICH of a matched frame is complete.
+    countdown: usize,
+    hunting: bool,
+    soft: Vec<i16>,
+    coded: Vec<i16>,
+    info: Vec<bool>,
+    /// Frame type last reported, so a 100 ms heartbeat does not become a log entry per frame.
+    last_kind: Option<DvFrameKind>,
+}
+
+impl Decoder {
+    fn new() -> Self {
+        Self {
+            window: SymbolWindow::new(FICH_SYMBOLS),
+            viterbi: Viterbi5::new(),
+            countdown: 0,
+            hunting: true,
+            soft: Vec::with_capacity(FICH_CODED_BITS),
+            coded: Vec::with_capacity(FICH_CODED_BITS),
+            info: Vec::with_capacity(FICH_INFO_BITS),
+            last_kind: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.window.reset();
+        self.countdown = 0;
+        self.hunting = true;
+        self.last_kind = None;
+    }
+
+    fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
+        self.window.push(symbol);
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            if self.countdown == 0 {
+                self.hunting = true;
+                if let Some(frame) = self.fich() {
+                    out.events.push(DecoderEvent::Dv(frame));
+                }
+            }
+            return;
+        }
+        if self.hunting && self.window.sync_distance(SYNC, SYNC_BITS) <= SYNC_TOLERANCE {
+            self.hunting = false;
+            self.countdown = FICH_SYMBOLS;
+        }
+    }
+
+    /// Decode the FICH sitting in the last 100 symbols.
+    fn fich(&mut self) -> Option<DvFrame> {
+        self.window.soft_bits(0, FICH_SYMBOLS, &mut self.soft);
+        // De-interleave: the FICH is written into a 20 × 5 matrix by column and read by row,
+        // so coded pair `i` comes from bit 2·(i/5) + 40·(i%5).
+        self.coded.clear();
+        for i in 0..FICH_SYMBOLS {
+            let n = 2 * (i / 5) + 40 * (i % 5);
+            self.coded.push(self.soft[n]);
+            self.coded.push(self.soft[n + 1]);
+        }
+        // 100 steps in, 96 information bits out: the last four are the encoder's flush.
+        self.info.clear();
+        self.viterbi.decode(&self.coded, &mut self.info);
+
+        // Four Golay(24,12,8) blocks, 12 information bits each.
+        let mut fich = [0u8; FICH_BYTES];
+        let mut errors = 0;
+        let mut value = 0u64;
+        for block in 0..4 {
+            let word = self.info[block * 24..(block + 1) * 24]
+                .iter()
+                .fold(0u64, |acc, &b| acc << 1 | u64::from(b));
+            let (info, repaired) = CyclicCode::GOLAY_24_12.decode(word)?;
+            errors += repaired;
+            value = value << 12 | u64::from(info);
+        }
+        for (i, byte) in fich.iter_mut().enumerate() {
+            *byte = (value >> (40 - i * 8)) as u8;
+        }
+        // CRC-16 over the four information bytes, sent high byte first.
+        let crc = !crc16_msb(0x1021, 0, &fich[..4]);
+        if crc != u16::from_be_bytes([fich[4], fich[5]]) {
+            return None;
+        }
+
+        let frame_type = fich[0] >> 6 & 0x03;
+        let kind = match frame_type {
+            0 => DvFrameKind::Header,
+            2 => DvFrameKind::Terminator,
+            _ => DvFrameKind::Voice,
+        };
+        // A communication frame arrives ten times a second and says the same thing each time;
+        // only a change of frame type is news.
+        if kind == DvFrameKind::Voice && self.last_kind == Some(DvFrameKind::Voice) {
+            return None;
+        }
+        self.last_kind = Some(kind);
+
+        let mut frame = DvFrame::new(DvMode::Ysf, kind);
+        frame.errors_corrected = errors;
+        frame.group_call = Some(fich[0] >> 2 & 0x03 != 0x03);
+        frame.opcode = Some(data_mode_name(fich[2] & 0x03).to_owned());
+        let dg_id = fich[3] & 0x7F;
+        if dg_id != 0 {
+            frame.destination = Some(u32::from(dg_id));
+        }
+        Some(frame)
+    }
+}
+
+/// The four payload layouts a YSF transmission can use (the FICH "DT" field).
+fn data_mode_name(dt: u8) -> &'static str {
+    match dt {
+        0 => "V/D mode 1",
+        1 => "data FR mode",
+        2 => "V/D mode 2",
+        _ => "voice FR mode",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dv::testutil::decode, testgen::dv::ysf as tx, testutil::settings};
+
+    fn channel() -> YsfChannel {
+        YsfChannel::new(
+            ChannelCtx {
+                input_rate: INPUT_RATE_HZ,
+            },
+            settings(ChannelParams::Ysf(YsfParams::default())),
+        )
+        .expect("ysf channel")
+    }
+
+    #[test]
+    fn decodes_the_frame_information_channel() {
+        let fich = tx::Fich::default();
+        let iq = tx::transmission(&fich, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+
+        let header = frames.first().expect("a decoded frame");
+        assert_eq!(header.mode, DvMode::Ysf);
+        assert_eq!(header.kind, DvFrameKind::Header);
+        assert_eq!(header.opcode.as_deref(), Some("V/D mode 2"));
+        assert_eq!(header.destination, Some(u32::from(fich.dg_id)));
+        assert_eq!(header.errors_corrected, 0);
+        assert!(
+            frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
+            "no terminator: {frames:?}"
+        );
+    }
+
+    /// Three communication frames arrive between the header and the terminator, and they say
+    /// the same thing; the log gets one line, not three.
+    #[test]
+    fn a_run_of_identical_frames_is_reported_once() {
+        let iq = tx::transmission(&tx::Fich::default(), INPUT_RATE_HZ);
+        let frames = decode(&mut channel(), &iq);
+        assert_eq!(
+            frames
+                .iter()
+                .filter(|f| f.kind == DvFrameKind::Voice)
+                .count(),
+            1,
+            "{frames:?}"
+        );
+    }
+
+    #[test]
+    fn noise_decodes_to_nothing() {
+        let noise = crate::testutil::complex_noise(21, 0.5, 400_000);
+        assert!(decode(&mut channel(), &noise).is_empty());
+    }
+}

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -9,6 +9,7 @@ mod adsb;
 mod ais;
 mod am;
 mod aprs;
+mod dv;
 mod morse;
 mod navtex;
 mod nfm;
@@ -34,6 +35,9 @@ pub use adsb::AdsbChannel;
 pub use ais::AisChannelRx;
 pub use am::{AmChannel, AmTx};
 pub use aprs::{AprsChannel, AprsTx};
+pub use dv::{
+    DmrChannel, DpmrChannel, DstarChannel, M17Channel, NxdnChannel, P25Channel, YsfChannel,
+};
 pub use morse::MorseChannel;
 pub use navtex::NavtexChannel;
 pub use nfm::{NfmChannel, NfmTx};
@@ -84,6 +88,13 @@ pub fn occupied_band(params: &ChannelParams) -> (f64, f64) {
         ChannelParams::Navtex(_) => navtex::occupied_band(),
         ChannelParams::Acars(p) => acars::occupied_band(p),
         ChannelParams::Subghz(p) => subghz::occupied_band(p),
+        ChannelParams::Dmr(_) => dv::dmr::occupied_band(),
+        ChannelParams::Dstar(_) => dv::dstar::occupied_band(),
+        ChannelParams::Ysf(_) => dv::ysf::occupied_band(),
+        ChannelParams::Nxdn(p) => dv::nxdn::occupied_band(p),
+        ChannelParams::P25(_) => dv::p25::occupied_band(),
+        ChannelParams::Dpmr(_) => dv::dpmr::occupied_band(),
+        ChannelParams::M17(_) => dv::m17::occupied_band(),
     }
 }
 
@@ -130,6 +141,13 @@ pub fn channel_filter(params: &ChannelParams) -> Result<ChannelFilter, ChannelEr
         ChannelParams::Navtex(_) => Ok(navtex::channel_filter()),
         ChannelParams::Acars(p) => acars::channel_filter(p),
         ChannelParams::Subghz(p) => subghz::channel_filter(p),
+        ChannelParams::Dmr(_) => Ok(dv::dmr::channel_filter()),
+        ChannelParams::Dstar(_) => Ok(dv::dstar::channel_filter()),
+        ChannelParams::Ysf(_) => Ok(dv::ysf::channel_filter()),
+        ChannelParams::Nxdn(p) => Ok(dv::nxdn::channel_filter(p)),
+        ChannelParams::P25(_) => Ok(dv::p25::channel_filter()),
+        ChannelParams::Dpmr(_) => Ok(dv::dpmr::channel_filter()),
+        ChannelParams::M17(_) => Ok(dv::m17::channel_filter()),
     }
 }
 
@@ -358,6 +376,41 @@ const REGISTRY: &[Registration] = &[
         create: boxed::<SubghzChannel>,
         create_tx: None,
     },
+    Registration {
+        descriptor: DmrChannel::descriptor,
+        create: boxed::<DmrChannel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: DstarChannel::descriptor,
+        create: boxed::<DstarChannel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: YsfChannel::descriptor,
+        create: boxed::<YsfChannel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: NxdnChannel::descriptor,
+        create: boxed::<NxdnChannel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: P25Channel::descriptor,
+        create: boxed::<P25Channel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: DpmrChannel::descriptor,
+        create: boxed::<DpmrChannel>,
+        create_tx: None,
+    },
+    Registration {
+        descriptor: M17Channel::descriptor,
+        create: boxed::<M17Channel>,
+        create_tx: None,
+    },
 ];
 
 /// Descriptors for every compiled-in channel type (PLAN §8: static registry).
@@ -464,8 +517,9 @@ mod tests {
     use std::collections::HashSet;
 
     use sdrmm_wire::{
-        AcarsParams, AdsbParams, AisParams, AmParams, AprsParams, ChannelParams, MorseParams,
-        NavtexParams, NfmParams, PocsagParams, RttyParams, SsbParams, SubghzParams, WfmParams,
+        AcarsParams, AdsbParams, AisParams, AmParams, AprsParams, ChannelParams, DmrParams,
+        DpmrParams, DstarParams, M17Params, MorseParams, NavtexParams, NfmParams, NxdnParams,
+        P25Params, PocsagParams, RttyParams, SsbParams, SubghzParams, WfmParams, YsfParams,
     };
 
     use super::*;
@@ -486,6 +540,13 @@ mod tests {
             "navtex" => ChannelParams::Navtex(NavtexParams::default()),
             "acars" => ChannelParams::Acars(AcarsParams::default()),
             "subghz" => ChannelParams::Subghz(SubghzParams::default()),
+            "dmr" => ChannelParams::Dmr(DmrParams::default()),
+            "dstar" => ChannelParams::Dstar(DstarParams::default()),
+            "ysf" => ChannelParams::Ysf(YsfParams::default()),
+            "nxdn" => ChannelParams::Nxdn(NxdnParams::default()),
+            "p25" => ChannelParams::P25(P25Params::default()),
+            "dpmr" => ChannelParams::Dpmr(DpmrParams::default()),
+            "m17" => ChannelParams::M17(M17Params::default()),
             other => panic!("unexpected type id {other}"),
         }
     }
@@ -493,13 +554,13 @@ mod tests {
     #[test]
     fn descriptors_are_unique_and_complete() {
         let all = descriptors();
-        assert_eq!(all.len(), 13);
+        assert_eq!(all.len(), 20);
         let ids: HashSet<&str> = all.iter().map(|d| d.type_id.as_str()).collect();
         assert_eq!(
             ids,
             HashSet::from([
                 "nfm", "am", "ssb", "wfm", "pocsag", "adsb", "ais", "aprs", "rtty", "morse",
-                "navtex", "acars", "subghz",
+                "navtex", "acars", "subghz", "dmr", "dstar", "ysf", "nxdn", "p25", "dpmr", "m17",
             ])
         );
         for d in &all {
@@ -517,6 +578,12 @@ mod tests {
                 "navtex" => (600.0, 8_000.0),
                 "acars" => (12_500.0, 48_000.0),
                 "subghz" => (150_000.0, 250_000.0),
+                // The digital-voice modes all meet the DDC at 48 kHz; they differ in how much
+                // of it they occupy — 12.5 kHz for the four that share a 12.5 kHz raster,
+                // 6.25 for the narrow pair, and 9 kHz for M17.
+                "dmr" | "ysf" | "p25" => (12_500.0, 48_000.0),
+                "dstar" | "nxdn" | "dpmr" => (6_250.0, 48_000.0),
+                "m17" => (9_000.0, 48_000.0),
                 other => panic!("unexpected type id {other}"),
             };
             assert_eq!(d.bandwidth_hz, bandwidth, "{}", d.type_id);

--- a/crates/channels/src/testgen/dv/dmr.rs
+++ b/crates/channels/src/testgen/dv/dmr.rs
@@ -1,0 +1,203 @@
+//! DMR reference transmitter (ETSI TS 102 361-1): builds the bursts of a whole transmission —
+//! voice LC header, a voice superframe carrying its link control in the embedded field, and a
+//! terminator — and modulates them as a direct-mode radio would.
+
+use num_complex::Complex;
+use sdrmm_dsp::{Bptc128, Bptc196, CyclicCode, crc16_msb, rs129_parity};
+
+use super::{bits, c4fm, dibits, filler};
+
+/// Direct-mode slot 1 sync patterns, which name their timeslot on the wire.
+const VOICE_SYNC: u64 = 0x5D57_7F77_57FF;
+const DATA_SYNC: u64 = 0xF7FD_D5DD_FD55;
+
+const DT_VOICE_LC_HEADER: u8 = 0x1;
+const DT_TERMINATOR_WITH_LC: u8 = 0x2;
+const DT_CSBK: u8 = 0x3;
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+
+/// One call, as its transmitter would key it.
+pub struct Call {
+    pub color_code: u8,
+    pub group: bool,
+    pub destination: u32,
+    pub source: u32,
+}
+
+impl Default for Call {
+    fn default() -> Self {
+        Self {
+            color_code: 1,
+            group: true,
+            destination: 505,
+            source: 2_621_001,
+        }
+    }
+}
+
+impl Call {
+    /// The 72-bit full link control this call is described by.
+    #[must_use]
+    pub fn link_control(&self) -> Vec<bool> {
+        let flco = u64::from(!self.group) * 3;
+        let mut lc = bits(flco, 8);
+        // Feature set id 0 (ETSI standard) and no service options.
+        lc.extend(bits(0, 8));
+        lc.extend(bits(0, 8));
+        lc.extend(bits(u64::from(self.destination), 24));
+        lc.extend(bits(u64::from(self.source), 24));
+        lc
+    }
+}
+
+/// A voice LC header burst, a voice superframe whose embedded link control repeats the same
+/// addressing, and a terminator: 8 bursts, 30 ms apart in the slot, with the other slot's time
+/// left as the idle carrier a direct-mode radio transmits.
+#[must_use]
+pub fn transmission(call: &Call, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = Vec::new();
+    // Lead-in: the receiver's clock and level estimates need a run of symbols before the
+    // first burst, exactly as they would get from a real transmitter's preamble.
+    symbols.extend(dibits(&filler(400, 7)));
+
+    symbols.extend(dibits(&data_burst(
+        call,
+        DT_VOICE_LC_HEADER,
+        &lc_with_parity(call, [0x96, 0x96, 0x96]),
+    )));
+    symbols.extend(idle_slot());
+
+    let embedded = Bptc128::encode(&embedded_block(call));
+    // Burst A carries the sync; B to E one quarter each of the embedded link control; F the
+    // null fragment that closes the superframe.
+    symbols.extend(dibits(&voice_burst(call, None)));
+    symbols.extend(idle_slot());
+    for (i, lcss) in [0b01u8, 0b11, 0b11, 0b10].into_iter().enumerate() {
+        let fragment: Vec<bool> = embedded[i * 32..(i + 1) * 32].to_vec();
+        symbols.extend(dibits(&voice_burst(call, Some((lcss, fragment)))));
+        symbols.extend(idle_slot());
+    }
+    symbols.extend(dibits(&voice_burst(call, Some((0b00, vec![false; 32])))));
+    symbols.extend(idle_slot());
+
+    symbols.extend(dibits(&data_burst(
+        call,
+        DT_TERMINATOR_WITH_LC,
+        &lc_with_parity(call, [0x99, 0x99, 0x99]),
+    )));
+    symbols.extend(dibits(&filler(200, 11)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// A single CSBK burst — the signalling that travels outside a call.
+#[must_use]
+pub fn csbk(
+    color_code: u8,
+    opcode: u8,
+    destination: u32,
+    source: u32,
+    rate: f64,
+) -> Vec<Complex<f32>> {
+    let mut payload = bits(u64::from(opcode) & 0x3F, 8);
+    // Feature set id, then the sixteen opcode-specific bits every CSBK carries ahead of its
+    // two addresses.
+    payload.extend(bits(0, 8));
+    payload.extend(bits(0, 16));
+    payload.extend(bits(u64::from(destination), 24));
+    payload.extend(bits(u64::from(source), 24));
+    let crc = !crc16_msb(0x1021, 0, &pack(&payload)) ^ 0xA5A5;
+    payload.extend(bits(u64::from(crc), 16));
+
+    let call = Call {
+        color_code,
+        ..Call::default()
+    };
+    let mut symbols = dibits(&filler(400, 3));
+    symbols.extend(dibits(&data_burst(&call, DT_CSBK, &payload)));
+    symbols.extend(dibits(&filler(200, 5)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// The 96-bit signalling block of a link control frame: 72 bits of addressing and the
+/// Reed-Solomon parity, masked by frame type.
+fn lc_with_parity(call: &Call, mask: [u8; 3]) -> Vec<bool> {
+    let lc = call.link_control();
+    let parity = rs129_parity(&pack(&lc));
+    let mut out = lc;
+    for (byte, m) in parity.into_iter().zip(mask) {
+        out.extend(bits(u64::from(byte ^ m), 8));
+    }
+    out
+}
+
+/// The 77 bits a BPTC(128,77) embedded block carries: the link control with its five-bit
+/// checksum threaded through column 10 of rows 2 to 6.
+fn embedded_block(call: &Call) -> [bool; Bptc128::DATA_BITS] {
+    let lc = call.link_control();
+    let checksum = pack(&lc).iter().map(|&b| u32::from(b)).sum::<u32>() % 31;
+    let mut out = [false; Bptc128::DATA_BITS];
+    let (mut read, mut check_bit) = (0, 0);
+    for (i, slot) in out.iter_mut().enumerate() {
+        if i >= 22 && i % 11 == 10 {
+            *slot = checksum >> (4 - check_bit) & 1 == 1;
+            check_bit += 1;
+        } else {
+            *slot = lc[read];
+            read += 1;
+        }
+    }
+    out
+}
+
+/// A 264-bit data burst: BPTC payload either side of the sync, with the Golay slot type in
+/// between.
+fn data_burst(call: &Call, data_type: u8, payload: &[bool]) -> Vec<bool> {
+    let mut block = [false; Bptc196::DATA_BITS];
+    for (slot, &bit) in block.iter_mut().zip(payload) {
+        *slot = bit;
+    }
+    let coded = Bptc196::encode(&block);
+    let slot_type =
+        CyclicCode::GOLAY_20_8.encode(u32::from(call.color_code) << 4 | u32::from(data_type));
+
+    let mut burst = coded[..98].to_vec();
+    burst.extend(bits(slot_type >> 10, 10));
+    burst.extend(bits(DATA_SYNC, 48));
+    burst.extend(bits(slot_type & 0x3FF, 10));
+    burst.extend(&coded[98..]);
+    burst
+}
+
+/// A 264-bit voice burst: filler where the vocoder frames go, and either the sync (burst A) or
+/// an embedded signalling field with one quarter of the link control (bursts B to F).
+fn voice_burst(call: &Call, embedded: Option<(u8, Vec<bool>)>) -> Vec<bool> {
+    let mut burst = filler(108, u32::from(call.color_code) + 17);
+    match embedded {
+        None => burst.extend(bits(VOICE_SYNC, 48)),
+        Some((lcss, fragment)) => {
+            let emb = CyclicCode::QR_16_7
+                .encode(u32::from(call.color_code) << 3 | u32::from(lcss & 0b11));
+            burst.extend(bits(emb >> 8, 8));
+            burst.extend(fragment);
+            burst.extend(bits(emb & 0xFF, 8));
+        }
+    }
+    burst.extend(filler(108, u32::from(call.color_code) + 23));
+    burst
+}
+
+/// The other timeslot, which this transmitter is not using.
+fn idle_slot() -> Vec<u8> {
+    dibits(&filler(264, 29))
+}
+
+fn pack(bits: &[bool]) -> Vec<u8> {
+    bits.as_chunks::<8>()
+        .0
+        .iter()
+        .map(|chunk| chunk.iter().fold(0u8, |acc, &b| acc << 1 | u8::from(b)))
+        .collect()
+}

--- a/crates/channels/src/testgen/dv/dpmr.rs
+++ b/crates/channels/src/testgen/dv/dpmr.rs
@@ -1,0 +1,131 @@
+//! dPMR reference transmitter (ETSI TS 102 490): a header frame with both copies of the header
+//! information and the colour code between them, then a superframe and an end frame.
+
+use num_complex::Complex;
+
+use super::{bits, c4fm, dibits, filler};
+
+const BAUD: f64 = 2_400.0;
+const DEVIATION_HZ: f64 = 1_050.0;
+const RRC_ALPHA: f64 = 0.2;
+
+const FS1: u64 = 0x57FF_5F75_D577;
+const FS2: u64 = 0x5F_F77D;
+const FS3: u64 = 0x7D_DFF5;
+
+/// One call as a dPMR radio keys it.
+pub struct Call {
+    pub colour_code: u16,
+    pub called: u32,
+    pub own: u32,
+    /// Communication mode: 0 is an individual call, anything else a group.
+    pub mode: u8,
+}
+
+impl Default for Call {
+    fn default() -> Self {
+        Self {
+            colour_code: 0x0A5,
+            called: 0x00_FFFF,
+            own: 0x12_3456,
+            mode: 1,
+        }
+    }
+}
+
+/// Preamble, header frame, two superframe halves and an end frame.
+#[must_use]
+pub fn transmission(call: &Call, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 67));
+    symbols.extend(dibits(&bits(FS1, 48)));
+    symbols.extend(dibits(&header_info(call)));
+    symbols.extend(dibits(&colour_code(call.colour_code)));
+    symbols.extend(dibits(&header_info(call)));
+
+    for _ in 0..2 {
+        symbols.extend(dibits(&bits(FS2, 24)));
+        symbols.extend(dibits(&filler(456, 71)));
+    }
+    symbols.extend(dibits(&bits(FS3, 24)));
+    symbols.extend(dibits(&filler(400, 73)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// Twelve colour-code bits, each sent as `01` for zero and `11` for one (§6.1.5).
+fn colour_code(value: u16) -> Vec<bool> {
+    let mut out = Vec::with_capacity(24);
+    for i in (0..12).rev() {
+        out.push(value >> i & 1 == 1);
+        out.push(true);
+    }
+    out
+}
+
+/// The 72-bit header information through its CRC, Hamming blocks, interleaver and scrambler.
+fn header_info(call: &Call) -> Vec<bool> {
+    let mut info = bits(0, 4);
+    info.extend(bits(u64::from(call.called), 24));
+    info.extend(bits(u64::from(call.own), 24));
+    info.extend(bits(u64::from(call.mode) & 0x07, 3));
+    info.extend(bits(0, 4 + 2 + 11));
+
+    let mut bytes: Vec<u8> = info
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|chunk| chunk.iter().fold(0u8, |acc, &b| acc << 1 | u8::from(b)))
+        .collect();
+    bytes.push(crc8(&bytes));
+
+    // Shortened Hamming(12,8): systematic, so the four parity bits sit after the byte. The
+    // decoder reads only the information half, so the parity is generated but never relied on.
+    let mut blocks = Vec::with_capacity(120);
+    for &byte in &bytes {
+        blocks.extend(bits(u64::from(byte), 8));
+        blocks.extend(hamming_parity(byte));
+    }
+    // Interleave: ten 12-bit blocks written down the columns, read out along the rows.
+    let mut interleaved = vec![false; 120];
+    for r in 0..12 {
+        for c in 0..10 {
+            interleaved[r * 10 + c] = blocks[c * 12 + r];
+        }
+    }
+    let mut register = 0x1FFu16;
+    interleaved
+        .into_iter()
+        .map(|bit| {
+            let feedback = (register >> 8 ^ register >> 4) & 1;
+            register = (register << 1 | feedback) & 0x1FF;
+            bit ^ (feedback == 1)
+        })
+        .collect()
+}
+
+/// The four parity bits of the shortened Hamming(12,8), as the generator matrix of §7.3 gives
+/// them.
+fn hamming_parity(byte: u8) -> Vec<bool> {
+    let bit = |i: u8| byte >> (7 - i) & 1 == 1;
+    let sum = |taps: &[u8]| taps.iter().fold(false, |acc, &t| acc ^ bit(t));
+    vec![
+        sum(&[0, 1, 2, 3]),
+        sum(&[1, 2, 3, 4]),
+        sum(&[0, 1, 2, 4]),
+        sum(&[0, 2, 3, 4]),
+    ]
+}
+
+fn crc8(data: &[u8]) -> u8 {
+    let mut crc = 0u8;
+    for &byte in data {
+        crc ^= byte;
+        for _ in 0..8 {
+            crc = if crc & 0x80 != 0 {
+                crc << 1 ^ 0x07
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}

--- a/crates/channels/src/testgen/dv/dstar.rs
+++ b/crates/channels/src/testgen/dv/dstar.rs
@@ -1,0 +1,120 @@
+//! D-Star reference transmitter: GMSK voice frames whose slow-data channel repeats the header,
+//! which is the path a receiver joining a call in progress actually reads.
+
+use num_complex::Complex;
+use sdrmm_dsp::crc16_x25;
+
+use super::filler;
+use crate::testgen::fsk;
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_200.0;
+const SYNC: u32 = 0x0055_2D16;
+const FRAME_BITS: usize = 96;
+const HEADER_BYTES: usize = 41;
+const SCRAMBLER: [u8; 3] = [0x70, 0x4F, 0x93];
+
+/// One call, as the header names it.
+pub struct Call {
+    pub urcall: String,
+    pub mycall: String,
+    pub repeater: String,
+    pub text: String,
+}
+
+impl Default for Call {
+    fn default() -> Self {
+        Self {
+            urcall: "CQCQCQ".to_owned(),
+            mycall: "DL1ABC".to_owned(),
+            repeater: "DB0ABC B".to_owned(),
+            text: "hello from sdr--".to_owned(),
+        }
+    }
+}
+
+/// A transmission long enough for the header to come round twice in the slow-data channel.
+#[must_use]
+pub fn transmission(call: &Call, rate: f64) -> Vec<Complex<f32>> {
+    let header = header(call);
+    let mut slow = Vec::new();
+    // Header segments, five bytes at a time, then the text message in four-character packets.
+    for chunk in header.chunks(5) {
+        slow.push(build_packet(0x50 | chunk.len() as u8, chunk));
+    }
+    let text = format!("{:<20}", call.text);
+    for (i, chunk) in text.as_bytes().chunks(4).take(4).enumerate() {
+        slow.push(build_packet(0x40 | i as u8, chunk));
+    }
+
+    let mut bits = Vec::new();
+    // A lead-in of alternating bits: the bit sync every D-Star transmitter opens with.
+    for i in 0..64 {
+        bits.push(i % 2 == 0);
+    }
+    // Ten slow-data packets fit in a superframe: frames 1 and 2 carry the first, 3 and 4 the
+    // second, and so on. Two superframes are enough for the header to come round once.
+    for superframe in 0..2 {
+        // Frame 0 of a superframe carries the sync in its data field.
+        bits.extend(voice_frame(&sync_data(), superframe));
+        for frame in 1..21 {
+            let index = superframe * 10 + (frame - 1) / 2;
+            let source = slow.get(index).copied().unwrap_or([0x66; 6]);
+            let half = (frame - 1) % 2 * 3;
+            let bytes = [source[half], source[half + 1], source[half + 2]];
+            bits.extend(voice_frame(&scramble(bytes), superframe * 21 + frame));
+        }
+    }
+    fsk(&bits, BAUD, DEVIATION_HZ, rate)
+}
+
+fn sync_data() -> [u8; 3] {
+    [(SYNC >> 16) as u8, (SYNC >> 8) as u8, SYNC as u8]
+}
+
+fn scramble(data: [u8; 3]) -> [u8; 3] {
+    [
+        data[0] ^ SCRAMBLER[0],
+        data[1] ^ SCRAMBLER[1],
+        data[2] ^ SCRAMBLER[2],
+    ]
+}
+
+fn build_packet(header: u8, payload: &[u8]) -> [u8; 6] {
+    let mut packet = [0x66u8; 6];
+    packet[0] = header;
+    for (slot, &byte) in packet[1..].iter_mut().zip(payload) {
+        *slot = byte;
+    }
+    packet
+}
+
+/// 72 bits of vocoder filler and 24 bits of data.
+fn voice_frame(data: &[u8; 3], seed: usize) -> Vec<bool> {
+    let mut bits = filler(FRAME_BITS - 24, 97 + seed as u32);
+    for &byte in data {
+        for i in (0..8).rev() {
+            bits.push(byte >> i & 1 == 1);
+        }
+    }
+    bits
+}
+
+/// The 41-byte header: flags, the four callsigns, and a CRC over the rest.
+fn header(call: &Call) -> Vec<u8> {
+    let field = |text: &str, len: usize| {
+        let mut bytes = text.as_bytes().to_vec();
+        bytes.resize(len, b' ');
+        bytes
+    };
+    let mut header = vec![0u8, 0, 0];
+    header.extend(field(&call.repeater, 8));
+    header.extend(field(&call.repeater, 8));
+    header.extend(field(&call.urcall, 8));
+    header.extend(field(&call.mycall, 8));
+    header.extend(field("SDR", 4));
+    let crc = crc16_x25(&header);
+    header.extend(crc.to_le_bytes());
+    assert_eq!(header.len(), HEADER_BYTES);
+    header
+}

--- a/crates/channels/src/testgen/dv/m17.rs
+++ b/crates/channels/src/testgen/dv/m17.rs
@@ -1,0 +1,93 @@
+//! M17 reference transmitter: a link setup frame through the same chain the specification
+//! defines — CRC, convolutional code, puncturing, interleaving, randomising — then stream
+//! frames and an end-of-transmission marker.
+
+use num_complex::Complex;
+use sdrmm_dsp::{crc16_msb, fec::conv};
+
+use super::{bits, c4fm, dibits, filler};
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 2_400.0;
+const RRC_ALPHA: f64 = 0.5;
+
+const SYNC_LSF: u64 = 0x55F7;
+const SYNC_STREAM: u64 = 0xFF5D;
+const SYNC_EOT: u64 = 0x555D;
+
+const PAYLOAD_BITS: usize = 368;
+const LSF_CODED_BITS: usize = 488;
+
+const RANDOMIZER: [u8; 46] = [
+    0xD6, 0xB5, 0xE2, 0x30, 0x82, 0xFF, 0x84, 0x62, 0xBA, 0x4E, 0x96, 0x90, 0xD8, 0x98, 0xDD, 0x5D,
+    0x0C, 0xC8, 0x52, 0x43, 0x91, 0x1D, 0xF8, 0x6E, 0x68, 0x2F, 0x35, 0xDA, 0x14, 0xEA, 0xCD, 0x76,
+    0x19, 0x8D, 0xD5, 0x80, 0xD1, 0x33, 0x87, 0x13, 0x57, 0x18, 0x2D, 0x29, 0x78, 0xC3,
+];
+
+const CALLSIGN_ALPHABET: &[u8; 40] = b" ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
+
+/// A transmission: link setup, three stream frames, end of transmission.
+#[must_use]
+pub fn transmission(destination: &str, source: &str, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 79));
+    symbols.extend(dibits(&bits(SYNC_LSF, 16)));
+    symbols.extend(dibits(&link_setup(destination, source)));
+    for i in 0..3 {
+        symbols.extend(dibits(&bits(SYNC_STREAM, 16)));
+        symbols.extend(dibits(&filler(PAYLOAD_BITS, 83 + i)));
+    }
+    symbols.extend(dibits(&bits(SYNC_EOT, 16)));
+    symbols.extend(dibits(&filler(200, 89)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// The 368 payload bits of a link setup frame.
+fn link_setup(destination: &str, source: &str) -> Vec<bool> {
+    let mut lsf = bits(callsign(destination), 48);
+    lsf.extend(bits(callsign(source), 48));
+    // Stream type: voice over a stream, unencrypted.
+    lsf.extend(bits(0b0000_0000_0000_0101, 16));
+    // 112 bits of metadata, which a plain voice call leaves empty.
+    lsf.extend(std::iter::repeat_n(false, 112));
+    let bytes: Vec<u8> = lsf
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|chunk| chunk.iter().fold(0u8, |acc, &b| acc << 1 | u8::from(b)))
+        .collect();
+    lsf.extend(bits(u64::from(crc16_msb(0x5935, 0xFFFF, &bytes)), 16));
+
+    // Four flush bits, then the rate-1/2 code and its puncturing pattern.
+    lsf.extend([false; 4]);
+    let mut coded = Vec::with_capacity(LSF_CODED_BITS);
+    conv::encode(&lsf, &mut coded);
+    let punctured: Vec<bool> = coded
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| (i % 61) % 4 != 2)
+        .map(|(_, bit)| bit)
+        .collect();
+    assert_eq!(punctured.len(), PAYLOAD_BITS);
+
+    let mut interleaved = vec![false; PAYLOAD_BITS];
+    for (i, slot) in interleaved.iter_mut().enumerate() {
+        *slot = punctured[(45 * i + 92 * i * i) % PAYLOAD_BITS];
+    }
+    for (i, bit) in interleaved.iter_mut().enumerate() {
+        if RANDOMIZER[i / 8] >> (7 - i % 8) & 1 == 1 {
+            *bit = !*bit;
+        }
+    }
+    interleaved
+}
+
+/// Base-40 callsign encoding (M17 spec §2.3.1).
+fn callsign(call: &str) -> u64 {
+    if call == "ALL" {
+        return 0xFFFF_FFFF_FFFF;
+    }
+    call.bytes()
+        .rev()
+        .filter_map(|c| CALLSIGN_ALPHABET.iter().position(|&a| a == c))
+        .fold(0u64, |acc, index| acc * 40 + index as u64)
+}

--- a/crates/channels/src/testgen/dv/mod.rs
+++ b/crates/channels/src/testgen/dv/mod.rs
@@ -1,0 +1,83 @@
+//! Reference modulators for the digital-voice decoders (PLAN §14).
+//!
+//! The shaping lives here and the framing lives in the per-mode submodules, because that is how
+//! the modes actually differ: they all put four levels on a carrier the same way, and then each
+//! spends its bits differently.
+//!
+//! What these generators do *not* produce is voice. Every mode's payload here is filler — the
+//! decoders read the signalling around it and there is no vocoder to feed — so a generated
+//! burst carries a deterministic pattern where a radio would carry AMBE or Codec2 frames.
+
+pub mod dmr;
+pub mod dpmr;
+pub mod dstar;
+pub mod m17;
+pub mod nxdn;
+pub mod p25;
+pub mod ysf;
+
+use std::f64::consts::TAU;
+
+use num_complex::Complex;
+use sdrmm_dsp::{RealDecimator, design_rrc, fsk4};
+
+/// Matched-filter span the receivers use, and so the span a transmitter must shape to for the
+/// cascade to be a Nyquist pulse.
+const RRC_SPAN: usize = 8;
+
+/// A C4FM transmitter: one symbol per dibit through a root-raised-cosine shaping filter, then
+/// frequency modulation at `deviation_hz` for the outer levels.
+#[must_use]
+pub fn c4fm(
+    dibits: &[u8],
+    rate: f64,
+    baud: f64,
+    deviation_hz: f64,
+    alpha: f64,
+) -> Vec<Complex<f32>> {
+    let sps = rate / baud;
+    let taps = design_rrc(sps, alpha, RRC_SPAN);
+    let mut impulses = vec![0.0f32; dibits.len() * sps as usize + taps.len()];
+    for (i, &dibit) in dibits.iter().enumerate() {
+        impulses[i * sps as usize] = fsk4::level(dibit) / 3.0 * sps as f32;
+    }
+    let mut shaped = Vec::new();
+    RealDecimator::new(&taps, 1).process(&impulses, &mut shaped);
+    let mut phase = 0.0f64;
+    shaped
+        .iter()
+        .map(|&s| {
+            phase += TAU * f64::from(s) * deviation_hz / rate;
+            Complex::from_polar(1.0, phase as f32)
+        })
+        .collect()
+}
+
+/// Split bits into the dibits a 4FSK symbol carries, most significant bit first.
+#[must_use]
+pub fn dibits(bits: &[bool]) -> Vec<u8> {
+    bits.chunks(2)
+        .map(|pair| u8::from(pair[0]) << 1 | u8::from(*pair.get(1).unwrap_or(&false)))
+        .collect()
+}
+
+/// The `len` low bits of `value`, most significant first — how every field in these
+/// specifications is written down.
+#[must_use]
+pub fn bits(value: u64, len: usize) -> Vec<bool> {
+    (0..len).rev().map(|i| value >> i & 1 == 1).collect()
+}
+
+/// Deterministic filler where a radio would put vocoder frames.
+#[must_use]
+pub fn filler(len: usize, seed: u32) -> Vec<bool> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state & 1 == 1
+        })
+        .collect()
+}

--- a/crates/channels/src/testgen/dv/nxdn.rs
+++ b/crates/channels/src/testgen/dv/nxdn.rs
@@ -1,0 +1,53 @@
+//! NXDN reference transmitter: frame sync word, link information channel, filler payload.
+
+use num_complex::Complex;
+
+use super::{bits, c4fm, dibits, filler};
+
+const RRC_ALPHA: f64 = 0.2;
+const FSW: u64 = 0x000C_DF59;
+
+/// Which NXDN width the generator is transmitting.
+pub struct Shape {
+    pub baud: f64,
+    pub deviation_hz: f64,
+}
+
+impl Default for Shape {
+    fn default() -> Self {
+        Self {
+            baud: 2_400.0,
+            deviation_hz: 1_050.0,
+        }
+    }
+}
+
+/// A transmission: a signalling frame, three traffic frames and a closing signalling frame.
+#[must_use]
+pub fn transmission(shape: &Shape, rf_channel: u8, outbound: bool, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 53));
+    for functional in [0u8, 2, 2, 2, 0] {
+        symbols.extend(frame(rf_channel, functional, outbound));
+    }
+    symbols.extend(dibits(&filler(200, 59)));
+    c4fm(&symbols, rate, shape.baud, shape.deviation_hz, RRC_ALPHA)
+}
+
+/// One 384-bit frame.
+fn frame(rf_channel: u8, functional: u8, outbound: bool) -> Vec<u8> {
+    let mut lich = bits(u64::from(rf_channel) & 0x03, 2);
+    lich.extend(bits(u64::from(functional) & 0x03, 2));
+    // Option, then direction.
+    lich.extend(bits(0, 2));
+    lich.push(outbound);
+    // Odd parity over the seven bits before it.
+    let ones = lich.iter().filter(|b| **b).count();
+    lich.push(ones % 2 == 0);
+    // The eight bits the specification reserves for the channel's own use.
+    lich.extend(bits(0, 8));
+
+    let mut out = dibits(&bits(FSW, 20));
+    out.extend(dibits(&lich));
+    out.extend(dibits(&filler(348, 61 + u32::from(functional))));
+    out
+}

--- a/crates/channels/src/testgen/dv/p25.rs
+++ b/crates/channels/src/testgen/dv/p25.rs
@@ -1,0 +1,73 @@
+//! P25 Phase 1 reference transmitter: sync, a BCH-coded network identifier with the status
+//! symbols a transmitter interleaves into the frame, and filler for the rest.
+
+use num_complex::Complex;
+use sdrmm_dsp::CyclicCode;
+
+use super::{bits, c4fm, dibits, filler};
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+const SYNC: u64 = 0x5575_F5FF_77FF;
+
+/// Frame lengths in bits, status symbols included (TIA-102.BAAA §7.3): a header, the two voice
+/// frames, a terminator and a trunking block.
+fn frame_bits(duid: u8) -> usize {
+    match duid {
+        0x0 => 792,
+        0x3 => 144,
+        0x7 => 720,
+        0xF => 432,
+        _ => 1_728,
+    }
+}
+
+/// A transmission: header, two voice frames, terminator.
+#[must_use]
+pub fn transmission(nac: u16, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 31));
+    for duid in [0x0u8, 0x5, 0xA, 0x3] {
+        symbols.extend(frame(nac, duid));
+    }
+    symbols.extend(dibits(&filler(200, 37)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// A single trunking block frame, which is what a control channel transmits continuously.
+#[must_use]
+pub fn trunking(nac: u16, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 41));
+    symbols.extend(frame(nac, 0x7));
+    symbols.extend(dibits(&filler(200, 43)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// One frame: sync, network identifier, payload — with a status di-bit inserted after every 35
+/// payload di-bits, starting at bit 70.
+fn frame(nac: u16, duid: u8) -> Vec<u8> {
+    let mut body = bits(SYNC, 48);
+    body.extend(bits(
+        CyclicCode::BCH_63_16.encode(u32::from(nac) << 4 | u32::from(duid & 0x0F)),
+        64,
+    ));
+    let total = frame_bits(duid);
+    body.extend(filler(
+        total.saturating_sub(body.len()),
+        47 + u32::from(duid),
+    ));
+
+    let mut out = Vec::with_capacity(total);
+    let mut written = 0;
+    for bit in body {
+        if written >= 70 && (written - 70) % 72 == 0 {
+            // Status di-bit 01: "unknown, use the default".
+            out.push(false);
+            out.push(true);
+            written += 2;
+        }
+        out.push(bit);
+        written += 1;
+    }
+    dibits(&out)
+}

--- a/crates/channels/src/testgen/dv/ysf.rs
+++ b/crates/channels/src/testgen/dv/ysf.rs
@@ -1,0 +1,90 @@
+//! System Fusion reference transmitter: sync, a coded FICH, and filler where the vocoder and
+//! data channel would be.
+
+use num_complex::Complex;
+use sdrmm_dsp::{CyclicCode, crc16_msb, fec::conv};
+
+use super::{bits, c4fm, dibits, filler};
+
+const BAUD: f64 = 4_800.0;
+const DEVIATION_HZ: f64 = 1_944.0;
+const RRC_ALPHA: f64 = 0.2;
+const SYNC: u64 = 0x00D4_71C9_634D;
+
+/// Frame information channel fields, as the FICH publishes them.
+pub struct Fich {
+    /// 0 header, 1 communications, 2 terminator.
+    pub frame_type: u8,
+    /// 0 V/D mode 1, 1 data FR, 2 V/D mode 2, 3 voice FR.
+    pub data_mode: u8,
+    pub dg_id: u8,
+}
+
+impl Default for Fich {
+    fn default() -> Self {
+        Self {
+            frame_type: 0,
+            data_mode: 2,
+            dg_id: 7,
+        }
+    }
+}
+
+/// A whole transmission: a header frame, three communication frames and a terminator, each 100
+/// ms long, with the lead-in a receiver's clock needs.
+#[must_use]
+pub fn transmission(fich: &Fich, rate: f64) -> Vec<Complex<f32>> {
+    let mut symbols = dibits(&filler(400, 13));
+    for frame_type in [fich.frame_type, 1, 1, 1, 2] {
+        symbols.extend(frame(&Fich {
+            frame_type,
+            ..*fich
+        }));
+    }
+    symbols.extend(dibits(&filler(200, 17)));
+    c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
+}
+
+/// One 480-symbol frame.
+fn frame(fich: &Fich) -> Vec<u8> {
+    let mut out = dibits(&bits(SYNC, 40));
+    out.extend(dibits(&fich_bits(fich)));
+    // Everything after the FICH is the data and voice channel, which carries no signalling
+    // this decoder reads.
+    out.extend(dibits(&filler(720, 23)));
+    out
+}
+
+/// The 100 coded symbols of a FICH: CRC, four Golay blocks, the convolutional code and the
+/// interleaver, in the order a transmitter applies them.
+fn fich_bits(fich: &Fich) -> Vec<bool> {
+    let mut info = [0u8; 6];
+    info[0] = fich.frame_type << 6;
+    info[2] = fich.data_mode & 0x03;
+    info[3] = fich.dg_id & 0x7F;
+    let crc = !crc16_msb(0x1021, 0, &info[..4]);
+    info[4] = (crc >> 8) as u8;
+    info[5] = crc as u8;
+
+    let value = info
+        .iter()
+        .fold(0u64, |acc, &byte| acc << 8 | u64::from(byte));
+    let mut coded = Vec::with_capacity(96);
+    for block in 0..4 {
+        let word = CyclicCode::GOLAY_24_12.encode((value >> (36 - block * 12)) as u32 & 0x0FFF);
+        coded.extend(bits(word, 24));
+    }
+    // Four flush bits return the encoder to its zero state, which is what lets the decoder
+    // keep 96 information bits out of 100 steps.
+    coded.extend([false; 4]);
+    let mut convolved = Vec::with_capacity(200);
+    conv::encode(&coded, &mut convolved);
+
+    let mut interleaved = vec![false; 200];
+    for i in 0..100 {
+        let n = 2 * (i / 5) + 40 * (i % 5);
+        interleaved[n] = convolved[i * 2];
+        interleaved[n + 1] = convolved[i * 2 + 1];
+    }
+    interleaved
+}

--- a/crates/channels/src/testgen/mod.rs
+++ b/crates/channels/src/testgen/mod.rs
@@ -24,6 +24,7 @@
 pub mod acars;
 pub mod adsb;
 pub mod ais;
+pub mod dv;
 pub mod morse;
 pub mod navtex;
 pub mod pocsag;

--- a/crates/dsp/src/fec/block.rs
+++ b/crates/dsp/src/fec/block.rs
@@ -1,0 +1,372 @@
+//! Block codes the digital-voice signalling layers are built from (PLAN §13 wave 3).
+//!
+//! Two families, both systematic — information bits first, parity after — because that is how
+//! every one of these codes is published and how the modes pack them on the wire:
+//!
+//! * [`ParityCode`], the Hamming family, written as one XOR mask per parity bit. The masks are
+//!   the specification's own tables (ETSI TS 102 361-1 B.3.11/B.3.12 for DMR, TIA-102.BAAA for
+//!   P25) rather than a derived parity-check matrix: the published codes are *particular*
+//!   Hamming codes among many equivalent ones, and only the published column order decodes a
+//!   real transmitter.
+//! * [`CyclicCode`], a shortened cyclic code plus an even-parity bit: DMR's Golay(20,8,8) slot
+//!   type (generator 0xC75, the binary Golay polynomial, shortened from (24,12,8)) and its
+//!   QR(16,7,6) EMB (generator 0x139, shortened from the extended quadratic-residue (18,9,6)).
+//!
+//! Decoding is exhaustive nearest-codeword search over the 2^k messages — 256 candidates for
+//! the Golay, 128 for the QR. That is the maximum-likelihood answer by construction, needs no
+//! syndrome table, and at one slot type per 30 ms burst costs nothing worth optimising.
+
+/// A systematic single-error-correcting code defined by one parity mask per check bit.
+///
+/// Bit order is the specification's: `word[0..k]` are the information bits, `word[k..n]` the
+/// parity bits, in transmission order.
+#[derive(Clone, Copy, Debug)]
+pub struct ParityCode {
+    k: usize,
+    /// One mask per parity bit; bit `i` set means information bit `i` is in that parity sum.
+    parity: &'static [u16],
+}
+
+impl ParityCode {
+    /// Hamming(13,9,3) — the columns of a DMR BPTC(196,96) block (ETSI TS 102 361-1 B.3.11).
+    pub const HAMMING_13_9: Self = Self {
+        k: 9,
+        parity: &[0b0_0110_1011, 0b0_1101_0111, 0b1_1010_1111, 0b1_0011_0101],
+    };
+
+    /// Hamming(15,11,3) — the rows of a DMR BPTC(196,96) block (ETSI TS 102 361-1 B.3.12).
+    pub const HAMMING_15_11: Self = Self {
+        k: 11,
+        parity: &[
+            0b001_1010_1111,
+            0b011_0101_1110,
+            0b110_1011_1100,
+            0b100_1101_0111,
+        ],
+    };
+
+    /// Hamming(16,11,4) — the same code with an extra check bit, protecting the rows of the
+    /// BPTC(128,77) block a DMR voice burst carries its embedded link control in.
+    pub const HAMMING_16_11: Self = Self {
+        k: 11,
+        parity: &[
+            0b001_1010_1111,
+            0b011_0101_1110,
+            0b110_1011_1100,
+            0b100_1101_0111,
+            0b111_0110_0101,
+        ],
+    };
+
+    /// Hamming(10,6,3) — one hexbit of a P25 link control or encryption sync word
+    /// (TIA-102.BAAA §7.3).
+    pub const HAMMING_10_6: Self = Self {
+        k: 6,
+        parity: &[0b10_0111, 0b10_1011, 0b01_1101, 0b01_1110],
+    };
+
+    /// Hamming(17,12,3) — the rows of a P25 confirmed-data block (TIA-102.BAAA §7.4).
+    pub const HAMMING_17_12: Self = Self {
+        k: 12,
+        parity: &[
+            0b0010_1100_1111,
+            0b0101_1001_1111,
+            0b1011_0011_1110,
+            0b0100_1011_0011,
+            0b1001_0110_0111,
+        ],
+    };
+
+    /// Information bits carried.
+    #[must_use]
+    pub const fn k(&self) -> usize {
+        self.k
+    }
+
+    /// Codeword length in bits.
+    #[must_use]
+    pub const fn n(&self) -> usize {
+        self.k + self.parity.len()
+    }
+
+    /// Fill `word[k..n]` from the information bits in `word[..k]`.
+    ///
+    /// # Panics
+    /// If `word` is shorter than [`ParityCode::n`].
+    pub fn encode(&self, word: &mut [bool]) {
+        assert!(word.len() >= self.n(), "word shorter than the codeword");
+        for (j, &mask) in self.parity.iter().enumerate() {
+            word[self.k + j] = self.sum(word, mask);
+        }
+    }
+
+    /// Correct `word` in place, returning the number of bits repaired, or `None` when the
+    /// syndrome names no single-bit error the code can locate — for the distance-4 member that
+    /// is a detected double error, for the distance-3 ones an uncorrectable pattern.
+    ///
+    /// # Panics
+    /// If `word` is shorter than [`ParityCode::n`].
+    pub fn decode(&self, word: &mut [bool]) -> Option<u32> {
+        assert!(word.len() >= self.n(), "word shorter than the codeword");
+        let mut syndrome = 0u32;
+        for (j, &mask) in self.parity.iter().enumerate() {
+            if self.sum(word, mask) != word[self.k + j] {
+                syndrome |= 1 << j;
+            }
+        }
+        if syndrome == 0 {
+            return Some(0);
+        }
+        // A single parity bit disagreeing with the information is an error in that parity bit.
+        if syndrome.count_ones() == 1 {
+            let j = syndrome.trailing_zeros() as usize;
+            word[self.k + j] = !word[self.k + j];
+            return Some(1);
+        }
+        // Otherwise the syndrome is the check-matrix column of the flipped information bit.
+        for (i, bit) in word.iter_mut().enumerate().take(self.k) {
+            if self.column(i) == syndrome {
+                *bit = !*bit;
+                return Some(1);
+            }
+        }
+        None
+    }
+
+    fn sum(&self, word: &[bool], mask: u16) -> bool {
+        let mut acc = false;
+        for (i, &bit) in word.iter().enumerate().take(self.k) {
+            acc ^= mask >> i & 1 == 1 && bit;
+        }
+        acc
+    }
+
+    /// The check-matrix column for information bit `i`: which parity sums it takes part in.
+    fn column(&self, i: usize) -> u32 {
+        self.parity
+            .iter()
+            .enumerate()
+            .filter(|(_, mask)| *mask >> i & 1 == 1)
+            .fold(0, |acc, (j, _)| acc | 1 << j)
+    }
+}
+
+/// A shortened cyclic code with an appended even-parity bit, decoded by exhaustive search.
+///
+/// The codeword is `info` (`k` bits, first transmitted) then `info · x^parity mod gen`
+/// (`parity` bits) then one bit making the whole word even weight. Words are `u32`, MSB of the
+/// `n`-bit word first on the wire.
+#[derive(Clone, Copy, Debug)]
+pub struct CyclicCode {
+    k: u32,
+    parity: u32,
+    generator: u64,
+    correctable: u32,
+}
+
+/// Longest message any code here carries, so the Gray-code walk needs no allocation.
+const MAX_MESSAGE_BITS: usize = 16;
+
+impl CyclicCode {
+    /// Golay(20,8,8) — the DMR slot type, carrying colour code and data type either side of the
+    /// sync (ETSI TS 102 361-1 B.3.3). Corrects three errors and detects four.
+    pub const GOLAY_20_8: Self = Self {
+        k: 8,
+        parity: 11,
+        generator: 0xC75,
+        correctable: 3,
+    };
+
+    /// QR(16,7,6) — the DMR embedded signalling field in a voice burst (B.3.4). Corrects two.
+    pub const QR_16_7: Self = Self {
+        k: 7,
+        parity: 8,
+        generator: 0x139,
+        correctable: 2,
+    };
+
+    /// The extended binary Golay(24,12,8) the Golay(20,8) above is shortened from — YSF's FICH
+    /// is four of these. Corrects three errors and detects four.
+    pub const GOLAY_24_12: Self = Self {
+        k: 12,
+        parity: 11,
+        generator: 0xC75,
+        correctable: 3,
+    };
+
+    /// BCH(63,16,23) plus an even-parity bit — the 64-bit network identifier every P25 frame
+    /// opens with (TIA-102.BAAA §7.2). The generator is the product of the minimal polynomials
+    /// of α¹ to α²² over GF(64) with primitive polynomial `x⁶ + x + 1`, which is degree 47 and
+    /// so leaves exactly 16 information bits.
+    pub const BCH_63_16: Self = Self {
+        k: 16,
+        parity: 47,
+        generator: 0xCD93_0BDD_3B2B,
+        correctable: 11,
+    };
+
+    /// Codeword length in bits.
+    #[must_use]
+    pub const fn n(&self) -> u32 {
+        self.k + self.parity + 1
+    }
+
+    /// Mask of the `n` transmitted bits.
+    fn mask(&self) -> u64 {
+        let n = self.n();
+        if n >= 64 { u64::MAX } else { (1 << n) - 1 }
+    }
+
+    /// The `n`-bit codeword for `info`, MSB first.
+    #[must_use]
+    pub fn encode(&self, info: u32) -> u64 {
+        let info = u64::from(info) & ((1 << self.k) - 1);
+        let mut rem = info << self.parity;
+        let deg = 63 - self.generator.leading_zeros();
+        for shift in (self.parity..self.k + self.parity).rev() {
+            if rem >> shift & 1 == 1 {
+                rem ^= self.generator << (shift - deg);
+            }
+        }
+        let word = (info << (self.parity + 1)) | (rem << 1);
+        word | u64::from(word.count_ones() % 2 == 1)
+    }
+
+    /// Nearest codeword to `word`, as `(information bits, errors corrected)`. `None` when the
+    /// nearest one is further away than the code can correct, which is a detected error rather
+    /// than a silent guess.
+    ///
+    /// The search walks the messages in Gray-code order, so each candidate codeword is one XOR
+    /// away from the last: the whole 2^k sweep costs one XOR and one population count per
+    /// candidate, which is what makes an exhaustive decode affordable even for the 65 536
+    /// messages of P25's BCH.
+    #[must_use]
+    pub fn decode(&self, word: u64) -> Option<(u32, u32)> {
+        let word = word & self.mask();
+        // The code is linear, so the codeword of a message is the XOR of the codewords of its
+        // set bits.
+        let mut rows = [0u64; MAX_MESSAGE_BITS];
+        for (i, row) in rows.iter_mut().enumerate().take(self.k as usize) {
+            *row = self.encode(1 << i);
+        }
+        let mut codeword = self.encode(0);
+        let mut best = (0u32, (codeword ^ word).count_ones());
+        for i in 1..1u32 << self.k {
+            codeword ^= rows[i.trailing_zeros() as usize];
+            let distance = (codeword ^ word).count_ones();
+            if distance < best.1 {
+                best = (i ^ (i >> 1), distance);
+            }
+        }
+        (best.1 <= self.correctable).then_some(best)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property that makes a code the code it claims to be. A wrong parity table still
+    /// round-trips against itself; only the distance says whether it is the published one.
+    fn min_distance_parity(code: &ParityCode) -> u32 {
+        let mut best = u32::MAX;
+        for info in 1..1u32 << code.k() {
+            let mut word = vec![false; code.n()];
+            for (i, bit) in word.iter_mut().enumerate().take(code.k()) {
+                *bit = info >> i & 1 == 1;
+            }
+            code.encode(&mut word);
+            best = best.min(word.iter().filter(|b| **b).count() as u32);
+        }
+        best
+    }
+
+    #[test]
+    fn the_hamming_family_has_its_published_distances() {
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_13_9), 3);
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_15_11), 3);
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_16_11), 4);
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_10_6), 3);
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_17_12), 3);
+    }
+
+    #[test]
+    fn parity_codes_repair_any_single_bit() {
+        for code in [
+            ParityCode::HAMMING_13_9,
+            ParityCode::HAMMING_15_11,
+            ParityCode::HAMMING_16_11,
+            ParityCode::HAMMING_10_6,
+            ParityCode::HAMMING_17_12,
+        ] {
+            let mut clean = vec![false; code.n()];
+            for (i, bit) in clean.iter_mut().enumerate().take(code.k()) {
+                *bit = i % 3 == 0;
+            }
+            code.encode(&mut clean);
+            for flip in 0..code.n() {
+                let mut word = clean.clone();
+                word[flip] = !word[flip];
+                assert_eq!(code.decode(&mut word), Some(1), "bit {flip}");
+                assert_eq!(word, clean, "bit {flip} was repaired to a different word");
+            }
+        }
+    }
+
+    /// Distance 4 buys detection, not correction: the extended member must refuse a double
+    /// error rather than "repair" it into a third wrong word.
+    #[test]
+    fn the_extended_hamming_detects_double_errors() {
+        let code = ParityCode::HAMMING_16_11;
+        let mut clean = vec![false; code.n()];
+        clean[0] = true;
+        clean[4] = true;
+        code.encode(&mut clean);
+        let mut word = clean.clone();
+        word[2] = !word[2];
+        word[9] = !word[9];
+        assert_eq!(code.decode(&mut word), None);
+    }
+
+    #[test]
+    fn the_cyclic_codes_have_their_published_distances() {
+        for (code, distance) in [(CyclicCode::GOLAY_20_8, 8), (CyclicCode::QR_16_7, 6)] {
+            let min = (1..1u32 << code.k)
+                .map(|info| code.encode(info).count_ones())
+                .min()
+                .unwrap();
+            assert_eq!(min, distance);
+        }
+    }
+
+    /// The DMR slot type as ETSI publishes it: eight information bits followed by the remainder
+    /// modulo 0xC75 and an even-parity bit. These two are the first entries of the encoding
+    /// table every DMR implementation ships, and pin the bit order this code is packed in.
+    #[test]
+    fn golay_20_8_matches_the_published_slot_type_words() {
+        assert_eq!(CyclicCode::GOLAY_20_8.encode(0x01) >> 1 & 0x7FF, 0x475);
+        assert_eq!(CyclicCode::GOLAY_20_8.encode(0x02) >> 1 & 0x7FF, 0x49F);
+    }
+
+    #[test]
+    fn cyclic_codes_correct_up_to_their_limit_and_refuse_beyond_it() {
+        for (code, limit) in [(CyclicCode::GOLAY_20_8, 3), (CyclicCode::QR_16_7, 2)] {
+            let info = 0b101;
+            let clean = code.encode(info);
+            for errors in 0..=limit {
+                let mut word = clean;
+                for bit in 0..errors {
+                    word ^= 1 << (bit * 5 % code.n());
+                }
+                assert_eq!(code.decode(word), Some((info, errors)), "{errors} errors");
+            }
+            // Both codes have even minimum distance, so one error past the correction limit
+            // lands strictly between two codewords: the decoder must say so, not guess.
+            let mut word = clean;
+            for bit in 0..=limit {
+                word ^= 1 << (bit * 5 % code.n());
+            }
+            assert_eq!(code.decode(word), None, "{} errors", limit + 1);
+        }
+    }
+}

--- a/crates/dsp/src/fec/bptc.rs
+++ b/crates/dsp/src/fec/bptc.rs
@@ -1,0 +1,248 @@
+//! The DMR block product turbo codes (ETSI TS 102 361-1 B.2): a rectangle of bits with a
+//! Hamming code along every row *and* every column, interleaved across the burst so a fade
+//! that destroys a run of bits leaves at most one error in each codeword.
+//!
+//! Two shapes are in use and both live here because they differ only in their dimensions and
+//! their row code:
+//!
+//! * [`Bptc196`] — 196 bits either side of a data burst's sync, carrying 96 bits of signalling
+//!   (a link control, a CSBK, a data header). 13 rows of Hamming(15,11,3), 15 columns of
+//!   Hamming(13,9,3).
+//! * [`Bptc128`] — the 128 bits a voice superframe carries its embedded link control in, four
+//!   bursts at a time, carrying 77. 8 rows of Hamming(16,11,4), 16 columns of even parity.
+//!
+//! Decoding alternates row and column passes: a repair in one direction changes the syndromes
+//! in the other, which is what lets the product code correct patterns neither code could alone.
+
+use super::block::ParityCode;
+
+/// Passes over the rectangle before giving up. Each pass can only reduce the number of bad
+/// codewords, so a fixed point is reached quickly; the cap bounds the work when the burst is
+/// noise and no fixed point exists.
+const MAX_PASSES: usize = 5;
+
+/// The interleaved 196-bit block a DMR data burst carries.
+pub struct Bptc196;
+
+impl Bptc196 {
+    /// Payload bits either side of the sync, before deinterleaving.
+    pub const CODED_BITS: usize = 196;
+    /// Signalling bits recovered from one block.
+    pub const DATA_BITS: usize = 96;
+
+    /// The interleaver: coded bit `a` of the burst is matrix bit `a·181 mod 196`
+    /// (ETSI TS 102 361-1 B.2.1). 181 is coprime with 196, so this is a permutation.
+    fn deinterleave(coded: &[bool; Self::CODED_BITS]) -> [bool; Self::CODED_BITS] {
+        let mut matrix = [false; Self::CODED_BITS];
+        for (a, slot) in matrix.iter_mut().enumerate() {
+            *slot = coded[a * 181 % Self::CODED_BITS];
+        }
+        matrix
+    }
+
+    /// Recover the 96 signalling bits, returning them with the number of bit errors repaired,
+    /// or `None` when a row or column codeword is still inconsistent after the last pass.
+    #[must_use]
+    pub fn decode(coded: &[bool; Self::CODED_BITS]) -> Option<([bool; Self::DATA_BITS], u32)> {
+        let mut matrix = Self::deinterleave(coded);
+        let mut corrected = 0;
+        for _ in 0..MAX_PASSES {
+            let repaired = Self::pass(&mut matrix)?;
+            corrected += repaired;
+            if repaired == 0 {
+                return Some((Self::extract(&matrix), corrected));
+            }
+        }
+        // The passes never settled: the block is still being changed on the last one, so
+        // nothing here has been shown to be a codeword.
+        None
+    }
+
+    /// One column pass followed by one row pass, returning the bits repaired.
+    fn pass(matrix: &mut [bool; Self::CODED_BITS]) -> Option<u32> {
+        let mut corrected = 0;
+        for c in 0..15 {
+            let mut column: [bool; 13] = std::array::from_fn(|r| matrix[r * 15 + c + 1]);
+            corrected += ParityCode::HAMMING_13_9.decode(&mut column)?;
+            for (r, bit) in column.into_iter().enumerate() {
+                matrix[r * 15 + c + 1] = bit;
+            }
+        }
+        // Only the first nine rows carry information; the last four are the column parity and
+        // are checked by the column pass that just ran.
+        for r in 0..9 {
+            let start = r * 15 + 1;
+            corrected += ParityCode::HAMMING_15_11.decode(&mut matrix[start..start + 15])?;
+        }
+        Some(corrected)
+    }
+
+    /// Matrix positions of the 96 information bits, in order. Row 0 gives its first three
+    /// columns to the reserved R(0..2) bits the burst still transmits, so it carries eight
+    /// information bits where every other row carries eleven.
+    fn data_positions() -> impl Iterator<Item = usize> {
+        (4..=11).chain((1..9).flat_map(|row| row * 15 + 1..=row * 15 + 11))
+    }
+
+    fn extract(matrix: &[bool; Self::CODED_BITS]) -> [bool; Self::DATA_BITS] {
+        let mut out = [false; Self::DATA_BITS];
+        for (slot, a) in out.iter_mut().zip(Self::data_positions()) {
+            *slot = matrix[a];
+        }
+        out
+    }
+
+    /// Build the 196 coded bits for `data` — the reference modulator's half of [`decode`].
+    #[must_use]
+    pub fn encode(data: &[bool; Self::DATA_BITS]) -> [bool; Self::CODED_BITS] {
+        let mut matrix = [false; Self::CODED_BITS];
+        for (a, &bit) in Self::data_positions().zip(data.iter()) {
+            matrix[a] = bit;
+        }
+        for r in 0..9 {
+            let start = r * 15 + 1;
+            ParityCode::HAMMING_15_11.encode(&mut matrix[start..start + 15]);
+        }
+        for c in 0..15 {
+            let mut column: [bool; 13] = std::array::from_fn(|r| matrix[r * 15 + c + 1]);
+            ParityCode::HAMMING_13_9.encode(&mut column);
+            for (r, bit) in column.into_iter().enumerate() {
+                matrix[r * 15 + c + 1] = bit;
+            }
+        }
+        let mut coded = [false; Self::CODED_BITS];
+        for (a, bit) in matrix.into_iter().enumerate() {
+            coded[a * 181 % Self::CODED_BITS] = bit;
+        }
+        coded
+    }
+}
+
+/// The 128-bit block a DMR voice superframe carries its embedded link control in, spread over
+/// the embedded signalling fields of bursts B to E.
+pub struct Bptc128;
+
+impl Bptc128 {
+    pub const CODED_BITS: usize = 128;
+    /// Seven rows of eleven information bits. The mode above splits them into the 72-bit link
+    /// control and the five-bit checksum interleaved with it — see [`Bptc128::decode`].
+    pub const DATA_BITS: usize = 77;
+
+    /// The wire order is the transpose of the rectangle: the four bursts each carry 32 bits,
+    /// read down the columns. Position 127 is its own image, as it is for every transpose of
+    /// this shape.
+    fn transpose(index: usize) -> usize {
+        if index == 127 { 127 } else { index * 16 % 127 }
+    }
+
+    /// Recover the 77 information bits row by row (row `r`, columns 0 to 10, at output index
+    /// `r · 11 + c`), with the number of bits repaired.
+    ///
+    /// The five-bit checksum the embedded link control carries is *inside* those bits, at
+    /// column 10 of rows 2 to 6; this code has no opinion about it.
+    #[must_use]
+    pub fn decode(coded: &[bool; Self::CODED_BITS]) -> Option<([bool; Self::DATA_BITS], u32)> {
+        let mut matrix = [false; Self::CODED_BITS];
+        for (a, &bit) in coded.iter().enumerate() {
+            matrix[Self::transpose(a)] = bit;
+        }
+        let mut corrected = 0;
+        for r in 0..7 {
+            corrected += ParityCode::HAMMING_16_11.decode(&mut matrix[r * 16..r * 16 + 16])?;
+        }
+        // The eighth row is even parity down each column. It cannot locate an error, so a
+        // failure here means a row code accepted a pattern it should not have.
+        for c in 0..16 {
+            if (0..8).fold(false, |acc, r| acc ^ matrix[r * 16 + c]) {
+                return None;
+            }
+        }
+        let mut out = [false; Self::DATA_BITS];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = matrix[i / 11 * 16 + i % 11];
+        }
+        Some((out, corrected))
+    }
+
+    /// Build the 128 coded bits for `data`.
+    #[must_use]
+    pub fn encode(data: &[bool; Self::DATA_BITS]) -> [bool; Self::CODED_BITS] {
+        let mut matrix = [false; Self::CODED_BITS];
+        for (i, &bit) in data.iter().enumerate() {
+            matrix[i / 11 * 16 + i % 11] = bit;
+        }
+        for r in 0..7 {
+            ParityCode::HAMMING_16_11.encode(&mut matrix[r * 16..r * 16 + 16]);
+        }
+        for c in 0..16 {
+            matrix[7 * 16 + c] = (0..7).fold(false, |acc, r| acc ^ matrix[r * 16 + c]);
+        }
+        let mut coded = [false; Self::CODED_BITS];
+        for (a, slot) in coded.iter_mut().enumerate() {
+            *slot = matrix[Self::transpose(a)];
+        }
+        coded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pattern<const N: usize>(seed: u32) -> [bool; N] {
+        let mut state = seed | 1;
+        std::array::from_fn(|_| {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state & 1 == 1
+        })
+    }
+
+    #[test]
+    fn bptc196_round_trips() {
+        let data: [bool; 96] = pattern(7);
+        let coded = Bptc196::encode(&data);
+        assert_eq!(Bptc196::decode(&coded), Some((data, 0)));
+    }
+
+    /// What the product code is for: errors spread across the burst by the interleaver land in
+    /// different rows and columns, and each one is a single-bit repair.
+    #[test]
+    fn bptc196_repairs_scattered_errors() {
+        let data: [bool; 96] = pattern(11);
+        let mut coded = Bptc196::encode(&data);
+        for bit in [3usize, 44, 91, 150, 195] {
+            coded[bit] = !coded[bit];
+        }
+        let (decoded, corrected) = Bptc196::decode(&coded).expect("repairable");
+        assert_eq!(decoded, data);
+        assert!(corrected >= 5, "corrected {corrected} of 5 planted errors");
+    }
+
+    #[test]
+    fn bptc128_round_trips_and_repairs_one_bit_per_row() {
+        let data: [bool; 77] = pattern(3);
+        let mut coded = Bptc128::encode(&data);
+        assert_eq!(Bptc128::decode(&coded), Some((data, 0)));
+        coded[5] = !coded[5];
+        coded[70] = !coded[70];
+        let (decoded, corrected) = Bptc128::decode(&coded).expect("repairable");
+        assert_eq!(decoded, data);
+        assert_eq!(corrected, 2);
+    }
+
+    /// A burst of noise is not a block. Whatever the passes converge on, an inconsistent
+    /// rectangle must be refused rather than handed up as signalling.
+    #[test]
+    fn bptc_refuses_a_block_it_cannot_reconcile() {
+        let noise: [bool; 196] = pattern(99);
+        let mut heavy = Bptc196::encode(&pattern::<96>(5));
+        for (i, bit) in heavy.iter_mut().enumerate() {
+            if i % 3 == 0 {
+                *bit = noise[i];
+            }
+        }
+        assert!(Bptc196::decode(&heavy).is_none_or(|(_, c)| c > 0));
+    }
+}

--- a/crates/dsp/src/fec/conv.rs
+++ b/crates/dsp/src/fec/conv.rs
@@ -1,0 +1,212 @@
+//! The rate-1/2, constraint-length-5 convolutional code every amateur digital-voice mode
+//! protects its signalling with, and a soft-decision Viterbi decoder for it.
+//!
+//! Generators are G1 = 0b11001 and G2 = 0b10111 (the taps YSF, NXDN and M17 all specify —
+//! M17 writes them 0x19 and 0x17). One information bit produces two coded bits, G1 first.
+//!
+//! Punctured codes are handled without a second code path: the caller expands its received
+//! stream back to the unpunctured length and marks the positions the transmitter never sent
+//! with [`ERASURE`], which contributes equally to both branches and so votes for neither.
+
+/// Soft value of one received coded bit: positive votes for 1, negative for 0, and the
+/// magnitude is the confidence. [`ERASURE`] is the absence of a vote.
+pub type Soft = i16;
+
+/// A coded bit the transmitter punctured away.
+pub const ERASURE: Soft = 0;
+
+/// Full confidence, the value a hard decision maps to.
+pub const CONFIDENT: Soft = 64;
+
+const STATES: usize = 16;
+const G1: u8 = 0b1_1001;
+const G2: u8 = 0b1_0111;
+
+/// Map a hard bit to a soft value.
+#[must_use]
+pub fn soft(bit: bool) -> Soft {
+    if bit { CONFIDENT } else { -CONFIDENT }
+}
+
+/// Encode `bits` at rate 1/2, appending two coded bits per information bit. The caller adds
+/// whatever flush bits its mode specifies — some flush the register, some leave it running
+/// into the next frame, and this code does not decide that for them.
+pub fn encode(bits: &[bool], out: &mut Vec<bool>) {
+    let mut reg = 0u8;
+    for &bit in bits {
+        reg = (reg << 1 | u8::from(bit)) & 0x1F;
+        out.push((reg & G1).count_ones() % 2 == 1);
+        out.push((reg & G2).count_ones() % 2 == 1);
+    }
+}
+
+/// Soft-decision Viterbi decoder for [`encode`].
+///
+/// Owns its traceback buffer, which grows once to the longest frame it is given and is reused
+/// after that — the one allocating primitive in `fec`, and it allocates only on the first frame
+/// of a call. Everything else is fixed-size state.
+#[derive(Clone, Debug, Default)]
+pub struct Viterbi5 {
+    /// One bit per state per step: which predecessor won.
+    decisions: Vec<u16>,
+    metrics: [i32; STATES],
+    next: [i32; STATES],
+}
+
+impl Viterbi5 {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decode `coded` (two soft values per information bit) into `out`, returning the winning
+    /// path metric — the accumulated agreement between the received soft values and the
+    /// codeword the decoder settled on, so a caller can compare two hypotheses.
+    ///
+    /// The encoder is assumed to have started from the all-zero state, which every mode here
+    /// specifies. The final state is not constrained: modes that flush their register end in
+    /// state zero anyway, and modes that do not would be punished for it.
+    ///
+    /// # Panics
+    /// If `coded` has an odd length.
+    pub fn decode(&mut self, coded: &[Soft], out: &mut Vec<bool>) -> i32 {
+        assert!(
+            coded.len().is_multiple_of(2),
+            "rate 1/2 needs an even number of bits"
+        );
+        let steps = coded.len() / 2;
+        self.decisions.clear();
+        self.decisions.resize(steps, 0);
+        // Only the all-zero start state is reachable; the rest begin unreachably bad.
+        self.metrics = [i32::MIN / 4; STATES];
+        self.metrics[0] = 0;
+
+        let (pairs, _) = coded.as_chunks::<2>();
+        for (step, &[first, second]) in pairs.iter().enumerate() {
+            let (r1, r2) = (i32::from(first), i32::from(second));
+            let mut decisions = 0u16;
+            for state in 0..STATES {
+                // Two predecessors reach `state`: the one whose register held `state >> 1`
+                // with a 0 shifted in, and the one that held `state >> 1 | 8` with a 1.
+                let mut best = (i32::MIN, false);
+                for prev_high in [false, true] {
+                    let prev = state >> 1 | usize::from(prev_high) << 3;
+                    let reg = (prev << 1 | state & 1) as u8;
+                    let b1 = (reg & G1).count_ones() % 2 == 1;
+                    let b2 = (reg & G2).count_ones() % 2 == 1;
+                    let branch = if b1 { r1 } else { -r1 } + if b2 { r2 } else { -r2 };
+                    let metric = self.metrics[prev].saturating_add(branch);
+                    if metric > best.0 {
+                        best = (metric, prev_high);
+                    }
+                }
+                self.next[state] = best.0;
+                decisions |= u16::from(best.1) << state;
+            }
+            self.decisions[step] = decisions;
+            self.metrics = self.next;
+        }
+
+        let mut state = (0..STATES)
+            .max_by_key(|&s| self.metrics[s])
+            .unwrap_or_default();
+        let metric = self.metrics[state];
+        let start = out.len();
+        for step in (0..steps).rev() {
+            // The information bit at this step is the one that was shifted in: the low bit of
+            // the state the path arrived at.
+            out.push(state & 1 == 1);
+            let prev_high = self.decisions[step] >> state & 1 == 1;
+            state = state >> 1 | usize::from(prev_high) << 3;
+        }
+        out[start..].reverse();
+        metric
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn softs(bits: &[bool]) -> Vec<Soft> {
+        bits.iter().copied().map(soft).collect()
+    }
+
+    fn message(len: usize, seed: u32) -> Vec<bool> {
+        let mut state = seed | 1;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                state & 1 == 1
+            })
+            .collect()
+    }
+
+    #[test]
+    fn round_trips_a_flushed_frame() {
+        let mut bits = message(96, 5);
+        bits.extend([false; 4]);
+        let mut coded = Vec::new();
+        encode(&bits, &mut coded);
+        assert_eq!(coded.len(), bits.len() * 2);
+
+        let mut out = Vec::new();
+        Viterbi5::new().decode(&softs(&coded), &mut out);
+        assert_eq!(out, bits);
+    }
+
+    /// The reason a convolutional code is there at all: errors the block codes around it would
+    /// have to detect and drop, this one repairs.
+    #[test]
+    fn repairs_scattered_channel_errors() {
+        let mut bits = message(72, 9);
+        bits.extend([false; 4]);
+        let mut coded = Vec::new();
+        encode(&bits, &mut coded);
+        let mut received = softs(&coded);
+        for bit in [3usize, 40, 41, 90, 130] {
+            received[bit] = -received[bit];
+        }
+        let mut out = Vec::new();
+        Viterbi5::new().decode(&received, &mut out);
+        assert_eq!(out, bits);
+    }
+
+    /// A punctured code is the same decoder with holes in its input.
+    #[test]
+    fn erasures_stand_in_for_punctured_bits() {
+        let mut bits = message(48, 3);
+        bits.extend([false; 4]);
+        let mut coded = Vec::new();
+        encode(&bits, &mut coded);
+        let mut received = softs(&coded);
+        // Puncture every eighth coded bit — a 8/7 thinning of the rate-1/2 stream.
+        for (i, value) in received.iter_mut().enumerate() {
+            if i % 8 == 7 {
+                *value = ERASURE;
+            }
+        }
+        let mut out = Vec::new();
+        Viterbi5::new().decode(&received, &mut out);
+        assert_eq!(out, bits);
+    }
+
+    /// Soft input is not a luxury here: the same errors that a soft decoder rides through sink
+    /// a hard one, and the modes below feed it real symbol distances.
+    #[test]
+    fn weak_bits_lose_to_confident_ones() {
+        let mut bits = message(64, 21);
+        bits.extend([false; 4]);
+        let mut coded = Vec::new();
+        encode(&bits, &mut coded);
+        let mut received = softs(&coded);
+        for bit in [10usize, 11, 12, 13] {
+            received[bit] = if received[bit] > 0 { -1 } else { 1 };
+        }
+        let mut out = Vec::new();
+        Viterbi5::new().decode(&received, &mut out);
+        assert_eq!(out, bits);
+    }
+}

--- a/crates/dsp/src/fec/mod.rs
+++ b/crates/dsp/src/fec/mod.rs
@@ -1,9 +1,15 @@
-//! Checksums and error-correcting codes for the wave-1 decoders (PLAN §7): the HDLC/AIS
+//! Checksums and error-correcting codes for the framed decoders (PLAN §7): the HDLC/AIS
 //! CRC-16, the Mode S CRC-24 with single-bit correction, the POCSAG BCH(31,21) codeword and
-//! the RDS shortened cyclic (26,16) block.
+//! the RDS shortened cyclic (26,16) block, plus the block, product and convolutional codes the
+//! digital-voice signalling layers are built from in the submodules.
 //!
-//! All of it is stateless integer arithmetic over GF(2) — no allocation, no locks — so a
-//! decoder may call it straight from the DSP thread.
+//! All of it is integer arithmetic over GF(2) — no allocation, no locks — so a decoder may call
+//! it straight from the DSP thread. [`conv::Viterbi5`] is the one exception and says so: it owns
+//! a traceback buffer that grows once to the longest frame it is given.
+
+pub mod block;
+pub mod bptc;
+pub mod conv;
 
 /// CRC-16 polynomial 0x1021 in its reflected form, for the LSB-first loops below.
 const CCITT_POLY_REFLECTED: u16 = 0x8408;
@@ -37,6 +43,81 @@ pub fn crc16_x25(data: &[u8]) -> u16 {
 #[must_use]
 pub fn crc16_ccitt(data: &[u8]) -> u16 {
     crc16_reflected(0, data)
+}
+
+/// MSB-first CRC-16 over an arbitrary generator — the un-reflected form the digital-voice
+/// signalling codes check themselves with: `poly` 0x1021 init 0 is the CRC-CCITT that guards a
+/// DMR CSBK and a YSF FICH, `poly` 0x5935 init 0xFFFF the one M17 puts in its link setup frame.
+///
+/// Bit-granular because these fields are not all byte-aligned: an M17 LSF is 224 bits of body,
+/// a DMR CSBK 80, and rounding either up to bytes would checksum padding the transmitter never
+/// sent. [`crc16_msb`] is the byte-aligned convenience over the same register.
+#[must_use]
+pub fn crc16_msb_bits(poly: u16, init: u16, bits: &[bool]) -> u16 {
+    let mut crc = init;
+    for &bit in bits {
+        let msb = crc & 0x8000 != 0;
+        crc <<= 1;
+        if msb != bit {
+            crc ^= poly;
+        }
+    }
+    crc
+}
+
+/// Byte-aligned [`crc16_msb_bits`], MSB of each byte first.
+#[must_use]
+pub fn crc16_msb(poly: u16, init: u16, data: &[u8]) -> u16 {
+    let mut crc = init;
+    for &byte in data {
+        crc ^= u16::from(byte) << 8;
+        for _ in 0..8 {
+            let msb = crc & 0x8000 != 0;
+            crc <<= 1;
+            if msb {
+                crc ^= poly;
+            }
+        }
+    }
+    crc
+}
+
+/// Reed-Solomon(12,9) parity over GF(256) as DMR defines it for its full link control
+/// (ETSI TS 102 361-1 §B.3.9): the systematic remainder of the nine information octets by
+/// `x³ + 14x² + 56x + 64`, returned in transmission order.
+///
+/// Parity only — there is no correction here. The product code underneath a DMR burst has
+/// already repaired what it can, and a link control that still fails this check is one whose
+/// addresses would be a guess.
+#[must_use]
+pub fn rs129_parity(msg: &[u8]) -> [u8; 3] {
+    /// Generator coefficients, lowest order first.
+    const POLY: [u8; 3] = [64, 56, 14];
+    let mut parity = [0u8; 3];
+    for &byte in msg {
+        let feedback = byte ^ parity[2];
+        parity[2] = parity[1] ^ gf256_mul(POLY[2], feedback);
+        parity[1] = parity[0] ^ gf256_mul(POLY[1], feedback);
+        parity[0] = gf256_mul(POLY[0], feedback);
+    }
+    [parity[2], parity[1], parity[0]]
+}
+
+/// GF(256) multiply modulo `x⁸ + x⁴ + x³ + x² + 1`.
+fn gf256_mul(a: u8, b: u8) -> u8 {
+    let (mut a, mut b, mut product) = (a, b, 0u8);
+    while b != 0 {
+        if b & 1 == 1 {
+            product ^= a;
+        }
+        let high = a & 0x80 != 0;
+        a <<= 1;
+        if high {
+            a ^= 0x1D;
+        }
+        b >>= 1;
+    }
+    product
 }
 
 /// True when an HDLC frame's trailing little-endian 2-byte FCS matches its payload.

--- a/crates/dsp/src/fir.rs
+++ b/crates/dsp/src/fir.rs
@@ -79,6 +79,53 @@ pub fn design_gaussian(sps: f64, bt: f64, span: usize) -> Vec<f32> {
     h.into_iter().map(|v| v as f32).collect()
 }
 
+/// Root-raised-cosine matched filter: `sps` samples per symbol, `alpha` the roll-off (0.2 for
+/// the C4FM digital-voice modes, 0.5 for M17), `span` symbol periods either side of the pulse.
+/// The tap count is `2·span·sps` rounded up to odd, so the pulse has a true centre tap.
+/// Normalized to unity DC gain, which keeps a demodulator's level estimate meaning what it did
+/// before the filter.
+#[must_use]
+pub fn design_rrc(sps: f64, alpha: f64, span: usize) -> Vec<f32> {
+    assert!(sps > 1.0, "need more than one sample per symbol");
+    assert!(
+        alpha > 0.0 && alpha <= 1.0,
+        "roll-off must be in (0, 1]: {alpha}"
+    );
+    assert!(span >= 1, "span must cover at least one symbol");
+    let mut taps = (2.0 * span as f64 * sps).round() as usize;
+    if taps.is_multiple_of(2) {
+        taps += 1;
+    }
+    let center = (taps - 1) as f64 / 2.0;
+    let mut h: Vec<f64> = (0..taps)
+        .map(|k| {
+            let t = (k as f64 - center) / sps;
+            rrc_pulse(t, alpha)
+        })
+        .collect();
+    let sum: f64 = h.iter().sum();
+    for v in &mut h {
+        *v /= sum;
+    }
+    h.into_iter().map(|v| v as f32).collect()
+}
+
+/// The RRC impulse response at `t` symbol periods, with its two removable singularities —
+/// at the origin, and at `t = ±1/(4α)` where the closed form divides by zero — evaluated as
+/// the limits they are.
+fn rrc_pulse(t: f64, alpha: f64) -> f64 {
+    if t.abs() < 1e-9 {
+        return 1.0 - alpha + 4.0 * alpha / PI;
+    }
+    if (t.abs() - 1.0 / (4.0 * alpha)).abs() < 1e-9 {
+        let x = PI / (4.0 * alpha);
+        return alpha / 2.0f64.sqrt() * ((1.0 + 2.0 / PI) * x.sin() + (1.0 - 2.0 / PI) * x.cos());
+    }
+    let pt = PI * t;
+    let numerator = ((1.0 - alpha) * pt).sin() + 4.0 * alpha * t * ((1.0 + alpha) * pt).cos();
+    numerator / (pt * (1.0 - (4.0 * alpha * t).powi(2)))
+}
+
 fn sinc(x: f64) -> f64 {
     if x.abs() < 1e-12 {
         1.0

--- a/crates/dsp/src/fsk4.rs
+++ b/crates/dsp/src/fsk4.rs
@@ -1,0 +1,288 @@
+//! Four-level FSK symbol recovery (PLAN §13 wave 3) — the front end every digital-voice mode
+//! but D-Star shares.
+//!
+//! Chain: FM discriminator → root-raised-cosine matched filter → Gardner symbol clock → level
+//! normalisation. What comes out is one soft symbol per symbol period, scaled so the four
+//! transmitted levels sit at ±1 and ±3 whatever the transmitter's actual deviation is.
+//!
+//! The clock is a Gardner detector rather than the zero-crossing tracker the two-level decoders
+//! use, because with four levels a crossing is no longer a timing reference: a +1 → −3
+//! transition crosses zero a quarter of a symbol before a +3 → −3 one does, and a tracker that
+//! believed both would jitter with the data. Gardner's estimate is level-independent.
+//!
+//! Nothing here knows the deviation of the mode it is demodulating. The nominal figure only
+//! sets the discriminator's numeric scale; the decision levels are *measured*, because a
+//! narrowband transmitter that is 20% under-deviated is a signal to decode, not to reject, and
+//! because the same code then serves the ±1944 Hz 12.5 kHz modes and the ±1050 Hz 6.25 kHz ones.
+
+use num_complex::Complex;
+
+use crate::{FmDemod, RealDecimator, SymbolSync, fir::design_rrc};
+
+/// Symbol periods the centre estimate averages over. A receiver frequency error is static, so
+/// this is deliberately far longer than any run of one symbol a mode can transmit — the tail of
+/// a DMR sync pattern is 24 symbols of alternating ±3, a P25 status symbol run far fewer.
+const CENTRE_SYMBOLS: f32 = 150.0;
+
+/// Decay of the peak estimate, per symbol. Fast enough to follow a fading signal between
+/// bursts, slow enough that a run without an outer symbol does not shrink the eye.
+const PEAK_SYMBOLS: f32 = 60.0;
+
+/// Matched-filter span either side of the pulse, in symbol periods.
+const MATCHED_SPAN: usize = 8;
+
+/// Timing loop bandwidth in cycles per symbol. A transmitter's symbol clock is crystal-derived
+/// and drifts by parts per million, so the loop only has to acquire — quickly enough to be
+/// locked before a 30 ms burst's sync pattern arrives, and no faster.
+const TIMING_LOOP_BW: f64 = 0.01;
+
+/// The four levels a symbol is sliced to, as the dibits the modes read: +3 is 01, +1 is 00,
+/// −1 is 10, −3 is 11 (ETSI TS 102 361-1 §4.2.2, and the same in TIA-102 and the M17 spec).
+#[must_use]
+pub fn slice(symbol: f32) -> u8 {
+    match symbol {
+        s if s >= 2.0 => 0b01,
+        s if s >= 0.0 => 0b00,
+        s if s >= -2.0 => 0b10,
+        _ => 0b11,
+    }
+}
+
+/// Soft values for the two bits a symbol carries, for [`crate::fec::conv`] above: the first bit
+/// says the level is negative, the second that it is an outer one. Both are the distance to the
+/// decision boundary, scaled so a clean symbol reaches full confidence and clipped there — an
+/// over-deviated burst must not out-vote the rest of the frame.
+#[must_use]
+pub fn soft_bits(symbol: f32) -> [i16; 2] {
+    let scale = f32::from(crate::fec::conv::CONFIDENT) / 2.0;
+    let clip = |v: f32| (v * scale).clamp(-64.0, 64.0) as i16;
+    [clip(-symbol), clip(symbol.abs() - 2.0)]
+}
+
+/// The symbol level a dibit is transmitted at, in the same ±1/±3 units [`Fsk4Demod`] produces.
+#[must_use]
+pub fn level(dibit: u8) -> f32 {
+    match dibit & 0b11 {
+        0b01 => 3.0,
+        0b00 => 1.0,
+        0b10 => -1.0,
+        _ => -3.0,
+    }
+}
+
+/// Four-level FSK demodulator producing normalised soft symbols.
+pub struct Fsk4Demod {
+    demod: FmDemod,
+    matched: RealDecimator,
+    sync: SymbolSync,
+    centre: f32,
+    peak: f32,
+    centre_alpha: f32,
+    peak_decay: f32,
+    demod_buf: Vec<f32>,
+    filtered: Vec<f32>,
+    /// The timing recovery works on complex baseband; a discriminator produces real samples,
+    /// and for those Gardner's detector reduces to `(x[k] − x[k−1])·x_mid` — the same
+    /// expression, with the imaginary part carried along as zero.
+    centred: Vec<Complex<f32>>,
+    retimed: Vec<Complex<f32>>,
+}
+
+impl Fsk4Demod {
+    /// `deviation_hz` is the outer (±3) deviation, `alpha` the excess bandwidth of the
+    /// transmitter's pulse shaping — 0.2 for the C4FM modes, 0.5 for M17.
+    ///
+    /// # Panics
+    /// If the rate does not give at least two samples per symbol.
+    #[must_use]
+    pub fn new(rate: f64, baud: f64, deviation_hz: f64, alpha: f64) -> Self {
+        let sps = rate / baud;
+        assert!(sps >= 2.0, "need at least two samples per symbol");
+        Self {
+            demod: FmDemod::new(rate, deviation_hz),
+            matched: RealDecimator::new(&design_rrc(sps, alpha, MATCHED_SPAN), 1),
+            sync: SymbolSync::new(sps, TIMING_LOOP_BW),
+            centre: 0.0,
+            // A signal at the nominal deviation reads ±1 out of the discriminator, so the
+            // outer level starts where an on-frequency, correctly-deviated transmitter is.
+            peak: 1.0,
+            centre_alpha: 1.0 / (CENTRE_SYMBOLS * sps as f32),
+            peak_decay: 1.0 - 1.0 / PEAK_SYMBOLS,
+            demod_buf: Vec::new(),
+            filtered: Vec::new(),
+            centred: Vec::new(),
+            retimed: Vec::new(),
+        }
+    }
+
+    /// Demodulate a block, appending one soft symbol per recovered symbol period to `out`.
+    /// Timing and level state carry across calls, so any block split gives the same symbols.
+    pub fn process(&mut self, iq: &[Complex<f32>], out: &mut Vec<f32>) {
+        self.demod.process(iq, &mut self.demod_buf);
+        self.matched.process(&self.demod_buf, &mut self.filtered);
+        self.centred.clear();
+        for &sample in &self.filtered {
+            // Per sample rather than per symbol: the timing detector is fed the centred
+            // signal, so the estimate has to advance with the samples it is subtracted from,
+            // whatever size the blocks arrive in.
+            self.centre += self.centre_alpha * (sample - self.centre);
+            self.centred.push(Complex::new(sample - self.centre, 0.0));
+        }
+        self.retimed.clear();
+        self.sync.process(&self.centred, &mut self.retimed);
+        for symbol in &self.retimed {
+            let value = symbol.re;
+            self.peak = (self.peak * self.peak_decay).max(value.abs());
+            // Guard the divide: a squelched channel produces zeros, and a symbol stream of
+            // NaN would poison every decoder above this one.
+            let unit = self.peak / 3.0;
+            out.push(if unit > 1e-6 { value / unit } else { 0.0 });
+        }
+    }
+
+    /// Forget the timing and level estimates — the channel moved, and what this has learned
+    /// describes the transmitter it just left.
+    pub fn reset(&mut self) {
+        self.sync.reset();
+        self.centre = 0.0;
+        self.peak = 1.0;
+        self.demod_buf.clear();
+        self.filtered.clear();
+        self.centred.clear();
+        self.retimed.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::f64::consts::TAU;
+
+    use super::*;
+
+    /// A C4FM transmitter: symbol impulses through the transmit half of the root-raised-cosine
+    /// pair, frequency-modulated onto the carrier. Shaping matters to this test — an
+    /// unshaped rectangular symbol train through a receive RRC is not a Nyquist cascade, and
+    /// the inter-symbol interference that leaves is the transmitter's fault, not the clock's.
+    fn modulate(dibits: &[u8], rate: f64, baud: f64, deviation_hz: f64) -> Vec<Complex<f32>> {
+        let sps = rate / baud;
+        let taps = design_rrc(sps, 0.2, MATCHED_SPAN);
+        let mut impulses = vec![0.0f32; dibits.len() * sps as usize + taps.len()];
+        for (i, &dibit) in dibits.iter().enumerate() {
+            impulses[i * sps as usize] = level(dibit) / 3.0 * sps as f32;
+        }
+        let mut shaped = Vec::new();
+        RealDecimator::new(&taps, 1).process(&impulses, &mut shaped);
+        let mut phase = 0.0f64;
+        shaped
+            .iter()
+            .map(|&s| {
+                phase += TAU * f64::from(s) * deviation_hz / rate;
+                Complex::from_polar(1.0, phase as f32)
+            })
+            .collect()
+    }
+
+    fn dibits(len: usize, seed: u32) -> Vec<u8> {
+        let mut state = seed | 1;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 17;
+                state ^= state << 5;
+                (state & 3) as u8
+            })
+            .collect()
+    }
+
+    /// Errors between `got` and `sent` once the matched filter's delay is taken out, skipping
+    /// the lead-in the clock and the level estimate need. The alignment is searched rather than
+    /// assumed: it is a property of the filter span, not of the mode.
+    fn symbol_errors(got: &[u8], sent: &[u8], skip: usize) -> (usize, usize) {
+        let (delay, errors) = (0..32)
+            .map(|delay| {
+                let errors = got
+                    .iter()
+                    .enumerate()
+                    .skip(skip)
+                    .filter(|&(i, s)| sent.get(i.wrapping_sub(delay)).is_none_or(|w| w != s))
+                    .count();
+                (delay, errors)
+            })
+            .min_by_key(|&(_, errors)| errors)
+            .unwrap();
+        assert!((1..24).contains(&delay), "implausible alignment {delay}");
+        (errors, got.len() - skip)
+    }
+
+    /// The whole point of the front end: symbols in, the same symbols out, at a deviation the
+    /// demodulator was never told about.
+    #[test]
+    fn recovers_symbols_at_an_unexpected_deviation() {
+        for deviation in [1_944.0, 1_400.0, 2_600.0] {
+            let sent = dibits(400, 17);
+            let iq = modulate(&sent, 48_000.0, 4_800.0, deviation);
+            let mut demod = Fsk4Demod::new(48_000.0, 4_800.0, 1_944.0, 0.2);
+            let mut symbols = Vec::new();
+            demod.process(&iq, &mut symbols);
+            let got: Vec<u8> = symbols.iter().copied().map(slice).collect();
+            let (errors, total) = symbol_errors(&got, &sent, 40);
+            assert!(total > 300, "only {total} symbols at {deviation} Hz");
+            assert_eq!(errors, 0, "symbol errors at {deviation} Hz deviation");
+        }
+    }
+
+    /// A receiver is never exactly on frequency. The centre estimate has to absorb the offset
+    /// a mistuned dial or a drifting transmitter puts on the discriminator.
+    #[test]
+    fn tracks_a_carrier_offset() {
+        let sent = dibits(600, 5);
+        let mut iq = modulate(&sent, 48_000.0, 4_800.0, 1_944.0);
+        // 400 Hz off — a fifth of the outer deviation, which un-centred would slice the
+        // +1 level as +3 whenever it drifted high.
+        for (k, s) in iq.iter_mut().enumerate() {
+            *s *= Complex::from_polar(1.0, (TAU * 400.0 * k as f64 / 48_000.0) as f32);
+        }
+        let mut demod = Fsk4Demod::new(48_000.0, 4_800.0, 1_944.0, 0.2);
+        let mut symbols = Vec::new();
+        demod.process(&iq, &mut symbols);
+        let got: Vec<u8> = symbols.iter().copied().map(slice).collect();
+        // The centre estimate averages over hundreds of symbols, so the offset is only fully
+        // absorbed in the tail — which is what a decoder hunting a sync pattern needs.
+        let (errors, _) = symbol_errors(&got, &sent, symbols.len() - 200);
+        assert_eq!(errors, 0);
+    }
+
+    /// The host hands a channel whatever the device gave it. Every piece of state here — the
+    /// filter history, the timing accumulator, the centre and peak estimates — has to advance
+    /// with the samples rather than with the calls, or the same signal would decode differently
+    /// depending on the radio's buffer size.
+    #[test]
+    fn block_splits_do_not_change_the_symbols() {
+        let sent = dibits(300, 41);
+        let iq = modulate(&sent, 48_000.0, 4_800.0, 1_944.0);
+        let mut whole = Vec::new();
+        Fsk4Demod::new(48_000.0, 4_800.0, 1_944.0, 0.2).process(&iq, &mut whole);
+
+        let mut demod = Fsk4Demod::new(48_000.0, 4_800.0, 1_944.0, 0.2);
+        let mut ragged = Vec::new();
+        let mut pos = 0;
+        for len in [997usize, 1, 4_096, 65, 7].iter().cycle() {
+            if pos >= iq.len() {
+                break;
+            }
+            let end = (pos + len).min(iq.len());
+            demod.process(&iq[pos..end], &mut ragged);
+            pos = end;
+        }
+        assert_eq!(whole, ragged);
+    }
+
+    #[test]
+    fn a_silent_channel_produces_finite_symbols() {
+        let mut demod = Fsk4Demod::new(48_000.0, 4_800.0, 1_944.0, 0.2);
+        let mut symbols = Vec::new();
+        demod.process(&vec![Complex::new(0.0, 0.0); 4_800], &mut symbols);
+        assert!(!symbols.is_empty());
+        assert!(symbols.iter().all(|s| s.is_finite()), "non-finite symbol");
+    }
+}

--- a/crates/dsp/src/lib.rs
+++ b/crates/dsp/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fec;
 pub mod fir;
 pub mod firc;
 pub mod fm;
+pub mod fsk4;
 pub mod iir;
 pub mod nco;
 pub mod pll;
@@ -30,13 +31,18 @@ pub use bits::{
 pub use ddc::{Ddc, DdcError, flat_bandwidth_hz, resamplable_bandwidth_hz};
 pub use decim::{Decimator, RealDecimator};
 pub use fec::{
-    RdsOffset, crc16_ccitt, crc16_x25, hdlc_fcs_ok, mode_s_append_parity, mode_s_fix_single_bit,
-    mode_s_syndrome, pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block,
-    rds_syndrome,
+    RdsOffset,
+    block::{CyclicCode, ParityCode},
+    bptc::{Bptc128, Bptc196},
+    conv::Viterbi5,
+    crc16_ccitt, crc16_msb, crc16_msb_bits, crc16_x25, hdlc_fcs_ok, mode_s_append_parity,
+    mode_s_fix_single_bit, mode_s_syndrome, pocsag_bch_decode, pocsag_bch_encode, rds_check_block,
+    rds_encode_block, rds_syndrome, rs129_parity,
 };
-pub use fir::{design_bandpass, design_gaussian, design_lowpass};
+pub use fir::{design_bandpass, design_gaussian, design_lowpass, design_rrc};
 pub use firc::FirC;
 pub use fm::FmDemod;
+pub use fsk4::Fsk4Demod;
 pub use iir::{DcBlocker, Deemphasis, one_pole_coeff};
 pub use nco::Nco;
 pub use pll::{Costas, LoopFilter, Pll};

--- a/crates/wire/src/channel.rs
+++ b/crates/wire/src/channel.rs
@@ -482,6 +482,76 @@ impl Default for SubghzParams {
     }
 }
 
+/// Which DMR timeslot a channel reports. Both slots share one 12.5 kHz carrier in 30 ms
+/// alternation, so the receiver always hears both; this only decides what reaches the log.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DmrSlots {
+    #[default]
+    Both,
+    One,
+    Two,
+}
+
+impl DmrSlots {
+    /// Whether a burst decoded on `slot` (1 or 2) should be reported.
+    #[must_use]
+    pub fn accepts(self, slot: u8) -> bool {
+        match self {
+            Self::Both => true,
+            Self::One => slot == 1,
+            Self::Two => slot == 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct DmrParams {
+    #[serde(default)]
+    pub slots: DmrSlots,
+}
+
+/// The two NXDN channel widths. They are different radios as far as the receiver is
+/// concerned: 6.25 kHz halves both the symbol rate and the deviation of the 12.5 kHz one.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NxdnBandwidth {
+    /// 6.25 kHz, 2400 symbols per second — the common deployment.
+    #[default]
+    Narrow,
+    /// 12.5 kHz, 4800 symbols per second.
+    Wide,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct NxdnParams {
+    #[serde(default)]
+    pub bandwidth: NxdnBandwidth,
+}
+
+/// The digital-voice modes whose framing carries no options worth setting: everything about
+/// them — symbol rate, deviation, channel width, sync patterns — is fixed by the mode.
+macro_rules! empty_params {
+    ($($(#[$doc:meta])* $name:ident),* $(,)?) => {$(
+        $(#[$doc])*
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+        pub struct $name {}
+    )*};
+}
+
+empty_params! {
+    /// D-Star (GMSK, 4800 bit/s).
+    DstarParams,
+    /// System Fusion (C4FM, 4800 symbols/s).
+    YsfParams,
+    /// P25 Phase 1 (C4FM, 4800 symbols/s).
+    P25Params,
+    /// dPMR (C4FM, 2400 symbols/s, 6.25 kHz).
+    DpmrParams,
+    /// M17 (C4FM, 4800 symbols/s, RRC 0.5).
+    M17Params,
+}
+
 /// Type-discriminated demod parameters. Adjacently tagged so the generated TS is a
 /// discriminated union on `type`, and `{"type":"nfm","settings":{}}` deserializes with
 /// every field at its default.
@@ -501,6 +571,13 @@ pub enum ChannelParams {
     Navtex(NavtexParams),
     Acars(AcarsParams),
     Subghz(SubghzParams),
+    Dmr(DmrParams),
+    Dstar(DstarParams),
+    Ysf(YsfParams),
+    Nxdn(NxdnParams),
+    P25(P25Params),
+    Dpmr(DpmrParams),
+    M17(M17Params),
 }
 
 impl ChannelParams {
@@ -521,6 +598,13 @@ impl ChannelParams {
             Self::Navtex(_) => "navtex",
             Self::Acars(_) => "acars",
             Self::Subghz(_) => "subghz",
+            Self::Dmr(_) => "dmr",
+            Self::Dstar(_) => "dstar",
+            Self::Ysf(_) => "ysf",
+            Self::Nxdn(_) => "nxdn",
+            Self::P25(_) => "p25",
+            Self::Dpmr(_) => "dpmr",
+            Self::M17(_) => "m17",
         }
     }
 }

--- a/crates/wire/src/decode.rs
+++ b/crates/wire/src/decode.rs
@@ -321,6 +321,147 @@ pub struct SubghzFrame {
     pub timings_us: Vec<u32>,
 }
 
+/// Which digital-voice mode a [`DvFrame`] was heard on (PLAN §13 wave 3). One event type
+/// serves all of them because the *question* is the same in every mode — who is talking, to
+/// whom, on which network — and only the names for it differ.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DvMode {
+    #[default]
+    Dmr,
+    Dstar,
+    Ysf,
+    Nxdn,
+    P25,
+    Dpmr,
+    M17,
+}
+
+impl DvMode {
+    /// Display name, as operators write it.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dmr => "DMR",
+            Self::Dstar => "D-STAR",
+            Self::Ysf => "YSF",
+            Self::Nxdn => "NXDN",
+            Self::P25 => "P25",
+            Self::Dpmr => "dPMR",
+            Self::M17 => "M17",
+        }
+    }
+}
+
+/// What the burst was carrying. Every mode distinguishes these four, whatever it calls them:
+/// the frame that opens a transmission and names the parties, the voice frames that follow,
+/// the one that closes it, and the signalling that travels outside a call.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DvFrameKind {
+    /// Call setup: DMR voice LC header, D-Star header, P25 header, M17 link setup.
+    #[default]
+    Header,
+    /// A voice burst whose signalling named the call (late entry, or an embedded/link-control
+    /// repeat). Voice frames carrying nothing new are not reported — a 20 ms heartbeat is not
+    /// a log entry.
+    Voice,
+    /// End of transmission.
+    Terminator,
+    /// Signalling outside a call: a DMR CSBK, a P25 trunking block, an NXDN control message.
+    Control,
+    /// Payload data rather than voice: a DMR data header, a D-Star fast-data or slow-data
+    /// text block, an M17 packet.
+    Data,
+}
+
+/// One decoded digital-voice frame — the *metadata* of a call, not its audio.
+///
+/// No mode here produces sound: DMR, D-Star, YSF, NXDN, P25 and dPMR all carry AMBE-family
+/// vocoder frames and this build ships no vocoder, and M17's Codec2 payload is not decoded
+/// either (see FEATURES §9). What a decoder does recover is everything *around* the voice —
+/// who keyed up, on which talkgroup, over which repeater, with what encryption — which is what
+/// a scanner log is actually made of. Fields are `Option` because which of them exist is a
+/// property of the mode and the frame: a D-Star header has callsigns and no talkgroup, a DMR
+/// voice header the reverse.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct DvFrame {
+    pub mode: DvMode,
+    pub kind: DvFrameKind,
+    /// TDMA timeslot, 1 or 2 — DMR only; every other mode here is single-slot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u8>,
+    /// The mode's network discriminator, under whichever name it publishes: DMR colour code,
+    /// NXDN/dPMR RAN or colour code, P25 NAC, YSF has none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color_code: Option<u16>,
+    /// True for a talkgroup call, false for a call addressed to one radio.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_call: Option<bool>,
+    /// Numeric source address — DMR/NXDN/dPMR radio ID, P25 source unit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<u32>,
+    /// Numeric destination: talkgroup for a group call, radio ID for a private one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<u32>,
+    /// Source callsign — the modes that address by callsign rather than by number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_call: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_call: Option<String>,
+    /// The repeater or reflector the call is routed through: D-Star RPT1/RPT2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
+    /// Set when the frame says its payload is encrypted. `Some(false)` is a positive statement
+    /// that it is in the clear; `None` means the frame did not say.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted: Option<bool>,
+    /// Name of the signalling opcode for a control frame — "group voice channel grant",
+    /// "preamble", … — as its specification names it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opcode: Option<String>,
+    /// Free text the frame carried: a D-Star slow-data message, a YSF radio ID, an M17 meta
+    /// field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Bit errors the frame's error-correcting codes repaired — the honest signal-quality
+    /// readout, since a mode with no audio has no other.
+    pub errors_corrected: u32,
+}
+
+impl DvFrame {
+    /// A frame of `mode` and `kind` with nothing else known yet.
+    #[must_use]
+    pub fn new(mode: DvMode, kind: DvFrameKind) -> Self {
+        Self {
+            mode,
+            kind,
+            ..Self::default()
+        }
+    }
+
+    /// How the parties read on one line: `TG 505 ← 2621001`, `DL1ABC → CQCQCQ`.
+    #[must_use]
+    pub fn parties(&self) -> Option<String> {
+        let to = self.destination_call.clone().or_else(|| {
+            self.destination.map(|d| match self.group_call {
+                Some(false) => d.to_string(),
+                _ => format!("TG {d}"),
+            })
+        });
+        let from = self
+            .source_call
+            .clone()
+            .or_else(|| self.source.map(|s| s.to_string()));
+        match (to, from) {
+            (Some(to), Some(from)) => Some(format!("{to} ← {from}")),
+            (Some(to), None) => Some(to),
+            (None, Some(from)) => Some(from),
+            (None, None) => None,
+        }
+    }
+}
+
 /// Typed decoder output (PLAN §5). Adjacently tagged so the generated TypeScript is a
 /// discriminated union on `kind` that panels can exhaustively `switch` on, and so the log
 /// database can index on `kind` without parsing the blob.
@@ -337,6 +478,7 @@ pub enum DecoderEvent {
     Navtex(NavtexMessage),
     Acars(AcarsMessage),
     Subghz(SubghzFrame),
+    Dv(DvFrame),
 }
 
 impl DecoderEvent {
@@ -354,6 +496,7 @@ impl DecoderEvent {
             Self::Navtex(_) => "navtex",
             Self::Acars(_) => "acars",
             Self::Subghz(_) => "subghz",
+            Self::Dv(_) => "dv",
         }
     }
 
@@ -453,6 +596,35 @@ impl DecoderEvent {
                 }
                 parts.join(" · ")
             }
+            Self::Dv(f) => {
+                let mut parts = vec![f.mode.label().to_owned()];
+                if let Some(slot) = f.slot {
+                    parts.push(format!("TS{slot}"));
+                }
+                if let Some(cc) = f.color_code {
+                    parts.push(match f.mode {
+                        DvMode::P25 => format!("NAC {cc:03X}"),
+                        DvMode::Nxdn | DvMode::Dpmr => format!("RAN {cc}"),
+                        _ => format!("CC {cc}"),
+                    });
+                }
+                if let Some(parties) = f.parties() {
+                    parts.push(parties);
+                }
+                if let Some(via) = &f.via {
+                    parts.push(format!("via {via}"));
+                }
+                if let Some(opcode) = &f.opcode {
+                    parts.push(opcode.clone());
+                }
+                if f.encrypted == Some(true) {
+                    parts.push("encrypted".to_owned());
+                }
+                if let Some(text) = &f.text {
+                    parts.push(text.clone());
+                }
+                parts.join(" · ")
+            }
         }
     }
 
@@ -489,6 +661,12 @@ impl DecoderEvent {
                 .address
                 .map(|a| format!("{a:05X}"))
                 .or_else(|| (!f.data.is_empty()).then(|| f.data.clone())),
+            // Who keyed up, by whichever name the mode addresses them: a callsign where the
+            // mode has one, the radio ID where it does not.
+            Self::Dv(f) => f
+                .source_call
+                .clone()
+                .or_else(|| f.source.map(|s| s.to_string())),
             Self::Rtty(_) | Self::Morse(_) => None,
         }
     }

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -21,13 +21,15 @@ pub mod ws;
 
 pub use channel::{
     AcarsParams, AdsbParams, AisChannel, AisParams, AmParams, AprsMode, AprsParams,
-    ChannelDescriptor, ChannelInfo, ChannelParams, ChannelSettings, MorseParams, NavtexParams,
-    NfmParams, PocsagBaud, PocsagParams, RttyParams, RttyStopBits, Sideband, SsbParams,
-    SubghzModulation, SubghzParams, WfmParams,
+    ChannelDescriptor, ChannelInfo, ChannelParams, ChannelSettings, DmrParams, DmrSlots,
+    DpmrParams, DstarParams, M17Params, MorseParams, NavtexParams, NfmParams, NxdnBandwidth,
+    NxdnParams, P25Params, PocsagBaud, PocsagParams, RttyParams, RttyStopBits, Sideband, SsbParams,
+    SubghzModulation, SubghzParams, WfmParams, YsfParams,
 };
 pub use decode::{
-    AcarsMessage, AdsbMessage, AisMessage, AprsPacket, DecodedRecord, DecoderEvent, MorseText,
-    NavtexMessage, PocsagMessage, PocsagPayload, RdsUpdate, RttyText, SubghzEncoding, SubghzFrame,
+    AcarsMessage, AdsbMessage, AisMessage, AprsPacket, DecodedRecord, DecoderEvent, DvFrame,
+    DvFrameKind, DvMode, MorseText, NavtexMessage, PocsagMessage, PocsagPayload, RdsUpdate,
+    RttyText, SubghzEncoding, SubghzFrame,
 };
 pub use device::{
     Capabilities, DeviceInfo, DeviceSettings, Direction, Duplex, ExtraSetting, ExtraValue,

--- a/openapi.json
+++ b/openapi.json
@@ -2565,6 +2565,132 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/DmrParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dmr"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/DstarParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dstar"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/YsfParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ysf"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/NxdnParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nxdn"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/P25Params"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "p25"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/DpmrParams"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dpmr"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "settings",
+              "type"
+            ],
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/M17Params"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "m17"
+                ]
+              }
+            }
           }
         ],
         "description": "Type-discriminated demod parameters. Adjacently tagged so the generated TS is a\ndiscriminated union on `type`, and `{\"type\":\"nfm\",\"settings\":{}}` deserializes with\nevery field at its default."
@@ -3138,6 +3264,24 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "data",
+              "kind"
+            ],
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/DvFrame"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "dv"
+                ]
+              }
+            }
           }
         ],
         "description": "Typed decoder output (PLAN §5). Adjacently tagged so the generated TypeScript is a\ndiscriminated union on `kind` that panels can exhaustively `switch` on, and so the log\ndatabase can index on `kind` without parsing the blob."
@@ -3541,6 +3685,23 @@
           "tx"
         ]
       },
+      "DmrParams": {
+        "type": "object",
+        "properties": {
+          "slots": {
+            "$ref": "#/components/schemas/DmrSlots"
+          }
+        }
+      },
+      "DmrSlots": {
+        "type": "string",
+        "description": "Which DMR timeslot a channel reports. Both slots share one 12.5 kHz carrier in 30 ms\nalternation, so the receiver always hears both; this only decides what reaches the log.",
+        "enum": [
+          "both",
+          "one",
+          "two"
+        ]
+      },
       "DoctorCheck": {
         "type": "object",
         "description": "One diagnostic line.",
@@ -3600,6 +3761,14 @@
           }
         }
       },
+      "DpmrParams": {
+        "type": "object",
+        "description": "dPMR (C4FM, 2400 symbols/s, 6.25 kHz)."
+      },
+      "DstarParams": {
+        "type": "object",
+        "description": "D-Star (GMSK, 4800 bit/s)."
+      },
       "Duplex": {
         "type": "string",
         "description": "What a radio's hardware can do, and whether it can do it at once.\n\nIt lives here rather than in the device crate because it is the answer to \"what *kind* of\nradio is this\" that a workspace template filters on and the canvas draws ports from — the\narbitration that uses it ([`sdrmm-device`'s `DuplexState`]) is a separate thing, and stays\nwith the backends.",
@@ -3608,6 +3777,137 @@
           "tx_only",
           "half",
           "full"
+        ]
+      },
+      "DvFrame": {
+        "type": "object",
+        "description": "One decoded digital-voice frame — the *metadata* of a call, not its audio.\n\nNo mode here produces sound: DMR, D-Star, YSF, NXDN, P25 and dPMR all carry AMBE-family\nvocoder frames and this build ships no vocoder, and M17's Codec2 payload is not decoded\neither (see FEATURES §9). What a decoder does recover is everything *around* the voice —\nwho keyed up, on which talkgroup, over which repeater, with what encryption — which is what\na scanner log is actually made of. Fields are `Option` because which of them exist is a\nproperty of the mode and the frame: a D-Star header has callsigns and no talkgroup, a DMR\nvoice header the reverse.",
+        "required": [
+          "mode",
+          "kind",
+          "errors_corrected"
+        ],
+        "properties": {
+          "color_code": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The mode's network discriminator, under whichever name it publishes: DMR colour code,\nNXDN/dPMR RAN or colour code, P25 NAC, YSF has none.",
+            "minimum": 0
+          },
+          "destination": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Numeric destination: talkgroup for a group call, radio ID for a private one.",
+            "minimum": 0
+          },
+          "destination_call": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "encrypted": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Set when the frame says its payload is encrypted. `Some(false)` is a positive statement\nthat it is in the clear; `None` means the frame did not say."
+          },
+          "errors_corrected": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Bit errors the frame's error-correcting codes repaired — the honest signal-quality\nreadout, since a mode with no audio has no other.",
+            "minimum": 0
+          },
+          "group_call": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "True for a talkgroup call, false for a call addressed to one radio."
+          },
+          "kind": {
+            "$ref": "#/components/schemas/DvFrameKind"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/DvMode"
+          },
+          "opcode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Name of the signalling opcode for a control frame — \"group voice channel grant\",\n\"preamble\", … — as its specification names it."
+          },
+          "slot": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "TDMA timeslot, 1 or 2 — DMR only; every other mode here is single-slot.",
+            "minimum": 0
+          },
+          "source": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Numeric source address — DMR/NXDN/dPMR radio ID, P25 source unit.",
+            "minimum": 0
+          },
+          "source_call": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Source callsign — the modes that address by callsign rather than by number."
+          },
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Free text the frame carried: a D-Star slow-data message, a YSF radio ID, an M17 meta\nfield."
+          },
+          "via": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The repeater or reflector the call is routed through: D-Star RPT1/RPT2."
+          }
+        }
+      },
+      "DvFrameKind": {
+        "type": "string",
+        "description": "What the burst was carrying. Every mode distinguishes these four, whatever it calls them:\nthe frame that opens a transmission and names the parties, the voice frames that follow,\nthe one that closes it, and the signalling that travels outside a call.",
+        "enum": [
+          "header",
+          "voice",
+          "terminator",
+          "control",
+          "data"
+        ]
+      },
+      "DvMode": {
+        "type": "string",
+        "description": "Which digital-voice mode a [`DvFrame`] was heard on (PLAN §13 wave 3). One event type\nserves all of them because the *question* is the same in every mode — who is talking, to\nwhom, on which network — and only the names for it differ.",
+        "enum": [
+          "dmr",
+          "dstar",
+          "ysf",
+          "nxdn",
+          "p25",
+          "dpmr",
+          "m17"
         ]
       },
       "ExportFormat": {
@@ -3746,6 +4046,10 @@
             "format": "double"
           }
         }
+      },
+      "M17Params": {
+        "type": "object",
+        "description": "M17 (C4FM, 4800 symbols/s, RRC 0.5)."
       },
       "MorseParams": {
         "type": "object",
@@ -4044,6 +4348,26 @@
             }
           }
         }
+      },
+      "NxdnBandwidth": {
+        "type": "string",
+        "description": "The two NXDN channel widths. They are different radios as far as the receiver is\nconcerned: 6.25 kHz halves both the symbol rate and the deviation of the 12.5 kHz one.",
+        "enum": [
+          "narrow",
+          "wide"
+        ]
+      },
+      "NxdnParams": {
+        "type": "object",
+        "properties": {
+          "bandwidth": {
+            "$ref": "#/components/schemas/NxdnBandwidth"
+          }
+        }
+      },
+      "P25Params": {
+        "type": "object",
+        "description": "P25 Phase 1 (C4FM, 4800 symbols/s)."
       },
       "PatchApplyReport": {
         "type": "object",
@@ -5968,6 +6292,10 @@
             }
           }
         }
+      },
+      "YsfParams": {
+        "type": "object",
+        "description": "System Fusion (C4FM, 4800 symbols/s)."
       }
     }
   }

--- a/web/src/components/ChannelControls.tsx
+++ b/web/src/components/ChannelControls.tsx
@@ -23,6 +23,17 @@ const DEFAULT_SQUELCH_DB = -60;
 
 // Choice lists for the wire enums, typed off the generated union so a renamed or added variant
 // breaks here instead of shipping an option the server rejects.
+/** Which DMR timeslot reaches the log; the receiver always hears both. */
+const DMR_SLOTS: Options<NonNullable<ChannelParamsOf<"dmr">["slots"]>> = [
+  { value: "both", label: "Both" },
+  { value: "one", label: "TS1" },
+  { value: "two", label: "TS2" },
+];
+/** NXDN's two channel widths, which are two different symbol rates to the demodulator. */
+const NXDN_WIDTHS: Options<NonNullable<ChannelParamsOf<"nxdn">["bandwidth"]>> = [
+  { value: "narrow", label: "6.25" },
+  { value: "wide", label: "12.5" },
+];
 const SIDEBANDS: Options<NonNullable<ChannelParamsOf<"ssb">["sideband"]>> = [
   { value: "usb", label: "USB" },
   { value: "lsb", label: "LSB" },
@@ -519,6 +530,34 @@ function ModeControls({
           </label>
         </>
       );
+    case "dmr":
+      return (
+        <Segmented
+          label="Slot"
+          value={params.settings.slots ?? "both"}
+          options={DMR_SLOTS}
+          onChange={(slots) => onParams({ type: "dmr", settings: { ...params.settings, slots } })}
+        />
+      );
+    case "nxdn":
+      return (
+        <Segmented
+          label="Width"
+          value={params.settings.bandwidth ?? "narrow"}
+          options={NXDN_WIDTHS}
+          onChange={(bandwidth) =>
+            onParams({ type: "nxdn", settings: { ...params.settings, bandwidth } })
+          }
+        />
+      );
+    // Everything about these four — symbol rate, deviation, channel width, sync patterns — is
+    // fixed by the mode, so there is nothing to offer beyond the frequency the operator tuned.
+    case "dstar":
+    case "ysf":
+    case "p25":
+    case "dpmr":
+    case "m17":
+      return null;
     default:
       return unhandledMode(params);
   }

--- a/web/src/components/DecoderPanels.tsx
+++ b/web/src/components/DecoderPanels.tsx
@@ -16,6 +16,10 @@ import {
   aprsMotion,
   buildTranscript,
   type DecoderScope,
+  dvKind,
+  dvMode,
+  dvNetwork,
+  dvParties,
   formatAge,
   formatAltFreqs,
   formatClock,
@@ -583,6 +587,59 @@ export function SubghzView({ scope = {} }: { scope?: DecoderScope }) {
   );
 }
 
+/** Digital voice: one call per row, from whichever of the seven modes produced it. There is no
+ * audio to offer — none of these modes ships a vocoder here — so the row *is* the decode: who
+ * called whom, on which network, and what happened to the transmission. */
+export function DvView({ scope = {} }: { scope?: DecoderScope }) {
+  const records = recordsInScope(useDecodedKind("dv"), scope);
+
+  if (records.length === 0) {
+    return (
+      <div className={PANE}>
+        <span className={EMPTY}>No digital voice traffic.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={PANE}>
+      <div className="flex flex-col divide-y divide-line">
+        {records.map((r, i) => {
+          const f = r.event.data;
+          const network = dvNetwork(f);
+          const parties = dvParties(f);
+          const detail = [f.via == null ? null : `via ${f.via}`, f.opcode ?? null, f.text ?? null]
+            .filter((part) => part != null)
+            .join(" · ");
+          return (
+            <div key={`${r.at}-${i}`} className="flex flex-col gap-0.5 py-1">
+              <div className="flex flex-wrap items-baseline gap-2">
+                <span className="font-mono text-xs tabular-nums text-ink-dim">
+                  {formatClock(r.at)}
+                </span>
+                <span className="font-mono text-xs text-accent">{dvMode(f)}</span>
+                <span className="font-mono text-xs text-ink">{parties || dvKind(f)}</span>
+                {parties !== "" && (
+                  <span className="font-mono text-[10px] text-ink-dim">{dvKind(f)}</span>
+                )}
+                {network !== "" && (
+                  <span className="font-mono text-[10px] tabular-nums text-ink-dim">{network}</span>
+                )}
+                {f.encrypted === true && (
+                  <span className="font-mono text-[10px] text-warn">encrypted</span>
+                )}
+              </div>
+              {detail !== "" && (
+                <span className="pl-14 font-mono text-[10px] text-ink-dim">{detail}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 /** The view each decoder kind is read in. Keyed on the generated `DecoderKind`, so a decoder
  * added to `wire` fails to compile here until it has somewhere to be read. */
 const VIEWS: Record<DecoderKind, (scope: DecoderScope) => ReactNode> = {
@@ -596,6 +653,7 @@ const VIEWS: Record<DecoderKind, (scope: DecoderScope) => ReactNode> = {
   navtex: (scope) => <NavtexView scope={scope} />,
   acars: (scope) => <AcarsView scope={scope} />,
   subghz: (scope) => <SubghzView scope={scope} />,
+  dv: (scope) => <DvView scope={scope} />,
 };
 
 // `ChannelDescriptor.decoder_kind` is a bare string on the wire, so a server newer than this

--- a/web/src/components/decoderLog.ts
+++ b/web/src/components/decoderLog.ts
@@ -2,6 +2,7 @@
 // exportable, not scroll-back-only). The panel renders two sources through one row shape: the
 // stored page from `GET /api/decoderlog`, and the live tail from the WS store. Everything here
 // is pure so the panel stays a rendering shell.
+
 import type { DecodedState } from "../lib/decoded";
 import type {
   DecodedRecord,
@@ -11,6 +12,7 @@ import type {
   DecoderLogFilter,
   DeviceSet,
 } from "../lib/types";
+import { dvMode, dvNetwork, dvParties } from "./decoderViews";
 
 /** Exhaustive over `DecoderKind`: adding a decoder to `wire` fails the typecheck here until it
  * gets a label, and `DECODER_KINDS` follows for free. */
@@ -25,6 +27,7 @@ export const KIND_LABELS: Record<DecoderKind, string> = {
   navtex: "NAVTEX",
   acars: "ACARS",
   subghz: "Sub-GHz",
+  dv: "Digital voice",
 };
 
 export const DECODER_KINDS = Object.keys(KIND_LABELS) as DecoderKind[];
@@ -246,6 +249,18 @@ export function eventSummary(event: DecoderEvent): string {
         f.repeats > 1 ? `\u00d7${f.repeats}` : null,
       ]);
     }
+    case "dv": {
+      const f = event.data;
+      return join([
+        dvMode(f),
+        dvNetwork(f) || null,
+        dvParties(f) || null,
+        f.via == null ? null : `via ${f.via}`,
+        f.opcode ?? null,
+        f.encrypted === true ? "encrypted" : null,
+        f.text ?? null,
+      ]);
+    }
   }
 }
 
@@ -273,6 +288,11 @@ export function eventStation(event: DecoderEvent): string | null {
       }
       return f.data === "" ? null : f.data;
     }
+    // Who keyed up, by whichever name the mode addresses them.
+    case "dv":
+      return (
+        event.data.source_call ?? (event.data.source == null ? null : String(event.data.source))
+      );
     case "rtty":
     case "morse":
       return null;

--- a/web/src/components/decoderViews.test.ts
+++ b/web/src/components/decoderViews.test.ts
@@ -9,6 +9,10 @@ import {
   appendTranscript,
   aprsMotion,
   buildTranscript,
+  dvKind,
+  dvMode,
+  dvNetwork,
+  dvParties,
   formatAge,
   formatAltFreqs,
   formatAltitudeFt,
@@ -388,5 +392,76 @@ describe("sub-GHz", () => {
     expect(subghzTiming({ short_us: 320, repeats: 1 })).toBe("320 µs");
     expect(subghzTiming({ short_us: 320, repeats: 6 })).toBe("320 µs · ×6");
     expect(subghzTiming({ short_us: 0, repeats: 1 })).toBe("");
+  });
+});
+
+describe("digital voice", () => {
+  it("names the network the way each mode publishes it", () => {
+    expect(dvNetwork({ mode: "dmr", color_code: 1, slot: 2 })).toBe("TS2 CC 1");
+    expect(dvNetwork({ mode: "p25", color_code: 0x293, slot: null })).toBe("NAC 293");
+    expect(dvNetwork({ mode: "nxdn", color_code: 5, slot: null })).toBe("RAN 5");
+    expect(dvNetwork({ mode: "m17", color_code: null, slot: null })).toBe("");
+  });
+
+  it("marks a talkgroup so a number is not read as a radio", () => {
+    expect(
+      dvParties({
+        source: 2621001,
+        destination: 505,
+        group_call: true,
+        source_call: null,
+        destination_call: null,
+      }),
+    ).toBe("TG 505 ← 2621001");
+    expect(
+      dvParties({
+        source: 2621001,
+        destination: 2621002,
+        group_call: false,
+        source_call: null,
+        destination_call: null,
+      }),
+    ).toBe("2621002 ← 2621001");
+  });
+
+  it("prefers callsigns where the mode has them, and reports what it has", () => {
+    expect(
+      dvParties({
+        source: null,
+        destination: null,
+        group_call: true,
+        source_call: "DL1ABC",
+        destination_call: "ALL",
+      }),
+    ).toBe("ALL ← DL1ABC");
+    expect(
+      dvParties({
+        source: 42,
+        destination: null,
+        group_call: null,
+        source_call: null,
+        destination_call: null,
+      }),
+    ).toBe("42");
+    expect(
+      dvParties({
+        source: null,
+        destination: null,
+        group_call: null,
+        source_call: null,
+        destination_call: null,
+      }),
+    ).toBe("");
+  });
+
+  it("reads a frame kind as a scanner would say it", () => {
+    expect(dvKind({ kind: "header" })).toBe("call");
+    expect(dvKind({ kind: "terminator" })).toBe("end");
+    expect(dvKind({ kind: "control" })).toBe("signalling");
+  });
+
+  it("spells each mode as operators write it", () => {
+    expect(dvMode({ mode: "dstar" })).toBe("D-STAR");
+    expect(dvMode({ mode: "dpmr" })).toBe("dPMR");
   });
 });

--- a/web/src/components/decoderViews.ts
+++ b/web/src/components/decoderViews.ts
@@ -7,6 +7,7 @@ import type {
   AisMessage,
   DecodedRecord,
   DecodedRecordOf,
+  DvFrame,
   RdsUpdate,
 } from "../lib/types";
 import { formatHz } from "./format";
@@ -409,4 +410,78 @@ export function subghzTiming(frame: { short_us: number; repeats: number }): stri
     frame.short_us > 0 ? `${frame.short_us} µs` : "",
     frame.repeats > 1 ? `×${frame.repeats}` : "",
   );
+}
+
+// ── digital voice ─────────────────────────────────────────────────────────────────────────
+
+/** Mode names as operators write them, which is not how the wire spells them. */
+const DV_MODE_LABELS: Record<DvFrame["mode"], string> = {
+  dmr: "DMR",
+  dstar: "D-STAR",
+  ysf: "YSF",
+  nxdn: "NXDN",
+  p25: "P25",
+  dpmr: "dPMR",
+  m17: "M17",
+};
+
+export function dvMode(frame: Pick<DvFrame, "mode">): string {
+  return DV_MODE_LABELS[frame.mode];
+}
+
+/** The network the frame was heard on, under whichever name its mode publishes: a DMR colour
+ * code, an NXDN or dPMR RAN, a P25 network access code (which everyone quotes in hex). */
+export function dvNetwork(frame: Pick<DvFrame, "mode" | "color_code" | "slot">): string {
+  const parts: string[] = [];
+  if (frame.slot != null) {
+    parts.push(`TS${frame.slot}`);
+  }
+  if (frame.color_code != null) {
+    if (frame.mode === "p25") {
+      parts.push(`NAC ${frame.color_code.toString(16).toUpperCase().padStart(3, "0")}`);
+    } else if (frame.mode === "nxdn" || frame.mode === "dpmr") {
+      parts.push(`RAN ${frame.color_code}`);
+    } else {
+      parts.push(`CC ${frame.color_code}`);
+    }
+  }
+  return parts.join(" ");
+}
+
+/** Who is talking to whom, by whichever name the mode addresses them. `TG` marks a talkgroup,
+ * because a bare number next to a radio ID would read as another radio. */
+export function dvParties(
+  frame: Pick<
+    DvFrame,
+    "source" | "destination" | "source_call" | "destination_call" | "group_call"
+  >,
+): string {
+  const to =
+    frame.destination_call ??
+    (frame.destination == null
+      ? null
+      : frame.group_call === false
+        ? String(frame.destination)
+        : `TG ${frame.destination}`);
+  const from = frame.source_call ?? (frame.source == null ? null : String(frame.source));
+  if (to != null && from != null) {
+    return `${to} ← ${from}`;
+  }
+  return to ?? from ?? "";
+}
+
+/** What the frame was: the words a scanner shows rather than the specification's field names. */
+export function dvKind(frame: Pick<DvFrame, "kind">): string {
+  switch (frame.kind) {
+    case "header":
+      return "call";
+    case "voice":
+      return "in progress";
+    case "terminator":
+      return "end";
+    case "control":
+      return "signalling";
+    case "data":
+      return "data";
+  }
 }

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -852,6 +852,34 @@ export interface components {
             settings: components["schemas"]["SubghzParams"];
             /** @enum {string} */
             type: "subghz";
+        } | {
+            settings: components["schemas"]["DmrParams"];
+            /** @enum {string} */
+            type: "dmr";
+        } | {
+            settings: components["schemas"]["DstarParams"];
+            /** @enum {string} */
+            type: "dstar";
+        } | {
+            settings: components["schemas"]["YsfParams"];
+            /** @enum {string} */
+            type: "ysf";
+        } | {
+            settings: components["schemas"]["NxdnParams"];
+            /** @enum {string} */
+            type: "nxdn";
+        } | {
+            settings: components["schemas"]["P25Params"];
+            /** @enum {string} */
+            type: "p25";
+        } | {
+            settings: components["schemas"]["DpmrParams"];
+            /** @enum {string} */
+            type: "dpmr";
+        } | {
+            settings: components["schemas"]["M17Params"];
+            /** @enum {string} */
+            type: "m17";
         };
         /** @description Per-channel settings: where the channel sits and how it demodulates. */
         ChannelSettings: {
@@ -1059,6 +1087,10 @@ export interface components {
             data: components["schemas"]["SubghzFrame"];
             /** @enum {string} */
             kind: "subghz";
+        } | {
+            data: components["schemas"]["DvFrame"];
+            /** @enum {string} */
+            kind: "dv";
         };
         /**
          * @description One stored decoder frame (PLAN §11: decoder logs are queryable and exportable, not
@@ -1224,6 +1256,15 @@ export interface components {
          * @enum {string}
          */
         Direction: "rx" | "tx";
+        DmrParams: {
+            slots?: components["schemas"]["DmrSlots"];
+        };
+        /**
+         * @description Which DMR timeslot a channel reports. Both slots share one 12.5 kHz carrier in 30 ms
+         *     alternation, so the receiver always hears both; this only decides what reaches the log.
+         * @enum {string}
+         */
+        DmrSlots: "both" | "one" | "two";
         /** @description One diagnostic line. */
         DoctorCheck: {
             /** @description What was actually found. */
@@ -1244,6 +1285,10 @@ export interface components {
             /** @description Server version (`CARGO_PKG_VERSION`). */
             version: string;
         };
+        /** @description dPMR (C4FM, 2400 symbols/s, 6.25 kHz). */
+        DpmrParams: Record<string, never>;
+        /** @description D-Star (GMSK, 4800 bit/s). */
+        DstarParams: Record<string, never>;
         /**
          * @description What a radio's hardware can do, and whether it can do it at once.
          *
@@ -1254,6 +1299,84 @@ export interface components {
          * @enum {string}
          */
         Duplex: "rx_only" | "tx_only" | "half" | "full";
+        /**
+         * @description One decoded digital-voice frame — the *metadata* of a call, not its audio.
+         *
+         *     No mode here produces sound: DMR, D-Star, YSF, NXDN, P25 and dPMR all carry AMBE-family
+         *     vocoder frames and this build ships no vocoder, and M17's Codec2 payload is not decoded
+         *     either (see FEATURES §9). What a decoder does recover is everything *around* the voice —
+         *     who keyed up, on which talkgroup, over which repeater, with what encryption — which is what
+         *     a scanner log is actually made of. Fields are `Option` because which of them exist is a
+         *     property of the mode and the frame: a D-Star header has callsigns and no talkgroup, a DMR
+         *     voice header the reverse.
+         */
+        DvFrame: {
+            /**
+             * Format: int32
+             * @description The mode's network discriminator, under whichever name it publishes: DMR colour code,
+             *     NXDN/dPMR RAN or colour code, P25 NAC, YSF has none.
+             */
+            color_code?: number | null;
+            /**
+             * Format: int32
+             * @description Numeric destination: talkgroup for a group call, radio ID for a private one.
+             */
+            destination?: number | null;
+            destination_call?: string | null;
+            /**
+             * @description Set when the frame says its payload is encrypted. `Some(false)` is a positive statement
+             *     that it is in the clear; `None` means the frame did not say.
+             */
+            encrypted?: boolean | null;
+            /**
+             * Format: int32
+             * @description Bit errors the frame's error-correcting codes repaired — the honest signal-quality
+             *     readout, since a mode with no audio has no other.
+             */
+            errors_corrected: number;
+            /** @description True for a talkgroup call, false for a call addressed to one radio. */
+            group_call?: boolean | null;
+            kind: components["schemas"]["DvFrameKind"];
+            mode: components["schemas"]["DvMode"];
+            /**
+             * @description Name of the signalling opcode for a control frame — "group voice channel grant",
+             *     "preamble", … — as its specification names it.
+             */
+            opcode?: string | null;
+            /**
+             * Format: int32
+             * @description TDMA timeslot, 1 or 2 — DMR only; every other mode here is single-slot.
+             */
+            slot?: number | null;
+            /**
+             * Format: int32
+             * @description Numeric source address — DMR/NXDN/dPMR radio ID, P25 source unit.
+             */
+            source?: number | null;
+            /** @description Source callsign — the modes that address by callsign rather than by number. */
+            source_call?: string | null;
+            /**
+             * @description Free text the frame carried: a D-Star slow-data message, a YSF radio ID, an M17 meta
+             *     field.
+             */
+            text?: string | null;
+            /** @description The repeater or reflector the call is routed through: D-Star RPT1/RPT2. */
+            via?: string | null;
+        };
+        /**
+         * @description What the burst was carrying. Every mode distinguishes these four, whatever it calls them:
+         *     the frame that opens a transmission and names the parties, the voice frames that follow,
+         *     the one that closes it, and the signalling that travels outside a call.
+         * @enum {string}
+         */
+        DvFrameKind: "header" | "voice" | "terminator" | "control" | "data";
+        /**
+         * @description Which digital-voice mode a [`DvFrame`] was heard on (PLAN §13 wave 3). One event type
+         *     serves all of them because the *question* is the same in every mode — who is talking, to
+         *     whom, on which network — and only the names for it differ.
+         * @enum {string}
+         */
+        DvMode: "dmr" | "dstar" | "ysf" | "nxdn" | "p25" | "dpmr" | "m17";
         /**
          * @description Export format for `GET /api/decoderlog/export/{format}` (PLAN §11: CSV/JSON). It is a
          *     path segment, not a query field: `serde_urlencoded` cannot flatten a struct, so sharing
@@ -1299,6 +1422,8 @@ export interface components {
             /** Format: double */
             value_db: number;
         };
+        /** @description M17 (C4FM, 4800 symbols/s, RRC 0.5). */
+        M17Params: Record<string, never>;
         MorseParams: {
             /**
              * Format: double
@@ -1421,6 +1546,17 @@ export interface components {
             needs_channel_type?: boolean;
             ports: components["schemas"]["PortSpec"][];
         };
+        /**
+         * @description The two NXDN channel widths. They are different radios as far as the receiver is
+         *     concerned: 6.25 kHz halves both the symbol rate and the deviation of the 12.5 kHz one.
+         * @enum {string}
+         */
+        NxdnBandwidth: "narrow" | "wide";
+        NxdnParams: {
+            bandwidth?: components["schemas"]["NxdnBandwidth"];
+        };
+        /** @description P25 Phase 1 (C4FM, 4800 symbols/s). */
+        P25Params: Record<string, never>;
         /**
          * @description `POST /api/workspaces/{id}/apply` — what applying the workspace did.
          *
@@ -2350,6 +2486,8 @@ export interface components {
             active?: number | null;
             workspaces: components["schemas"]["WorkspaceInfo"][];
         };
+        /** @description System Fusion (C4FM, 4800 symbols/s). */
+        YsfParams: Record<string, never>;
     };
     responses: never;
     parameters: never;

--- a/web/src/lib/decoded.ts
+++ b/web/src/lib/decoded.ts
@@ -298,6 +298,9 @@ function stationId(event: DecoderEvent): string | null {
     case "subghz":
     case "rtty":
     case "morse":
+    // A digital-voice frame is an event in a call — a start, an end, a signalling block — and
+    // merging them forward would blur two calls from the same radio into one row.
+    case "dv":
       return null;
   }
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -40,6 +40,7 @@ export type PocsagMessage = components["schemas"]["PocsagMessage"];
 export type RdsUpdate = components["schemas"]["RdsUpdate"];
 export type RttyText = components["schemas"]["RttyText"];
 export type MorseText = components["schemas"]["MorseText"];
+export type DvFrame = components["schemas"]["DvFrame"];
 export type ServerEvent = components["schemas"]["ServerEvent"];
 export type StreamKind = components["schemas"]["StreamKind"];
 export type ClientCommand = components["schemas"]["ClientCommand"];


### PR DESCRIPTION
Implements FEATURES §9. **These decode the call, not the voice.**

Every mode here but M17 carries an AMBE-family vocoder and this build ships none, so no
digital-voice channel produces audio (`has_audio: false` for all seven). What they do recover is
the signalling around the payload — who transmitted, to which talkgroup or callsign, on which
colour code or network, encrypted or not — which is what a scanner log is actually made of, and
which is decodable without a vocoder.

## What ships

| Mode | Depth |
|---|---|
| **DMR** | all eight sync patterns, Golay(20,8) slot type, BPTC(196,96) → voice LC header, terminator, CSBK, data header, each confirmed by the RS(12,9) or CRC mask that names its own frame type. Talkgroup, radio ID, colour code, group/private, encryption. **Late entry** via the BPTC(128,77) embedded LC reassembled from bursts B–E |
| **M17** | full link setup: derandomiser → quadratic interleaver → P1 depuncture → Viterbi → CRC-16, giving both base-40 callsigns, encryption flag, EOT |
| **YSF** | FICH through interleaver, Viterbi, 4× Golay(24,12,8), CRC-16: frame type, data mode, DG-ID |
| **P25 Phase 1** | frame sync, status-symbol stripping, BCH(63,16,23) NID → NAC + DUID (header / call / terminator / trunking block) |
| **dPMR** | FS1/FS3/FS4 framing plus the full header information field (descramble, de-interleave, CRC-8): called and calling IDs, colour code, call type |
| **NXDN** | frame sync word and LICH at both widths (6.25 kHz @ 2400 sym/s, 12.5 kHz @ 4800) |
| **D-Star** | GMSK receiver plus the slow-data channel — the path by which a receiver joining a call in progress gets URCALL, MYCALL, repeater and the text message, behind the header's own CRC |

New in `dsp`: a shared four-level FSK front end (RRC matched filter, Gardner symbol clock,
*measured* decision levels so an under-deviated transmitter still decodes), the Hamming / Golay /
QR / BCH block codes these modes are built from, DMR's two BPTC product codes, a soft-decision
K=5 Viterbi with erasure-based puncturing, and DMR's RS(12,9) parity.

New in `wire`: one `DvFrame` event for all seven modes and one params struct each; the client
gets one panel, one log filter and (later) one trunking follower for the lot.

## Tests

Every mode has a reference modulator in `testgen` that encodes the real framing in reverse — the
same BPTC, Golay, convolutional and CRC layers — fed back through the decoder in ragged block
splits, plus a noise-decodes-to-nothing test per mode. The DSP primitives carry
minimum-distance and error-repair tests; the Golay(20,8) test pins the published DMR slot-type
words. `cargo xtask check` and `cargo xtask test` are green.

**None has yet decoded a real signal** — the same caveat the ADS-B / AIS / ACARS / NAVTEX
decoders carry. Constants came from the specifications where they are public (dPMR: ETSI TS 102
490; M17: the M17 spec and libm17; P25 sync/NID; DMR sync patterns and code parameters), and each
module names in its header comment what it could not verify.

## Deliberately not in this PR

- **Vocoder audio** (AMBE+2/IMBE, and Codec2 for M17). Each is a project in its own right; the
  framing here is what one would plug into.
- **Trunking following.** It needs the control-channel *payloads* — P25 TSBKs, DMR Tier III CSBK
  routing — which need P25's trellis code and interleaver tables first. This PR lands the frame
  that carries them and reports when one arrives.
- **Hardware AMBE dongle/server support.** A serial protocol to a device that is not here cannot
  meet the test rule (CLAUDE.md #2), and CI has no hardware.
- **FreeDV.** An OFDM modem plus Codec2 — a separate PR of comparable size.
- **DMR repeater slot numbering.** The CACH that names the timeslot is not decoded, so a slot is
  reported only where the sync pattern names it (direct mode).
- **The layer below each mode's framing** where it is not shipped above: P25 LDU link control and
  TSBKs, NXDN SACCH/FACCH addressing, YSF callsigns, M17 stream LICH late entry.

Each of these is listed as `[planned]` in FEATURES §9 with the reason.
