### PR TITLE
Expand DMR and P25 metadata decoding

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -196,10 +196,16 @@ talkgroup or callsign, on which colour code or network, encrypted or not.
   every burst — and coasts dead time at a long average of its tracked rate, because a TDMA gap
   multiplies whatever rate it coasts at by the gap's length
 - **[shipped]** DMR — all eight sync patterns, Golay(20,8) slot type, BPTC(196,96) signalling:
-  voice LC header, terminator, CSBK and data header, each confirmed by the Reed-Solomon or CRC
-  mask that names its own frame type. Talkgroup, radio ID, colour code, group/private,
-  encryption flag. **Late entry**: the BPTC(128,77) embedded link control is reassembled from
-  bursts B–E of a voice superframe, so a call joined in progress names itself within 240 ms.
+  voice LC header, terminator, CSBK, PI and data headers, rate-½/rate-¾/rate-1 data visibility,
+  each confirmed by the Reed-Solomon or CRC mask that names its own frame type. Talkgroup,
+  radio ID, colour code, group/private, emergency and encryption ALG/KID/MI. FID+opcode/FLCO
+  dispatch prevents vendor opcode collisions from being interpreted as ETSI addresses; known
+  Motorola, Hytera, Tait, JVCKENWOOD, EMC, Radio Activity, Flyde Micro and PROD-EL
+  feature IDs are named while unknown proprietary payloads remain explicitly unparsed.
+  Standard GPS Info feeds the shared map coordinates, and talker-alias header plus three blocks
+  reassemble 7-bit, ISO-8, UTF-8 and UTF-16BE names. **Late entry**: the BPTC(128,77) embedded
+  link control is reassembled from bursts B–E of a voice superframe, so a call joined in
+  progress names itself within 240 ms.
   Verified end to end against the generated keyed waveform — header, late-entry superframe and
   terminator — and against a recorded off-air call (`fixtures/dmr_call_48k`): repeated headers
   and three superframes' late entry, all naming the same radio
@@ -209,6 +215,12 @@ talkgroup or callsign, on which colour code or network, encrypted or not.
   identified from the full LC service options and muted rather than decoded as noise. A
   generated 440 Hz AMBE transmission proves all 18 frames of a superframe end to end, and the
   committed off-air call now proves that its real payload produces bounded PCM
+- **[shipped]** DMR repeater slots and Short LC — Hamming(7,4) TACT is deinterleaved from CACH,
+  activating the slot filter for base-station signals. Two independent call, alias, privacy,
+  embedded-LC and vocoder states follow simultaneous slots without cross-latching. Four CACH
+  payloads rebuild the Hamming(17,12) product code and CRC-8 Short LC: activity/hash updates and
+  Tier III control/payload site parameters. Tier III CSBK ALOHA/AHOY and logical channel grants
+  expose their channel, slot, emergency, system and address parameters
 - **[shipped]** M17 — the one mode that names both parties in the clear: link setup frame through
   derandomiser, quadratic interleaver, P1 depuncturing, Viterbi and CRC-16, with base-40
   callsigns, encryption flag and end-of-transmission. Stream frames undo P2 puncturing and
@@ -220,10 +232,14 @@ talkgroup or callsign, on which colour code or network, encrypted or not.
   second. All three speech layouts produce audio: carrier-interleaved AMBE+2 in V/D1,
   repetition-protected natural 49-bit AMBE+2 in V/D2, and full-rate IMBE with its Voice-FR
   interleaver and scrambler
-- **[shipped]** P25 Phase 1 — frame sync, status-symbol stripping and the BCH(63,16,23) network
-  identifier: NAC and data unit id, so headers, calls, terminators and trunking blocks are
-  distinguished and a system is identified by its NAC. LDU1 and LDU2 are collected at their
-  exact 1728-bit wire length, status dibits removed, and all nine Annex-H IMBE frames decoded
+- **[shipped]** P25 Phase 1 — frame sync, status-symbol stripping and BCH(63,16,23) NID plus the
+  protected metadata behind it. HDU Golay(18,6)+RS(36,20,17) yields talkgroup and encryption
+  ALG/KID/MI at call start; LDU1 Hamming(10,6)+RS(24,12,13) yields MFID-gated group/private link
+  control, source, talkgroup, emergency and privacy; LDU2 RS(24,16,9) refreshes encryption sync.
+  Encrypted voice is muted. All nine Annex-H IMBE frames per LDU decode. Rate-½ trellis,
+  deinterleave and CRC-16 validate TSBKs and expose standard channel grants plus network/RFSS/
+  adjacent-site status; Motorola 0x90, Harris 0xA4 and unknown MFIDs remain vendor-gated. PDU
+  payloads are retained as data metadata rather than silently dropped
 - **[shipped]** dPMR — FS1/FS3/FS4 framing and the full header information field (descrambled,
   de-interleaved, CRC-8 checked): called and calling IDs, colour code, individual versus group
   call. Once that checked header establishes a voice mode, FS2 opens the complete 756-symbol
@@ -256,14 +272,12 @@ talkgroup or callsign, on which colour code or network, encrypted or not.
   second after its last sync so the next transmitter meets clean estimates. Together with the
   transition-gated clock this closed the late-entry gap: the generated keyed waveform now
   decodes header, embedded link control and terminator alike
-- **[planned]** P25 link control and trunking blocks (LDU1 link control, TSBK), NXDN SACCH/FACCH
-  addressing and YSF callsigns — the signalling layers below each mode's voice framing
+- **[planned]** NXDN SACCH/FACCH addressing and YSF callsigns — the signalling layers below
+  each mode's voice framing
 - **[planned]** FreeDV
 - **[planned]** Trunking following — P25 / DMR Tier III control channel decode with auto-steered
   voice channels. Needs the control-channel payloads above first
 - **[planned]** Hardware AMBE dongle/server support
-- **[planned]** DMR repeater slot numbering — the CACH that names the timeslot is not decoded, so
-  a slot is reported only where the sync pattern itself names it (direct mode)
 
 ## 10. Aviation & marine
 

--- a/crates/channels/src/dv/dmr.rs
+++ b/crates/channels/src/dv/dmr.rs
@@ -18,9 +18,9 @@
 //! Only burst A of a voice superframe has a sync to find, so B to F are located by counting:
 //! the superframe is six bursts one 60 ms TDMA frame apart, in the slot the sync arrived on.
 //!
-//! **Repeater slot numbering is not decoded.** A repeater names the slot in the CACH that
-//! precedes each burst, which this does not read yet; direct-mode transmissions name their slot
-//! in the sync pattern itself and are reported with it.
+//! Repeater CACH supplies Hamming-protected slot numbering and four-fragment Short LC. Each slot
+//! owns independent call, embedded-LC, alias, privacy and vocoder state, so concurrent repeater
+//! calls never share codec history.
 
 use std::sync::LazyLock;
 
@@ -29,11 +29,11 @@ use blip25_vocoder::{
     vocoder::{FrameStatus, Rate, Vocoder},
 };
 use num_complex::Complex;
-use sdrmm_dsp::{Bptc128, Bptc196, CyclicCode, FracResampler, crc16_msb, rs129_parity};
+use sdrmm_dsp::{Bptc128, Bptc196, CyclicCode, FracResampler, ParityCode, crc16_msb, rs129_parity};
 use sdrmm_modem::cpm::CpmDemod;
 use sdrmm_wire::{
     ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DmrParams, DvFrame,
-    DvFrameKind, DvMode,
+    DvFrameKind, DvMode, DvSlotActivity, Vendor,
 };
 
 use super::{INPUT_RATE_HZ, SymbolWindow, bits_to_u32, c4fm_demod, c4fm_params, pack_bytes};
@@ -74,6 +74,10 @@ const DT_VOICE_LC_HEADER: u8 = 0x1;
 const DT_TERMINATOR_WITH_LC: u8 = 0x2;
 const DT_CSBK: u8 = 0x3;
 const DT_DATA_HEADER: u8 = 0x6;
+const DT_RATE_HALF_DATA: u8 = 0x7;
+const DT_RATE_THREE_QUARTER_DATA: u8 = 0x8;
+const DT_RATE_ONE_DATA: u8 = 0xA;
+const DT_UNIFIED_SINGLE_BLOCK_DATA: u8 = 0xB;
 
 /// CRC masks that make a frame type part of its own integrity check (§B.3.11).
 const VOICE_LC_HEADER_MASK: [u8; 3] = [0x96, 0x96, 0x96];
@@ -219,8 +223,6 @@ enum Pending {
     None,
     /// A burst whose sync has been seen, waiting for its trailing payload.
     Burst { voice: bool, slot: Option<u8> },
-    /// A voice burst located by counting from the superframe's burst A.
-    VoiceFollower { slot: Option<u8> },
 }
 
 struct Decoder {
@@ -229,34 +231,57 @@ struct Decoder {
     pending: Pending,
     /// Symbols still to arrive before the pending burst is complete.
     countdown: usize,
-    /// Voice bursts of the current superframe still expected (B to F).
-    followers: u8,
+    /// Independent B-to-F schedules for the two TDMA slots. A repeater can carry two calls and
+    /// the sync in one slot must not blind acquisition of the other.
+    followers: [u8; 2],
+    follower_countdown: [usize; 2],
     bits: Vec<bool>,
     bytes: Vec<u8>,
-    /// Embedded link control fragments collected across bursts B to E.
+    slots: [SlotState; 2],
+    short_lc: ShortLc,
+}
+
+struct SlotState {
     embedded: Vec<bool>,
-    /// Bit errors repaired in the frames that built the embedded link control.
     embedded_errors: u32,
-    /// Privacy comes from the LC service options or a standalone PI header, never from the
-    /// embedded field's PI bit (which §9.3.2 defines as pre-emption/reverse-channel routing).
     encrypted: Option<bool>,
+    talker_alias: TalkerAlias,
     voice: VoiceDecoder,
+}
+
+impl SlotState {
+    fn new() -> Self {
+        Self {
+            embedded: Vec::with_capacity(Bptc128::CODED_BITS),
+            embedded_errors: 0,
+            encrypted: None,
+            talker_alias: TalkerAlias::default(),
+            voice: VoiceDecoder::new(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.embedded.clear();
+        self.embedded_errors = 0;
+        self.encrypted = None;
+        self.talker_alias.reset();
+        self.voice.reset();
+    }
 }
 
 impl Decoder {
     fn new(params: DmrParams) -> Self {
         Self {
             params,
-            window: SymbolWindow::new(BURST_SYMBOLS),
+            window: SymbolWindow::new(SLOT_SYMBOLS),
             pending: Pending::None,
             countdown: 0,
-            followers: 0,
+            followers: [0; 2],
+            follower_countdown: [0; 2],
             bits: Vec::with_capacity(BURST_BITS),
             bytes: Vec::with_capacity(BURST_BITS / 8),
-            embedded: Vec::with_capacity(Bptc128::CODED_BITS),
-            embedded_errors: 0,
-            encrypted: None,
-            voice: VoiceDecoder::new(),
+            slots: std::array::from_fn(|_| SlotState::new()),
+            short_lc: ShortLc::default(),
         }
     }
 
@@ -264,15 +289,22 @@ impl Decoder {
         self.window.reset();
         self.pending = Pending::None;
         self.countdown = 0;
-        self.followers = 0;
-        self.embedded.clear();
-        self.embedded_errors = 0;
-        self.encrypted = None;
-        self.voice.reset();
+        self.followers = [0; 2];
+        self.follower_countdown = [0; 2];
+        self.slots.iter_mut().for_each(SlotState::reset);
+        self.short_lc.reset();
     }
 
     fn push(&mut self, symbol: f32, out: &mut ChannelOutputs) {
         self.window.push(symbol);
+        for index in 0..2 {
+            if self.follower_countdown[index] > 0 {
+                self.follower_countdown[index] -= 1;
+                if self.follower_countdown[index] == 0 {
+                    self.voice_burst(index as u8 + 1, out);
+                }
+            }
+        }
         if self.countdown > 0 {
             self.countdown -= 1;
             if self.countdown > 0 {
@@ -281,30 +313,56 @@ impl Decoder {
             match std::mem::replace(&mut self.pending, Pending::None) {
                 Pending::None => {}
                 Pending::Burst { voice, slot } => self.burst(voice, slot, out),
-                Pending::VoiceFollower { slot } => self.voice_burst(slot, out),
             }
             return;
         }
-        self.hunt();
+        self.hunt(out);
     }
 
     /// Look for a sync pattern ending at the symbol just pushed.
-    fn hunt(&mut self) {
+    fn hunt(&mut self, out: &mut ChannelOutputs) {
         for sync in &SYNCS {
             if self.window.sync_distance(sync.bits, SYNC_BITS) <= SYNC_TOLERANCE {
                 self.window.anchor(sync.bits, SYNC_BITS);
+                let slot = sync.slot.or_else(|| self.cach(out));
                 self.pending = Pending::Burst {
                     voice: sync.voice,
-                    slot: sync.slot,
+                    slot,
                 };
                 self.countdown = TRAILING_SYMBOLS;
-                // A sync means the superframe restarted; whatever fragments were being
-                // collected belong to a call that has ended.
-                self.embedded.clear();
-                self.embedded_errors = 0;
+                if let Some(index) = slot_index(slot) {
+                    self.slots[index].embedded.clear();
+                    self.slots[index].embedded_errors = 0;
+                    self.followers[index] = 0;
+                    self.follower_countdown[index] = 0;
+                }
                 return;
             }
         }
+    }
+
+    /// Decode the 24-bit CACH immediately preceding a repeater burst. At sync detection the
+    /// burst's first 54 payload symbols and 24 sync symbols are already in the window, placing
+    /// the twelve CACH symbols exactly 78 symbols back.
+    fn cach(&mut self, out: &mut ChannelOutputs) -> Option<u8> {
+        const CACH_BACK: usize = HALF_PAYLOAD_BITS / 2 + SYNC_BITS as usize / 2;
+        self.cach_at(CACH_BACK, out)
+    }
+
+    fn cach_at(&mut self, end_back: usize, out: &mut ChannelOutputs) -> Option<u8> {
+        const TACT: [usize; 7] = [0, 4, 8, 12, 14, 18, 22];
+        const PAYLOAD: [usize; 17] = [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 15, 16, 17, 19, 20, 21, 23];
+        self.window.bits(end_back, 12, &mut self.bits);
+        let mut tact = TACT.map(|position| self.bits[position]);
+        ParityCode::HAMMING_7_4.decode(&mut tact)?;
+        let slot = u8::from(tact[1]) + 1;
+        let lcss = u8::from(tact[2]) << 1 | u8::from(tact[3]);
+        let payload = PAYLOAD.map(|position| self.bits[position]);
+        if let Some(mut frame) = self.short_lc.push(lcss, payload) {
+            frame.errors_corrected = 0;
+            self.emit(frame, out);
+        }
+        Some(slot)
     }
 
     /// A burst whose last symbol has just arrived.
@@ -313,59 +371,65 @@ impl Decoder {
             // Burst A of a voice superframe: no signalling of its own, but it anchors the
             // five that follow, which carry the embedded link control.
             self.window.bits(0, BURST_SYMBOLS, &mut self.bits);
-            self.voice_payload(slot, out);
-            self.followers = 5;
-            self.schedule_follower(slot);
+            let index = slot_index(slot).unwrap_or(0);
+            self.voice_payload(index, slot, out);
+            self.followers[index] = 5;
+            self.schedule_follower(index);
             return;
         }
-        self.followers = 0;
+        if let Some(index) = slot_index(slot) {
+            self.followers[index] = 0;
+            self.follower_countdown[index] = 0;
+        }
         self.window.bits(0, BURST_SYMBOLS, &mut self.bits);
-        let Some(frame) = self.data_burst(slot) else {
+        let index = slot_index(slot).unwrap_or(0);
+        let Some(frame) = self.data_burst(index, slot) else {
             return;
         };
         match frame.kind {
             DvFrameKind::Header => {
                 if let Some(encrypted) = frame.encrypted {
-                    self.encrypted = Some(encrypted);
+                    self.slots[index].encrypted = Some(encrypted);
                 }
                 // A header starts a new codec stream. Repeated headers may reset this more
                 // than once, but no voice frame has arrived between them.
-                self.voice.reset();
+                self.slots[index].voice.reset();
             }
             DvFrameKind::Terminator => {
-                self.encrypted = None;
-                self.voice.reset();
+                self.slots[index].encrypted = None;
+                self.slots[index].voice.reset();
             }
             _ => {}
         }
         self.emit(frame, out);
     }
 
-    fn schedule_follower(&mut self, slot: Option<u8>) {
-        if self.followers == 0 {
+    fn schedule_follower(&mut self, index: usize) {
+        if self.followers[index] == 0 {
             return;
         }
-        self.followers -= 1;
-        self.pending = Pending::VoiceFollower { slot };
-        self.countdown = SUPERFRAME_STRIDE;
+        self.followers[index] -= 1;
+        self.follower_countdown[index] = SUPERFRAME_STRIDE;
     }
 
     /// A voice burst B to F, located by counting rather than by a sync.
-    fn voice_burst(&mut self, slot: Option<u8>, out: &mut ChannelOutputs) {
+    fn voice_burst(&mut self, slot: u8, out: &mut ChannelOutputs) {
+        let index = usize::from(slot - 1);
+        self.cach_at(BURST_SYMBOLS, out);
         self.window.bits(0, BURST_SYMBOLS, &mut self.bits);
-        if let Some(frame) = self.embedded_signalling(slot) {
+        if let Some(frame) = self.embedded_signalling(index, Some(slot)) {
             if let Some(encrypted) = frame.encrypted {
-                self.encrypted = Some(encrypted);
+                self.slots[index].encrypted = Some(encrypted);
             }
             self.emit(frame, out);
         }
-        self.voice_payload(slot, out);
-        self.schedule_follower(slot);
+        self.voice_payload(index, Some(slot), out);
+        self.schedule_follower(index);
     }
 
     /// Decode the 216-bit vocoder socket (§6.1), preserving the three contiguous 72-bit
     /// frame order while skipping the burst's centre sync/embedded field.
-    fn voice_payload(&mut self, slot: Option<u8>, out: &mut ChannelOutputs) {
+    fn voice_payload(&mut self, index: usize, slot: Option<u8>, out: &mut ChannelOutputs) {
         if slot.is_some_and(|slot| !self.params.slots.accepts(slot)) {
             return;
         }
@@ -376,7 +440,10 @@ impl Decoder {
             // A late-entry receiver does not know privacy until embedded LC completes in
             // burst E. Mute that short unknown prefix rather than vocoding ciphertext as
             // noise; a conventional header establishes Some(false) before burst A.
-            self.voice.decode(frame, self.encrypted != Some(false), out);
+            let state = &mut self.slots[index];
+            state
+                .voice
+                .decode(frame, state.encrypted != Some(false), out);
         }
     }
 
@@ -390,7 +457,7 @@ impl Decoder {
     }
 
     /// Slot type and BPTC payload of a data burst.
-    fn data_burst(&mut self, slot: Option<u8>) -> Option<DvFrame> {
+    fn data_burst(&mut self, index: usize, slot: Option<u8>) -> Option<DvFrame> {
         let slot_type = u64::from(bits_to_u32(&self.bits, 98, 10)) << 10
             | u64::from(bits_to_u32(&self.bits, 156, 10));
         let (info, slot_errors) = CyclicCode::GOLAY_20_8.decode(slot_type)?;
@@ -404,20 +471,37 @@ impl Decoder {
         {
             *slot = bit;
         }
+        if data_type == DT_RATE_THREE_QUARTER_DATA || data_type == DT_RATE_ONE_DATA {
+            let mut frame = if data_type == DT_RATE_THREE_QUARTER_DATA {
+                let decoded = decode_rate_three_quarter(&self.bits)?;
+                data_block(&decoded, "rate 3/4 data")
+            } else {
+                let decoded = decode_rate_one(&coded);
+                data_block(&decoded, "rate 1 data")
+            };
+            frame.slot = slot;
+            frame.color_code = Some(colour);
+            frame.errors_corrected = slot_errors;
+            return Some(frame);
+        }
         let (payload, payload_errors) = Bptc196::decode(&coded)?;
         let errors = slot_errors + payload_errors;
 
         let mut frame = match data_type {
-            DT_VOICE_LC_HEADER => self.link_control(&payload, VOICE_LC_HEADER_MASK)?,
+            DT_VOICE_LC_HEADER => self.link_control(index, &payload, VOICE_LC_HEADER_MASK)?,
             DT_TERMINATOR_WITH_LC => {
-                let mut frame = self.link_control(&payload, TERMINATOR_LC_MASK)?;
+                let mut frame = self.link_control(index, &payload, TERMINATOR_LC_MASK)?;
                 frame.kind = DvFrameKind::Terminator;
                 frame
             }
             DT_CSBK => self.csbk(&payload)?,
-            DT_DATA_HEADER => {
+            DT_DATA_HEADER => self.data_header(&payload)?,
+            DT_RATE_HALF_DATA => data_block(&payload, "rate 1/2 data"),
+            DT_UNIFIED_SINGLE_BLOCK_DATA => {
                 let mut frame = self.checked_block(&payload, DATA_HEADER_MASK)?;
                 frame.kind = DvFrameKind::Data;
+                frame.opcode = Some("unified single block data".to_owned());
+                frame.data = Some(hex_bits(&payload[..80]));
                 frame
             }
             // A privacy indicator header says the payload that follows is encrypted. Its
@@ -426,6 +510,12 @@ impl Decoder {
                 let mut frame = self.checked_block(&payload, PI_HEADER_MASK)?;
                 frame.kind = DvFrameKind::Header;
                 frame.encrypted = Some(true);
+                frame.algorithm_id = Some(bits_to_u32(&payload, 5, 3) as u8);
+                let fid = bits_to_u32(&payload, 8, 8) as u8;
+                set_dmr_vendor(&mut frame, fid);
+                frame.key_id = Some(bits_to_u32(&payload, 16, 8) as u16);
+                frame.message_indicator = Some(format!("{:08X}", bits_to_u32(&payload, 24, 32)));
+                frame.destination = Some(bits_to_u32(&payload, 56, 24));
                 frame
             }
             // Rate 1/2, 3/4 and full-rate data blocks, MBC continuations and idle: framed
@@ -448,7 +538,12 @@ impl Decoder {
 
     /// A full link control: 72 bits of addressing under Reed-Solomon(12,9) parity, masked by
     /// frame type so a header cannot be read as a terminator.
-    fn link_control(&mut self, payload: &[bool; 96], mask: [u8; 3]) -> Option<DvFrame> {
+    fn link_control(
+        &mut self,
+        index: usize,
+        payload: &[bool; 96],
+        mask: [u8; 3],
+    ) -> Option<DvFrame> {
         pack_bytes(payload, &mut self.bytes);
         let (lc, parity) = self.bytes.split_at(LC_BITS / 8);
         let mut received = [parity[0], parity[1], parity[2]];
@@ -458,7 +553,7 @@ impl Decoder {
         if rs129_parity(lc) != received {
             return None;
         }
-        Some(decode_lc(payload))
+        Some(self.decode_lc(index, payload))
     }
 
     /// A control signalling block: opcode, feature set id, and the two addresses most of the
@@ -466,40 +561,142 @@ impl Decoder {
     fn csbk(&mut self, payload: &[bool; 96]) -> Option<DvFrame> {
         let mut frame = self.checked_block(payload, CSBK_MASK)?;
         let opcode = bits_to_u32(payload, 2, 6) as u8;
-        frame.opcode = Some(csbk_opcode_name(opcode).to_owned());
+        let fid = bits_to_u32(payload, 8, 8) as u8;
+        set_dmr_vendor(&mut frame, fid);
+        frame.opcode = Some(csbk_opcode_name(fid, opcode));
+        if fid != 0 {
+            // Proprietary offsets are not interchangeable. Preserve the feature
+            // payload for inspection without manufacturing ETSI addresses from it.
+            frame.data = Some(hex_bits(&payload[16..80]));
+        }
         // These PDUs place target then source in their final 48 bits. Other opcode layouts
         // are named but not guessed at: for example ALOHA has only one address there.
-        if matches!(
-            opcode,
-            0b000100
-                | 0b000101
-                | 0b101110
-                | 0b101111
-                | 0b110000
-                | 0b110001
-                | 0b110010
-                | 0b110101
-                | 0b111000
-                | 0b111101
-        ) {
+        if fid == 0
+            && matches!(
+                opcode,
+                0b000100
+                    | 0b000101
+                    | 0b101110
+                    | 0b101111
+                    | 0b110000
+                    | 0b110001
+                    | 0b110010
+                    | 0b110101
+                    | 0b111000
+                    | 0b111101
+            )
+        {
             frame.destination = Some(bits_to_u32(payload, 32, 24));
             frame.source = Some(bits_to_u32(payload, 56, 24));
-        } else if opcode == 0b100110 {
+        } else if fid == 0 && opcode == 0b100110 {
             // NACK reverses that order: source then target (§7.1.2.4).
             frame.source = Some(bits_to_u32(payload, 32, 24));
             frame.destination = Some(bits_to_u32(payload, 56, 24));
         }
-        match opcode {
-            0b110001 | 0b110010 => frame.group_call = Some(true),
-            0b000100 | 0b000101 | 0b110000 | 0b110101 => frame.group_call = Some(false),
+        match (fid, opcode) {
+            (0, 0b110001 | 0b110010) => frame.group_call = Some(true),
+            (0, 0b000100 | 0b000101 | 0b110000 | 0b110101) => {
+                frame.group_call = Some(false);
+            }
             _ => {}
         }
+        decode_vendor_csbk(&mut frame, fid, opcode, payload);
+        decode_tier_three_csbk(&mut frame, fid, opcode, payload);
         Some(frame)
+    }
+
+    fn data_header(&mut self, payload: &[bool; 96]) -> Option<DvFrame> {
+        let mut frame = self.checked_block(payload, DATA_HEADER_MASK)?;
+        let format = bits_to_u32(payload, 4, 4) as u8;
+        frame.kind = DvFrameKind::Data;
+        frame.group_call = Some(payload[0]);
+        frame.destination = Some(bits_to_u32(payload, 16, 24));
+        frame.source = Some(bits_to_u32(payload, 40, 24));
+        frame.opcode = Some(data_format_name(format).to_owned());
+        frame.data = Some(format!(
+            "SAP {:X}, {} block(s)",
+            bits_to_u32(payload, 8, 4),
+            bits_to_u32(payload, 65, 7)
+        ));
+        Some(frame)
+    }
+
+    fn decode_lc(&mut self, index: usize, lc: &[bool]) -> DvFrame {
+        let flco = bits_to_u32(lc, 2, 6) as u8;
+        let fid = bits_to_u32(lc, 8, 8) as u8;
+        let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Header);
+        set_dmr_vendor(&mut frame, fid);
+        match (fid, flco) {
+            (0, 0 | 3) | (0x10, 0) | (0x06, 0 | 3) => {
+                frame.group_call = Some(flco == 0);
+                frame.destination = Some(bits_to_u32(lc, 24, 24));
+                frame.source = Some(bits_to_u32(lc, 48, 24));
+                frame.encrypted = Some(lc[17]);
+                frame.emergency = Some(lc[16]);
+                if fid != 0 {
+                    frame.opcode = Some(format!(
+                        "{} voice channel user",
+                        frame.vendor.map_or("vendor", Vendor::label)
+                    ));
+                }
+            }
+            (0, 4..=7) => {
+                frame.opcode = Some(talker_alias_opcode(flco).to_owned());
+                frame.talker_alias = self.slots[index].talker_alias.update(flco, lc);
+            }
+            (0x68, 4..=7) => {
+                frame.opcode = Some(format!("Hytera XPT {}", talker_alias_opcode(flco)));
+                frame.talker_alias = self.slots[index].talker_alias.update(flco, lc);
+            }
+            (0x10, 0x14..=0x17) => {
+                let alias_flco = flco - 0x10;
+                frame.opcode = Some(format!("Motorola {}", talker_alias_opcode(alias_flco)));
+                frame.talker_alias = self.slots[index].talker_alias.update(alias_flco, lc);
+            }
+            (0, 8) => {
+                frame.opcode = Some("GPS Info".to_owned());
+                decode_gps_info(&mut frame, lc);
+            }
+            (0x10, 4 | 7) => {
+                frame.opcode = Some("Capacity Plus voice channel user".to_owned());
+                frame.group_call = Some(flco == 4);
+                frame.destination = Some(bits_to_u32(lc, 24, 24));
+                frame.source = Some(bits_to_u32(lc, 56, 16));
+                frame.rest_channel = Some(bits_to_u32(lc, 52, 4) as u16);
+            }
+            (0x68, 0 | 3 | 9) => {
+                frame.opcode = Some(
+                    if flco == 9 {
+                        "Hytera XPT call alert"
+                    } else {
+                        "Hytera XPT voice channel user"
+                    }
+                    .to_owned(),
+                );
+                frame.group_call = Some(lc[1]);
+                frame.destination = Some(bits_to_u32(lc, 32, 16));
+                frame.source = Some(bits_to_u32(lc, 56, 16));
+                frame.channel = Some(bits_to_u32(lc, 16, 4) as u16);
+                if flco == 9 {
+                    frame.data = Some(format!(
+                        "free LCN {}, handshake {}",
+                        bits_to_u32(lc, 24, 4),
+                        bits_to_u32(lc, 28, 4)
+                    ));
+                }
+            }
+            _ => {
+                let vendor = frame.vendor.map_or("vendor", Vendor::label);
+                frame.opcode = Some(format!("{vendor} FLCO {flco}, unparsed"));
+                frame.data = Some(hex_bits(&lc[16..72]));
+            }
+        }
+        frame
     }
 
     /// The embedded signalling field of a voice burst: colour code and the link control
     /// fragment index, and — once four fragments have arrived — the link control itself.
-    fn embedded_signalling(&mut self, slot: Option<u8>) -> Option<DvFrame> {
+    fn embedded_signalling(&mut self, index: usize, slot: Option<u8>) -> Option<DvFrame> {
         let emb = u64::from(bits_to_u32(&self.bits, 108, 8)) << 8
             | u64::from(bits_to_u32(&self.bits, 148, 8));
         let (info, errors) = CyclicCode::QR_16_7.decode(emb)?;
@@ -510,23 +707,26 @@ impl Decoder {
         // three are the quarters of an embedded link control, in order.
         match lcss {
             0b01 => {
-                self.embedded.clear();
-                self.embedded_errors = 0;
+                self.slots[index].embedded.clear();
+                self.slots[index].embedded_errors = 0;
             }
             // A continuation or last fragment with nothing before it belongs to a superframe
             // this receiver did not hear the start of.
-            0b10 | 0b11 if !self.embedded.is_empty() => {}
+            0b10 | 0b11 if !self.slots[index].embedded.is_empty() => {}
             _ => return None,
         }
-        self.embedded.extend(self.bits[116..148].iter().copied());
-        self.embedded_errors += errors;
+        self.slots[index]
+            .embedded
+            .extend(self.bits[116..148].iter().copied());
+        self.slots[index].embedded_errors += errors;
 
         if lcss != 0b10 {
             return None;
         }
-        let coded: [bool; Bptc128::CODED_BITS] = self.embedded.as_slice().try_into().ok()?;
+        let coded: [bool; Bptc128::CODED_BITS] =
+            self.slots[index].embedded.as_slice().try_into().ok()?;
         let (data, bptc_errors) = Bptc128::decode(&coded)?;
-        self.embedded.clear();
+        self.slots[index].embedded.clear();
 
         // The 77 bits are the 72-bit link control with a five-bit checksum threaded through
         // column 10 of rows 2 to 6.
@@ -546,54 +746,559 @@ impl Decoder {
         if sum != checksum {
             return None;
         }
-        let mut frame = decode_lc(&lc);
+        let mut frame = self.decode_lc(index, &lc);
         frame.kind = DvFrameKind::Voice;
         frame.slot = slot;
         frame.color_code = Some(colour);
-        frame.errors_corrected = self.embedded_errors + bptc_errors;
+        frame.errors_corrected = self.slots[index].embedded_errors + bptc_errors;
         Some(frame)
     }
 }
 
-/// The addressing a full link control carries, whichever path it arrived by (ETSI §9.1.6).
-fn decode_lc(lc: &[bool]) -> DvFrame {
-    let flco = bits_to_u32(lc, 2, 6);
-    let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Header);
-    // FLCO 0 is a group call, 3 a call to one radio; the rest are talker alias and GPS
-    // blocks, which carry no addresses of their own.
-    match flco {
-        0 | 3 => {
-            frame.group_call = Some(flco == 0);
-            frame.destination = Some(bits_to_u32(lc, 24, 24));
-            frame.source = Some(bits_to_u32(lc, 48, 24));
-            // Service options bit 6 is the encryption flag.
-            frame.encrypted = Some(lc[17]);
+fn slot_index(slot: Option<u8>) -> Option<usize> {
+    slot.filter(|slot| (1..=2).contains(slot))
+        .map(|slot| usize::from(slot - 1))
+}
+
+#[derive(Default)]
+struct ShortLc {
+    payload: Vec<bool>,
+}
+
+impl ShortLc {
+    fn reset(&mut self) {
+        self.payload.clear();
+    }
+
+    fn push(&mut self, lcss: u8, payload: [bool; 17]) -> Option<DvFrame> {
+        match lcss {
+            0b01 => self.payload.clear(),
+            0b11 | 0b10 if !self.payload.is_empty() => {}
+            _ => return None,
         }
-        _ => frame.opcode = Some(format!("FLCO {flco}")),
+        self.payload.extend(payload);
+        if lcss != 0b10 || self.payload.len() != 68 {
+            return None;
+        }
+
+        // Four transmitted rows were read column-first from the 4x17 BPTC encode matrix.
+        let mut matrix = [[false; 17]; 4];
+        for column in 0..17 {
+            for (row, cells) in matrix.iter_mut().enumerate() {
+                cells[column] = self.payload[column * 4 + row];
+            }
+        }
+        self.payload.clear();
+        for row in &mut matrix[..3] {
+            ParityCode::HAMMING_17_12.decode(row)?;
+        }
+        for column in 0..17 {
+            if matrix
+                .iter()
+                .fold(false, |parity, row| parity ^ row[column])
+            {
+                return None;
+            }
+        }
+        let mut message = [false; 36];
+        for (target, bit) in message
+            .iter_mut()
+            .zip(matrix[..3].iter().flat_map(|row| &row[..12]))
+        {
+            *target = *bit;
+        }
+        if crc8_dmr(&message[..28]) != bits_to_u32(&message, 28, 8) as u8 {
+            return None;
+        }
+        Some(decode_short_lc(&message[..28]))
+    }
+}
+
+fn crc8_dmr(bits: &[bool]) -> u8 {
+    let mut crc = 0u8;
+    for &bit in bits {
+        let high = crc & 0x80 != 0;
+        crc <<= 1;
+        if high != bit {
+            crc ^= 0x07;
+        }
+    }
+    crc
+}
+
+fn decode_short_lc(bits: &[bool]) -> DvFrame {
+    let slco = bits_to_u32(bits, 0, 4) as u8;
+    let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Control);
+    frame.vendor = Some(Vendor::Etsi);
+    frame.manufacturer_id = Some(0);
+    match slco {
+        0 => frame.opcode = Some("Short LC null message".to_owned()),
+        1 => {
+            frame.opcode = Some("Short LC activity update".to_owned());
+            for (slot, activity_at, hash_at) in [(1, 4, 12), (2, 8, 20)] {
+                let activity = bits_to_u32(bits, activity_at, 4) as u8;
+                if activity != 0 {
+                    frame.slot_activity.push(DvSlotActivity {
+                        slot,
+                        activity: activity_name(activity).to_owned(),
+                        destination_hash: Some(bits_to_u32(bits, hash_at, 8) as u8),
+                    });
+                }
+            }
+        }
+        2 | 3 => {
+            frame.opcode = Some(if slco == 2 {
+                "Tier III control-channel system parameters".to_owned()
+            } else {
+                "Tier III payload-channel system parameters".to_owned()
+            });
+            frame.system_id = Some(bits_to_u32(bits, 6, 12) as u16);
+            frame.data = Some(format!(
+                "network model {}, common slot counter {}",
+                bits_to_u32(bits, 4, 2),
+                bits_to_u32(bits, 19, 9)
+            ));
+        }
+        8 => {
+            frame.opcode = Some("Hytera XPT Short LC".to_owned());
+            frame.vendor = Some(Vendor::Hytera);
+            frame.manufacturer_id = Some(0x68);
+            frame.channel = Some(bits_to_u32(bits, 12, 4) as u16);
+            frame.data = Some(format!(
+                "priority LCN {}, priority hash {:02X}",
+                bits_to_u32(bits, 16, 4),
+                bits_to_u32(bits, 20, 8)
+            ));
+        }
+        9 | 10 => {
+            frame.opcode = Some(if slco == 9 {
+                "Connect Plus traffic-channel Short LC".to_owned()
+            } else {
+                "Connect Plus control-channel Short LC".to_owned()
+            });
+            frame.vendor = Some(Vendor::Motorola);
+            frame.manufacturer_id = Some(0x06);
+            frame.network_id = Some(bits_to_u32(bits, 8, 8));
+            frame.site_id = Some(bits_to_u32(bits, 16, 8) as u16);
+        }
+        15 => {
+            frame.opcode = Some("Capacity Plus site Short LC".to_owned());
+            frame.vendor = Some(Vendor::Motorola);
+            frame.manufacturer_id = Some(0x10);
+            frame.site_id = Some(bits_to_u32(bits, 22, 3) as u16);
+            frame.rest_channel = Some(bits_to_u32(bits, 16, 4) as u16);
+        }
+        _ => frame.opcode = Some(format!("Short LC {slco:X}, unparsed")),
     }
     frame
 }
 
-fn csbk_opcode_name(opcode: u8) -> &'static str {
-    match opcode {
-        // TS 102 361-2 V2.5.1 Annex B.2. The published values are binary, not hex.
-        0b000100 => "unit-to-unit voice service request",
-        0b000101 => "unit-to-unit voice service answer response",
-        0b000111 => "channel timing",
-        0b100110 => "negative acknowledge response",
-        0b111000 => "BS outbound activation",
-        0b111101 => "preamble",
-        // TS 102 361-4 V1.12.1 Annex B.1.
-        0b011001 => "ALOHA",
-        0b011100 => "AHOY",
-        0b101110 => "clear",
-        0b101111 => "protect",
-        0b110000 => "private voice channel grant",
-        0b110001 => "talkgroup voice channel grant",
-        0b110010 => "broadcast talkgroup voice channel grant",
-        0b110101 => "duplex private voice channel grant",
-        _ => "CSBK",
+fn activity_name(activity: u8) -> &'static str {
+    match activity {
+        2 => "group CSBK",
+        3 => "individual CSBK",
+        8 => "group voice",
+        9 => "individual voice",
+        10 => "individual data",
+        11 => "group data",
+        12 => "emergency group voice",
+        13 => "emergency individual voice",
+        _ => "reserved activity",
     }
+}
+
+fn csbk_opcode_name(fid: u8, opcode: u8) -> String {
+    let name = match (fid, opcode) {
+        // TS 102 361-2 V2.5.1 Annex B.2. The published values are binary, not hex.
+        (0, 0b000100) => "unit-to-unit voice service request",
+        (0, 0b000101) => "unit-to-unit voice service answer response",
+        (0, 0b000111) => "channel timing",
+        (0, 0b100110) => "negative acknowledge response",
+        (0, 0b111000) => "BS outbound activation",
+        (0, 0b111101) => "preamble",
+        // TS 102 361-4 V1.12.1 Annex B.1.
+        (0, 0b011001) => "ALOHA",
+        (0, 0b011100) => "AHOY",
+        (0, 0b101110) => "clear",
+        (0, 0b101111) => "protect",
+        (0, 0b110000) => "private voice channel grant",
+        (0, 0b110001) => "talkgroup voice channel grant",
+        (0, 0b110010) => "broadcast talkgroup voice channel grant",
+        (0, 0b110101) => "duplex private voice channel grant",
+        (0x10, 0x3A) => "Capacity Plus system CSBK",
+        (0x10, 0x3B) => "Capacity Plus adjacent sites",
+        (0x10, 0x3E) => "Capacity Plus channel status",
+        (0x06, 0x01) => "Connect Plus adjacent sites",
+        (0x06, 0x03) => "Connect Plus voice channel grant",
+        (0x06, 0x06) => "Connect Plus data channel grant",
+        (0x06, 0x0C) => "Connect Plus slot termination",
+        (0x06, _) => "Connect Plus CSBK, unparsed",
+        (0x68, 0x0A) => "Hytera XPT site status",
+        (0x68, 0x0B) => "Hytera XPT adjacent sites",
+        (0x08 | 0x68, _) => "Hytera CSBK, unparsed",
+        _ => return format!("{} CSBK {opcode:02X}, unparsed", dmr_vendor(fid).label()),
+    };
+    name.to_owned()
+}
+
+fn dmr_vendor(fid: u8) -> Vendor {
+    match fid {
+        0 => Vendor::Etsi,
+        0x06 | 0x10 => Vendor::Motorola,
+        // Display-only assignments from ETSI's public DMR MFID registry. Parsing
+        // is dispatched separately, so a name cannot enable a proprietary layout.
+        0x04 => Vendor::FlydeMicro,
+        0x05 => Vendor::ProdEl,
+        0x08 | 0x68 | 0x88 => Vendor::Hytera,
+        0x0D | 0x13 | 0x1C | 0x20 => Vendor::Emc,
+        0x33 => Vendor::JvcKenwood,
+        0x3C => Vendor::RadioActivity,
+        0x58 => Vendor::Tait,
+        _ => Vendor::Unknown,
+    }
+}
+
+fn set_dmr_vendor(frame: &mut DvFrame, fid: u8) {
+    frame.vendor = Some(dmr_vendor(fid));
+    frame.manufacturer_id = Some(fid);
+}
+
+fn decode_vendor_csbk(frame: &mut DvFrame, fid: u8, opcode: u8, payload: &[bool]) {
+    match (fid, opcode) {
+        (0x10, 0x3A | 0x3E) => {
+            frame.rest_channel = Some(bits_to_u32(payload, 20, 4) as u16);
+            frame.data = Some(format!(
+                "fragment {}, transmitted TS {}, reserved {}",
+                bits_to_u32(payload, 16, 2),
+                u8::from(payload[18]) + 1,
+                u8::from(payload[19])
+            ));
+        }
+        (0x10, 0x3B) => {
+            let sites = (0..6)
+                .filter_map(|index| {
+                    let site = bits_to_u32(payload, 32 + index * 8, 4);
+                    (site != 0).then(|| {
+                        format!(
+                            "site {site} rest {}",
+                            bits_to_u32(payload, 36 + index * 8, 4)
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            frame.data = Some(if sites.is_empty() {
+                "no adjacent sites".to_owned()
+            } else {
+                sites.join(", ")
+            });
+        }
+        (0x06, 0x01) => {
+            let sites = (0..5)
+                .filter_map(|index| {
+                    let site = bits_to_u32(payload, 16 + index * 8, 8) & 0x3F;
+                    (site != 0).then_some(site.to_string())
+                })
+                .collect::<Vec<_>>();
+            frame.data = Some(format!("adjacent sites {}", sites.join(", ")));
+        }
+        (0x06, 0x03) => {
+            let option = bits_to_u32(payload, 72, 8) as u8;
+            frame.source = Some(bits_to_u32(payload, 16, 24));
+            frame.destination = Some(bits_to_u32(payload, 40, 24));
+            frame.channel = Some(bits_to_u32(payload, 64, 4) as u16);
+            frame.group_call = match option {
+                2 => Some(true),
+                3 => Some(false),
+                _ => None,
+            };
+            frame.data = Some(format!(
+                "granted TS {}, option {option:02X}",
+                u8::from(payload[68]) + 1
+            ));
+        }
+        (0x06, 0x06) => {
+            frame.destination = Some(bits_to_u32(payload, 16, 24));
+            frame.channel = Some(bits_to_u32(payload, 40, 4) as u16);
+            frame.data = Some(format!("granted TS {}", u8::from(payload[44]) + 1));
+        }
+        (0x68, 0x0A) => {
+            frame.channel = Some(bits_to_u32(payload, 16, 4) as u16);
+            frame.data = Some(format!(
+                "sequence {}, slot states {:03X}",
+                bits_to_u32(payload, 0, 2),
+                bits_to_u32(payload, 20, 12)
+            ));
+        }
+        _ => {}
+    }
+}
+
+fn decode_tier_three_csbk(frame: &mut DvFrame, fid: u8, opcode: u8, payload: &[bool]) {
+    if fid != 0 {
+        return;
+    }
+    if matches!(opcode, 0b110000..=0b110101) {
+        frame.channel = Some(bits_to_u32(payload, 16, 12) as u16);
+        frame.slot = Some(if payload[28] { 2 } else { 1 });
+        frame.emergency = Some(payload[30]);
+    } else if opcode == 0b011001 {
+        frame.system_id = Some(bits_to_u32(payload, 40, 16) as u16);
+        frame.destination = Some(bits_to_u32(payload, 56, 24));
+        frame.data = Some(format!(
+            "mask {}, service {}, wait {}, backoff {}",
+            bits_to_u32(payload, 25, 5),
+            bits_to_u32(payload, 30, 2),
+            bits_to_u32(payload, 32, 4),
+            bits_to_u32(payload, 37, 4)
+        ));
+    } else if opcode == 0b011100 {
+        frame.group_call = Some(payload[25]);
+        frame.destination = Some(bits_to_u32(payload, 32, 24));
+        frame.source = Some(bits_to_u32(payload, 56, 24));
+    }
+}
+
+fn data_format_name(format: u8) -> &'static str {
+    match format {
+        0 => "unified data transport header",
+        1 => "response header",
+        2 => "unconfirmed data header",
+        3 => "confirmed data header",
+        13 => "defined data header",
+        14 => "raw data header",
+        15 => "proprietary data header",
+        _ => "data header",
+    }
+}
+
+fn data_block(payload: &[bool], name: &str) -> DvFrame {
+    let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Data);
+    frame.opcode = Some(name.to_owned());
+    frame.data = Some(hex_bits(payload));
+    frame
+}
+
+fn hex_bits(bits: &[bool]) -> String {
+    let mut out = String::with_capacity(bits.len().div_ceil(4));
+    for nibble in bits.chunks(4) {
+        let value = nibble
+            .iter()
+            .fold(0u8, |acc, bit| acc << 1 | u8::from(*bit));
+        out.push(char::from_digit(u32::from(value), 16).unwrap_or('0'));
+    }
+    out
+}
+
+/// Decode the 8-state rate-3/4 trellis by maximum-likelihood dynamic programming. The four
+/// transmitted dibits per transition name one constellation point; the final zero tribit is
+/// the flush symbol and is not returned.
+fn decode_rate_three_quarter(burst: &[bool]) -> Option<[bool; 144]> {
+    const NEXT: [[u8; 8]; 8] = [
+        [0, 8, 4, 12, 2, 10, 6, 14],
+        [4, 12, 2, 10, 6, 14, 0, 8],
+        [1, 9, 5, 13, 3, 11, 7, 15],
+        [5, 13, 3, 11, 7, 15, 1, 9],
+        [3, 11, 7, 15, 1, 9, 5, 13],
+        [7, 15, 1, 9, 5, 13, 3, 11],
+        [2, 10, 6, 14, 0, 8, 4, 12],
+        [6, 14, 0, 8, 4, 12, 2, 10],
+    ];
+    const MAP: [[u8; 2]; 16] = [
+        [0, 2],
+        [2, 2],
+        [1, 3],
+        [3, 3],
+        [3, 2],
+        [1, 2],
+        [2, 3],
+        [0, 3],
+        [3, 1],
+        [1, 1],
+        [2, 0],
+        [0, 0],
+        [0, 1],
+        [2, 1],
+        [1, 0],
+        [3, 0],
+    ];
+    let mut air = Vec::with_capacity(98);
+    for pair in burst[..98]
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .chain(burst[166..].as_chunks::<2>().0.iter())
+    {
+        air.push(u8::from(pair[0]) << 1 | u8::from(pair[1]));
+    }
+    if air.len() != 98 {
+        return None;
+    }
+    let mut encoded = [0u8; 98];
+    for (i, value) in encoded.iter_mut().enumerate() {
+        // Closed form of table B.9: indices 0..25 cover the even columns and 26..49 the odd.
+        let source = if i < 50 {
+            (i % 26) * 8 + i / 26
+        } else {
+            let j = i - 50;
+            (j % 24) * 8 + 4 + j / 24
+        };
+        *value = air[97 - source];
+    }
+    let mut metric = [u16::MAX; 8];
+    metric[0] = 0;
+    let mut history = [[(0u8, 0u8); 8]; 49];
+    for step in 0..49 {
+        let observed = [encoded[step * 2], encoded[step * 2 + 1]];
+        let mut next_metric = [u16::MAX; 8];
+        for (state, &cost) in metric.iter().enumerate() {
+            if cost == u16::MAX {
+                continue;
+            }
+            for input in 0..8 {
+                let point = NEXT[state][input];
+                let distance = u16::from(MAP[usize::from(point)][0] != observed[0])
+                    + u16::from(MAP[usize::from(point)][1] != observed[1]);
+                let candidate = cost + distance;
+                if candidate < next_metric[input] {
+                    next_metric[input] = candidate;
+                    history[step][input] = (state as u8, input as u8);
+                }
+            }
+        }
+        metric = next_metric;
+    }
+    let mut state = 0usize;
+    let mut tribits = [0u8; 49];
+    for step in (0..49).rev() {
+        let (previous, input) = history[step][state];
+        tribits[step] = input;
+        state = usize::from(previous);
+    }
+    let mut out = [false; 144];
+    for (chunk, &tribit) in out.as_chunks_mut::<3>().0.iter_mut().zip(&tribits[..48]) {
+        chunk[0] = tribit & 4 != 0;
+        chunk[1] = tribit & 2 != 0;
+        chunk[2] = tribit & 1 != 0;
+    }
+    Some(out)
+}
+
+fn decode_rate_one(coded: &[bool; 196]) -> [bool; 192] {
+    let mut out = [false; 192];
+    // Rate-one blocks carry 192 uncoded information bits around four zero pad bits.
+    out[..96].copy_from_slice(&coded[..96]);
+    out[96..].copy_from_slice(&coded[100..]);
+    out
+}
+
+fn talker_alias_opcode(flco: u8) -> &'static str {
+    match flco {
+        4 => "talker alias header",
+        5 => "talker alias block 1",
+        6 => "talker alias block 2",
+        _ => "talker alias block 3",
+    }
+}
+
+#[derive(Default)]
+struct TalkerAlias {
+    format: u8,
+    length: usize,
+    bits: Vec<bool>,
+    next_block: u8,
+}
+
+impl TalkerAlias {
+    fn reset(&mut self) {
+        self.bits.clear();
+        self.length = 0;
+        self.next_block = 0;
+    }
+
+    fn update(&mut self, flco: u8, lc: &[bool]) -> Option<String> {
+        if flco == 4 {
+            self.format = bits_to_u32(lc, 16, 2) as u8;
+            self.length = bits_to_u32(lc, 18, 5) as usize;
+            self.bits.clear();
+            let start = if self.format == 0 { 23 } else { 24 };
+            self.bits.extend_from_slice(&lc[start..72]);
+            self.next_block = 5;
+        } else if flco == self.next_block {
+            self.bits.extend_from_slice(&lc[16..72]);
+            self.next_block += 1;
+        } else {
+            return None;
+        }
+        self.decode()
+    }
+
+    fn decode(&self) -> Option<String> {
+        let needed = match self.format {
+            0 => self.length * 7,
+            1 | 2 => self.length * 8,
+            3 => self.length * 16,
+            _ => return None,
+        };
+        if self.bits.len() < needed {
+            return None;
+        }
+        let text = match self.format {
+            0 => self.bits[..needed]
+                .as_chunks::<7>()
+                .0
+                .iter()
+                .map(|bits| bits_to_u32(bits, 0, 7) as u8 as char)
+                .collect(),
+            1 => self.bits[..needed]
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|bits| bits_to_u32(bits, 0, 8) as u8 as char)
+                .collect(),
+            2 => String::from_utf8(
+                self.bits[..needed]
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
+                    .map(|bits| bits_to_u32(bits, 0, 8) as u8)
+                    .collect(),
+            )
+            .ok()?,
+            3 => String::from_utf16(
+                &self.bits[..needed]
+                    .as_chunks::<16>()
+                    .0
+                    .iter()
+                    .map(|bits| bits_to_u32(bits, 0, 16) as u16)
+                    .collect::<Vec<_>>(),
+            )
+            .ok()?,
+            _ => return None,
+        };
+        Some(text.trim_end_matches('\0').to_owned())
+    }
+}
+
+fn decode_gps_info(frame: &mut DvFrame, lc: &[bool]) {
+    let error = bits_to_u32(lc, 20, 3);
+    let lon = signed_bits(bits_to_u32(lc, 23, 25), 25);
+    let lat = signed_bits(bits_to_u32(lc, 48, 24), 24);
+    frame.lon = Some(f64::from(lon) * 360.0 / 2f64.powi(25));
+    frame.lat = Some(f64::from(lat) * 180.0 / 2f64.powi(24));
+    frame.position_error_m = match error {
+        0 => Some(2),
+        1 => Some(20),
+        2 => Some(200),
+        3 => Some(2_000),
+        4 => Some(20_000),
+        5 => Some(200_000),
+        _ => None,
+    };
+}
+
+fn signed_bits(value: u32, width: u32) -> i32 {
+    let shift = 32 - width;
+    ((value << shift) as i32) >> shift
 }
 
 /// DMR's AMBE+2 interleave lands the two transmitted bits of each dibit in separate codec code
@@ -1004,6 +1709,102 @@ mod tests {
     }
 
     #[test]
+    fn vendor_csbk_opcode_collision_does_not_invent_addresses() {
+        let iq = tx::csbk_with_fid(3, 0x08, 0b111101, 505, 2_621_001, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+        let csbk = frames
+            .iter()
+            .find(|frame| frame.kind == DvFrameKind::Control)
+            .expect("vendor CSBK");
+        assert_eq!(csbk.vendor, Some(Vendor::Hytera));
+        assert_eq!(csbk.manufacturer_id, Some(0x08));
+        assert_eq!(csbk.opcode.as_deref(), Some("Hytera CSBK, unparsed"));
+        assert_eq!(csbk.destination, None);
+        assert_eq!(csbk.source, None);
+    }
+
+    #[test]
+    fn vendor_dispatch_decodes_connect_plus_and_capacity_plus_fields() {
+        let mut connect = [false; 96];
+        write_bits(&mut connect, 16, 24, 151_015);
+        write_bits(&mut connect, 40, 24, 1_216);
+        write_bits(&mut connect, 64, 4, 2);
+        connect[68] = true;
+        write_bits(&mut connect, 72, 8, 2);
+        let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Control);
+        decode_vendor_csbk(&mut frame, 0x06, 0x03, &connect);
+        assert_eq!(frame.source, Some(151_015));
+        assert_eq!(frame.destination, Some(1_216));
+        assert_eq!(frame.channel, Some(2));
+        assert_eq!(frame.group_call, Some(true));
+        assert!(
+            frame
+                .data
+                .as_deref()
+                .is_some_and(|data| data.contains("TS 2"))
+        );
+
+        let mut capacity = [false; 96];
+        write_bits(&mut capacity, 16, 2, 3);
+        write_bits(&mut capacity, 20, 4, 7);
+        let mut frame = DvFrame::new(DvMode::Dmr, DvFrameKind::Control);
+        decode_vendor_csbk(&mut frame, 0x10, 0x3E, &capacity);
+        assert_eq!(frame.rest_channel, Some(7));
+    }
+
+    #[test]
+    fn decodes_gps_info_link_control() {
+        let mut decoder = Decoder::new(DmrParams::default());
+        let mut lc = [false; 72];
+        write_bits(&mut lc, 2, 6, 8);
+        write_bits(&mut lc, 8, 8, 0);
+        write_bits(&mut lc, 20, 3, 1);
+        write_bits(&mut lc, 23, 25, ((12.5 / 360.0) * 2f64.powi(25)) as u32);
+        write_bits(
+            &mut lc,
+            48,
+            24,
+            ((-33.75 / 180.0) * 2f64.powi(24)) as i32 as u32,
+        );
+        let frame = decoder.decode_lc(0, &lc);
+        assert!((frame.lon.expect("longitude") - 12.5).abs() < 0.000_1);
+        assert!((frame.lat.expect("latitude") + 33.75).abs() < 0.000_1);
+        assert_eq!(frame.position_error_m, Some(20));
+    }
+
+    #[test]
+    fn reassembles_utf8_talker_alias() {
+        let mut decoder = Decoder::new(DmrParams::default());
+        let alias = b"SCANNER-ALIAS";
+        let mut stream = Vec::new();
+        for byte in alias {
+            stream.extend((0..8).rev().map(|bit| byte >> bit & 1 == 1));
+        }
+        stream.resize(49 + 3 * 56, false);
+        let mut completed = None;
+        for flco in 4u8..=7 {
+            let mut lc = [false; 72];
+            write_bits(&mut lc, 2, 6, u32::from(flco));
+            if flco == 4 {
+                write_bits(&mut lc, 16, 2, 2);
+                write_bits(&mut lc, 18, 5, alias.len() as u32);
+                lc[24..72].copy_from_slice(&stream[..48]);
+            } else {
+                let start = 48 + usize::from(flco - 5) * 56;
+                lc[16..72].copy_from_slice(&stream[start..start + 56]);
+            }
+            completed = decoder.decode_lc(0, &lc).talker_alias.or(completed);
+        }
+        assert_eq!(completed.as_deref(), Some("SCANNER-ALIAS"));
+    }
+
+    fn write_bits(target: &mut [bool], offset: usize, len: usize, value: u32) {
+        for (index, bit) in target[offset..offset + len].iter_mut().enumerate() {
+            *bit = value >> (len - 1 - index) & 1 == 1;
+        }
+    }
+
+    #[test]
     fn csbk_opcodes_are_the_specs_six_bit_binary_values() {
         for (opcode, name) in [
             (0b000100, "unit-to-unit voice service request"),
@@ -1017,7 +1818,7 @@ mod tests {
             (0b110000, "private voice channel grant"),
             (0b110001, "talkgroup voice channel grant"),
         ] {
-            assert_eq!(csbk_opcode_name(opcode), name, "opcode {opcode:06b}");
+            assert_eq!(csbk_opcode_name(0, opcode), name, "opcode {opcode:06b}");
         }
     }
 
@@ -1028,6 +1829,82 @@ mod tests {
         let iq = tx::transmission(&tx::Call::default(), INPUT_RATE_HZ);
         assert!(!decode(&mut channel(DmrSlots::One), &iq).is_empty());
         assert!(decode(&mut channel(DmrSlots::Two), &iq).is_empty());
+    }
+
+    #[test]
+    fn repeater_cach_activates_the_slot_filter() {
+        let call = tx::Call::default();
+        let iq = tx::repeater_transmission(&call, 2, INPUT_RATE_HZ);
+        assert!(decode(&mut channel(DmrSlots::One), &iq).is_empty());
+        let frames = decode(&mut channel(DmrSlots::Two), &iq);
+        assert!(!frames.is_empty());
+        assert!(frames.iter().all(|frame| frame.slot == Some(2)));
+    }
+
+    #[test]
+    fn concurrent_repeater_slots_keep_independent_call_state() {
+        let first = tx::Call {
+            destination: 101,
+            source: 1_000_001,
+            ..tx::Call::default()
+        };
+        let second = tx::Call {
+            destination: 202,
+            source: 2_000_002,
+            ..tx::Call::default()
+        };
+        let iq = tx::dual_slot_transmission(&first, &second, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+        for (slot, source, destination) in [
+            (1, first.source, first.destination),
+            (2, second.source, second.destination),
+        ] {
+            let call = frames
+                .iter()
+                .find(|frame| frame.slot == Some(slot) && frame.source == Some(source))
+                .unwrap_or_else(|| panic!("missing slot {slot} call: {frames:?}"));
+            assert_eq!(call.destination, Some(destination));
+        }
+    }
+
+    #[test]
+    fn short_lc_reports_activity_on_both_slots() {
+        let mut message = [false; 36];
+        write_bits(&mut message, 0, 4, 1);
+        write_bits(&mut message, 4, 4, 8);
+        write_bits(&mut message, 8, 4, 10);
+        write_bits(&mut message, 12, 8, 0xA5);
+        write_bits(&mut message, 20, 8, 0x5A);
+        let crc = crc8_dmr(&message[..28]);
+        write_bits(&mut message, 28, 8, u32::from(crc));
+
+        let mut matrix = [[false; 17]; 4];
+        for row in 0..3 {
+            matrix[row][..12].copy_from_slice(&message[row * 12..(row + 1) * 12]);
+            ParityCode::HAMMING_17_12.encode(&mut matrix[row]);
+        }
+        for column in 0..17 {
+            matrix[3][column] = matrix[..3]
+                .iter()
+                .fold(false, |parity, row| parity ^ row[column]);
+        }
+        let transmitted: Vec<bool> = (0..17)
+            .flat_map(|column| (0..4).map(move |row| matrix[row][column]))
+            .collect();
+        let mut decoder = ShortLc::default();
+        let mut frame = None;
+        for (index, lcss) in [1, 3, 3, 2].into_iter().enumerate() {
+            let payload: [bool; 17] = transmitted[index * 17..(index + 1) * 17]
+                .try_into()
+                .expect("CACH row");
+            frame = decoder.push(lcss, payload).or(frame);
+        }
+        let frame = frame.expect("decoded Short LC");
+        assert_eq!(frame.slot_activity.len(), 2);
+        assert_eq!(frame.slot_activity[0].activity, "group voice");
+        assert_eq!(frame.slot_activity[0].destination_hash, Some(0xA5));
+        assert_eq!(frame.slot_activity[1].activity, "individual data");
+        assert_eq!(frame.slot_activity[1].destination_hash, Some(0x5A));
     }
 
     /// Noise is not a call. Nothing may reach the log from a channel carrying only noise, at

--- a/crates/channels/src/dv/p25.rs
+++ b/crates/channels/src/dv/p25.rs
@@ -6,9 +6,9 @@
 //! The NID is a BCH(63,16,23) codeword with a parity bit, so eleven bit errors still decode.
 //!
 //! Voice LDUs are collected at their complete 1728-bit wire length, their status dibits removed,
-//! and their nine Annex-H IMBE frames decoded. This reports the NAC and transmission shape;
-//! link control inside an LDU and trunking blocks inside a TSDU remain signalling follow-up
-//! work (FEATURES §9).
+//! and their nine Annex-H IMBE frames decoded. The Hamming/Golay and GF(64) Reed-Solomon layers
+//! recover HDU, LDU1 link control and LDU2 encryption sync; TSDUs pass their trellis and CRC
+//! before standard or MFID-gated trunking fields are exposed.
 //!
 //! Status symbols complicate the framing: the transmitter inserts a dibit of its own after
 //! every 35 payload dibits, starting at bit 70 of the frame, and they have to come out before
@@ -17,11 +17,11 @@
 use std::sync::LazyLock;
 
 use num_complex::Complex;
-use sdrmm_dsp::CyclicCode;
+use sdrmm_dsp::{CyclicCode, ParityCode, crc16_msb, rs64_decode};
 use sdrmm_modem::cpm::CpmDemod;
 use sdrmm_wire::{
     ChannelDescriptor, ChannelParams, ChannelSettings, DecoderEvent, DvFrame, DvFrameKind, DvMode,
-    P25Params,
+    P25Params, Vendor,
 };
 
 use super::{INPUT_RATE_HZ, SymbolWindow, c4fm_demod, c4fm_params, vocoder::MbeDecoder};
@@ -140,6 +140,9 @@ struct Decoder {
     last_duid: Option<u8>,
     /// Once the NID has named an LDU, its complete frame is collected before audio extraction.
     pending_duid: Option<u8>,
+    pending_nac: u16,
+    pending_errors: u32,
+    encrypted: bool,
     vocoder: MbeDecoder,
     logical: Vec<bool>,
 }
@@ -153,6 +156,9 @@ impl Decoder {
             bits: Vec::with_capacity(NID_BITS + 2),
             last_duid: None,
             pending_duid: None,
+            pending_nac: 0,
+            pending_errors: 0,
+            encrypted: false,
             vocoder: MbeDecoder::full_rate(),
             logical: Vec::with_capacity(MAX_FRAME_BITS),
         }
@@ -164,6 +170,9 @@ impl Decoder {
         self.hunting = true;
         self.last_duid = None;
         self.pending_duid = None;
+        self.pending_nac = 0;
+        self.pending_errors = 0;
+        self.encrypted = false;
         self.vocoder.reset();
     }
 
@@ -173,8 +182,15 @@ impl Decoder {
             self.countdown -= 1;
             if self.countdown == 0 {
                 if let Some(duid) = self.pending_duid.take() {
+                    let frames = self.metadata(duid);
                     if is_voice(duid) {
                         self.voice(duid, out);
+                    }
+                    for frame in frames {
+                        out.events.push(DecoderEvent::Dv(frame));
+                    }
+                    if matches!(duid, DUID_TERMINATOR | DUID_TERMINATOR_LC) {
+                        self.encrypted = false;
                     }
                     self.hunting = true;
                 } else if let Some((duid, frame)) = self.nid() {
@@ -226,12 +242,17 @@ impl Decoder {
             DUID_PDU => DvFrameKind::Data,
             _ => DvFrameKind::Voice,
         };
-        // Voice frames repeat; everything else is an event in its own right.
-        if kind == DvFrameKind::Voice && self.last_duid.is_some_and(is_voice) {
+        // Voice metadata is emitted after its protected LC/encryption fields decode. Reporting
+        // the NID first would create a second, less useful line for every LDU.
+        if kind == DvFrameKind::Voice {
             self.last_duid = Some(duid);
+            self.pending_nac = nac;
+            self.pending_errors = errors;
             return Some((duid, None));
         }
         self.last_duid = Some(duid);
+        self.pending_nac = nac;
+        self.pending_errors = errors;
 
         let mut frame = DvFrame::new(DvMode::P25, kind);
         frame.color_code = Some(nac);
@@ -261,8 +282,387 @@ impl Decoder {
             for (slot, pair) in dibits.iter_mut().zip(frame.as_chunks::<2>().0) {
                 *slot = u8::from(pair[0]) << 1 | u8::from(pair[1]);
             }
-            self.vocoder.decode_full_dibits(&dibits, false, out);
+            self.vocoder
+                .decode_full_dibits(&dibits, self.encrypted, out);
         }
+    }
+
+    fn logical_frame(&mut self, duid: u8) {
+        let total_symbols = frame_bits(duid) / 2;
+        self.window.bits(0, total_symbols, &mut self.bits);
+        self.logical.clear();
+        for (index, &bit) in self.bits.iter().enumerate() {
+            if index >= STATUS_START && (index - STATUS_START) % STATUS_STRIDE < 2 {
+                continue;
+            }
+            self.logical.push(bit);
+        }
+    }
+
+    fn metadata(&mut self, duid: u8) -> Vec<DvFrame> {
+        self.logical_frame(duid);
+        match duid {
+            DUID_HEADER => self.header_data_unit().into_iter().collect(),
+            DUID_LDU1 => self.ldu_link_control().into_iter().collect(),
+            DUID_LDU2 => self.ldu_encryption_sync().into_iter().collect(),
+            DUID_TSDU => self.trunking_blocks(),
+            DUID_PDU => vec![self.packet_data()],
+            _ => Vec::new(),
+        }
+    }
+
+    fn signalling_symbols(&self) -> Option<([u8; 24], u32)> {
+        const BODY_START: usize = SYNC_BITS as usize + NID_BITS;
+        let mut coded = Vec::with_capacity(240);
+        for &voice_index in &[1usize, 2, 3, 4, 5, 6] {
+            let start = BODY_START + (IMBE_OFFSETS[voice_index] + 72) * 2;
+            coded.extend_from_slice(self.logical.get(start..start + 40)?);
+        }
+        let mut symbols = [0u8; 24];
+        let mut errors = 0;
+        for (symbol, word) in symbols
+            .iter_mut()
+            .zip(coded.as_slice().as_chunks::<10>().0.iter())
+        {
+            let mut word = *word;
+            errors += ParityCode::HAMMING_10_6.decode(&mut word)?;
+            *symbol = bits_value(&word[..6]) as u8;
+        }
+        Some((symbols, errors))
+    }
+
+    fn ldu_link_control(&mut self) -> Option<DvFrame> {
+        let (symbols, hamming_errors) = self.signalling_symbols()?;
+        let (data, rs_errors) = rs64_decode(&symbols, 12)?;
+        let bits = symbols_to_bits(&data);
+        let mut frame = decode_p25_link_control(&bits);
+        frame.kind = DvFrameKind::Voice;
+        self.finish_metadata(&mut frame, hamming_errors + rs_errors);
+        if let Some(encrypted) = frame.encrypted {
+            self.encrypted = encrypted;
+        }
+        Some(frame)
+    }
+
+    fn ldu_encryption_sync(&mut self) -> Option<DvFrame> {
+        let (symbols, hamming_errors) = self.signalling_symbols()?;
+        let (data, rs_errors) = rs64_decode(&symbols, 16)?;
+        let bits = symbols_to_bits(&data);
+        let mut frame = DvFrame::new(DvMode::P25, DvFrameKind::Voice);
+        frame.opcode = Some("encryption synchronization".to_owned());
+        decode_encryption(&mut frame, &bits, 0);
+        self.encrypted = frame.encrypted == Some(true);
+        self.finish_metadata(&mut frame, hamming_errors + rs_errors);
+        self.encrypted.then_some(frame)
+    }
+
+    fn header_data_unit(&mut self) -> Option<DvFrame> {
+        const BODY_START: usize = SYNC_BITS as usize + NID_BITS;
+        let body = self.logical.get(BODY_START..BODY_START + 36 * 18)?;
+        let mut symbols = [0u8; 36];
+        let mut golay_errors = 0;
+        for (symbol, word) in symbols.iter_mut().zip(body.as_chunks::<18>().0.iter()) {
+            let received = word
+                .iter()
+                .fold(0u64, |value, &bit| value << 1 | u64::from(bit));
+            let (data, errors) = CyclicCode::GOLAY_18_6.decode(received)?;
+            *symbol = data as u8;
+            golay_errors += errors;
+        }
+        let (data, rs_errors) = rs64_decode(&symbols, 20)?;
+        let bits = symbols_to_bits(&data);
+        let mut frame = DvFrame::new(DvMode::P25, DvFrameKind::Header);
+        frame.opcode = Some("header data unit".to_owned());
+        decode_p25_vendor(&mut frame, bits_value(&bits[72..80]) as u8);
+        frame.message_indicator = Some(hex_bits(&bits[..72]));
+        frame.algorithm_id = Some(bits_value(&bits[80..88]) as u8);
+        frame.key_id = Some(bits_value(&bits[88..104]) as u16);
+        frame.encrypted = frame.algorithm_id.map(|algorithm| algorithm != 0x80);
+        frame.destination = Some(bits_value(&bits[104..120]));
+        frame.group_call = Some(true);
+        self.encrypted = frame.encrypted == Some(true);
+        self.finish_metadata(&mut frame, golay_errors + rs_errors);
+        Some(frame)
+    }
+
+    fn trunking_blocks(&self) -> Vec<DvFrame> {
+        const BODY_START: usize = SYNC_BITS as usize + NID_BITS;
+        let mut frames = Vec::new();
+        for block in 0..3 {
+            let start = BODY_START + block * 196;
+            let Some(coded) = self.logical.get(start..start + 196) else {
+                break;
+            };
+            let Some(payload) = decode_p25_trellis(coded) else {
+                continue;
+            };
+            let bytes: Vec<u8> = payload[..80]
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|byte| bits_value(byte) as u8)
+                .collect();
+            let found = bits_value(&payload[80..96]) as u16;
+            if crc16_msb(0x1021, 0, &bytes) ^ 0xFFFF != found {
+                continue;
+            }
+            let mut frame = decode_tsbk(&payload);
+            frame.color_code = Some(self.pending_nac);
+            frame.errors_corrected = self.pending_errors;
+            frames.push(frame);
+            if payload[0] {
+                break;
+            }
+        }
+        frames
+    }
+
+    fn packet_data(&self) -> DvFrame {
+        const BODY_START: usize = SYNC_BITS as usize + NID_BITS;
+        let mut frame = DvFrame::new(DvMode::P25, DvFrameKind::Data);
+        frame.opcode = Some("packet data unit".to_owned());
+        frame.data = Some(hex_bits(
+            &self.logical[BODY_START.min(self.logical.len())..],
+        ));
+        frame.color_code = Some(self.pending_nac);
+        frame.errors_corrected = self.pending_errors;
+        frame
+    }
+
+    fn finish_metadata(&self, frame: &mut DvFrame, errors: u32) {
+        frame.color_code = Some(self.pending_nac);
+        frame.errors_corrected = self.pending_errors + errors;
+    }
+}
+
+fn bits_value(bits: &[bool]) -> u32 {
+    bits.iter()
+        .fold(0u32, |value, &bit| value << 1 | u32::from(bit))
+}
+
+fn symbols_to_bits(symbols: &[u8]) -> Vec<bool> {
+    let mut bits = Vec::with_capacity(symbols.len() * 6);
+    for &symbol in symbols {
+        bits.extend((0..6).rev().map(|bit| symbol >> bit & 1 != 0));
+    }
+    bits
+}
+
+fn hex_bits(bits: &[bool]) -> String {
+    bits.chunks(4)
+        .map(|nibble| {
+            char::from_digit(
+                nibble
+                    .iter()
+                    .fold(0u32, |value, &bit| value << 1 | u32::from(bit)),
+                16,
+            )
+            .unwrap_or('0')
+        })
+        .collect()
+}
+
+fn decode_p25_vendor(frame: &mut DvFrame, mfid: u8) {
+    frame.manufacturer_id = Some(mfid);
+    frame.vendor = Some(match mfid {
+        0 => Vendor::Standard,
+        0x90 => Vendor::Motorola,
+        0xA4 => Vendor::Harris,
+        _ => Vendor::Unknown,
+    });
+}
+
+fn decode_p25_link_control(bits: &[bool]) -> DvFrame {
+    let lcf = bits_value(&bits[..8]) as u8;
+    let mfid = bits_value(&bits[8..16]) as u8;
+    let mut frame = DvFrame::new(DvMode::P25, DvFrameKind::Voice);
+    decode_p25_vendor(&mut frame, mfid);
+    if mfid != 0 {
+        frame.opcode = Some(format!(
+            "{} link control {lcf:02X}, unparsed",
+            frame.vendor.map_or("vendor", Vendor::label)
+        ));
+        frame.data = Some(hex_bits(&bits[16..72]));
+        return frame;
+    }
+    match lcf {
+        0 => {
+            frame.opcode = Some("group voice channel user".to_owned());
+            frame.group_call = Some(true);
+            frame.emergency = Some(bits[16]);
+            frame.encrypted = Some(bits[17]);
+            frame.destination = Some(bits_value(&bits[32..48]));
+            frame.source = Some(bits_value(&bits[48..72]));
+        }
+        3 => {
+            frame.opcode = Some("unit-to-unit voice channel user".to_owned());
+            frame.group_call = Some(false);
+            frame.emergency = Some(bits[16]);
+            frame.encrypted = Some(bits[17]);
+            frame.destination = Some(bits_value(&bits[24..48]));
+            frame.source = Some(bits_value(&bits[48..72]));
+        }
+        _ => frame.opcode = Some(format!("link control {lcf:02X}")),
+    }
+    frame
+}
+
+fn decode_encryption(frame: &mut DvFrame, bits: &[bool], offset: usize) {
+    frame.message_indicator = Some(hex_bits(&bits[offset..offset + 72]));
+    frame.algorithm_id = Some(bits_value(&bits[offset + 72..offset + 80]) as u8);
+    frame.key_id = Some(bits_value(&bits[offset + 80..offset + 96]) as u16);
+    frame.encrypted = frame.algorithm_id.map(|algorithm| algorithm != 0x80);
+}
+
+fn decode_p25_trellis(coded: &[bool]) -> Option<[bool; 96]> {
+    const OUTPUT: [[[u8; 2]; 4]; 4] = [
+        [[0, 2], [3, 0], [0, 1], [3, 3]],
+        [[3, 2], [0, 0], [3, 1], [0, 3]],
+        [[2, 1], [1, 3], [2, 2], [1, 0]],
+        [[1, 1], [2, 3], [1, 2], [2, 0]],
+    ];
+    let deinterleaved = p25_data_deinterleave(coded)?;
+    let dibits: Vec<u8> = deinterleaved
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|pair| u8::from(pair[0]) << 1 | u8::from(pair[1]))
+        .collect();
+    if dibits.len() != 98 {
+        return None;
+    }
+    let mut metric = [u16::MAX; 4];
+    metric[0] = 0;
+    let mut history = [[(0u8, 0u8); 4]; 49];
+    for step in 0..49 {
+        let observed = [dibits[step * 2], dibits[step * 2 + 1]];
+        let mut next = [u16::MAX; 4];
+        for (state, &cost) in metric.iter().enumerate() {
+            if cost == u16::MAX {
+                continue;
+            }
+            for input in 0..4 {
+                let expected = OUTPUT[state][input];
+                let distance =
+                    u16::from(expected[0] != observed[0]) + u16::from(expected[1] != observed[1]);
+                if cost + distance < next[input] {
+                    next[input] = cost + distance;
+                    history[step][input] = (state as u8, input as u8);
+                }
+            }
+        }
+        metric = next;
+    }
+    let mut state = 0usize;
+    let mut input = [0u8; 49];
+    for step in (0..49).rev() {
+        let (previous, value) = history[step][state];
+        input[step] = value;
+        state = usize::from(previous);
+    }
+    let mut payload = [false; 96];
+    for (pair, &dibit) in payload.as_chunks_mut::<2>().0.iter_mut().zip(&input[..48]) {
+        pair[0] = dibit & 2 != 0;
+        pair[1] = dibit & 1 != 0;
+    }
+    Some(payload)
+}
+
+/// Undo the 98-dibit P25 data interleave. Four adjacent bits remain a trellis symbol; the
+/// interleaver writes those symbols down four columns separated by 48 bits on the air.
+fn p25_data_deinterleave(coded: &[bool]) -> Option<[bool; 196]> {
+    let coded: &[bool; 196] = coded.try_into().ok()?;
+    let mut output = [false; 196];
+    let mut target = 0;
+    for row in 0..12 {
+        for base in [0, 52, 100, 148] {
+            output[target..target + 4].copy_from_slice(&coded[base + row * 4..base + row * 4 + 4]);
+            target += 4;
+        }
+    }
+    output[target..].copy_from_slice(&coded[48..52]);
+    Some(output)
+}
+
+fn decode_tsbk(payload: &[bool; 96]) -> DvFrame {
+    let opcode = bits_value(&payload[2..8]) as u8;
+    let mfid = bits_value(&payload[8..16]) as u8;
+    let mut frame = DvFrame::new(DvMode::P25, DvFrameKind::Control);
+    decode_p25_vendor(&mut frame, mfid);
+    if mfid != 0 {
+        frame.opcode = Some(format!(
+            "{} TSBK {opcode:02X}, unparsed",
+            frame.vendor.map_or("vendor", Vendor::label)
+        ));
+        frame.data = Some(hex_bits(&payload[16..80]));
+        return frame;
+    }
+    frame.opcode = Some(tsbk_name(opcode).to_owned());
+    match opcode {
+        0 => {
+            frame.group_call = Some(true);
+            frame.emergency = Some(payload[16]);
+            frame.encrypted = Some(payload[17]);
+            frame.channel = Some(bits_value(&payload[24..40]) as u16);
+            frame.destination = Some(bits_value(&payload[40..56]));
+            frame.source = Some(bits_value(&payload[56..80]));
+        }
+        2 => {
+            frame.group_call = Some(true);
+            frame.channel = Some(bits_value(&payload[16..32]) as u16);
+            frame.destination = Some(bits_value(&payload[32..48]));
+            frame.data = Some(format!(
+                "second channel {:04X}, TG {}",
+                bits_value(&payload[48..64]),
+                bits_value(&payload[64..80])
+            ));
+        }
+        3 => {
+            frame.group_call = Some(true);
+            frame.emergency = Some(payload[16]);
+            frame.encrypted = Some(payload[17]);
+            frame.channel = Some(bits_value(&payload[32..48]) as u16);
+            frame.destination = Some(bits_value(&payload[64..80]));
+            frame.data = Some(format!(
+                "receive channel {:04X}",
+                bits_value(&payload[48..64])
+            ));
+        }
+        4 => {
+            frame.group_call = Some(false);
+            frame.emergency = Some(payload[16]);
+            frame.encrypted = Some(payload[17]);
+            frame.channel = Some(bits_value(&payload[24..40]) as u16);
+            frame.destination = Some(bits_value(&payload[40..64]));
+            frame.data = Some(hex_bits(&payload[64..80]));
+        }
+        0x3A | 0x3C => {
+            if opcode == 0x3A {
+                frame.system_id = Some(bits_value(&payload[28..40]) as u16);
+            }
+            frame.site_id = Some(bits_value(&payload[48..56]) as u16);
+            frame.channel = Some(bits_value(&payload[56..72]) as u16);
+        }
+        0x3B => {
+            frame.network_id = Some(bits_value(&payload[24..44]));
+            frame.system_id = Some(bits_value(&payload[44..56]) as u16);
+            frame.channel = Some(bits_value(&payload[56..72]) as u16);
+        }
+        _ => frame.data = Some(hex_bits(&payload[16..80])),
+    }
+    frame
+}
+
+fn tsbk_name(opcode: u8) -> &'static str {
+    match opcode {
+        0 => "group voice channel grant",
+        2 => "group voice channel grant update",
+        3 => "group voice channel grant update explicit",
+        4 => "unit-to-unit voice channel grant",
+        0x3A => "RFSS status broadcast",
+        0x3B => "network status broadcast",
+        0x3C => "adjacent site status broadcast",
+        _ => "trunking signalling block",
     }
 }
 
@@ -327,6 +727,19 @@ mod tests {
         assert_eq!(header.kind, DvFrameKind::Header);
         assert_eq!(header.color_code, Some(0x293));
         assert_eq!(header.errors_corrected, 0);
+        let hdu = frames
+            .iter()
+            .find(|frame| frame.opcode.as_deref() == Some("header data unit"))
+            .expect("decoded HDU");
+        assert_eq!(hdu.destination, Some(0x1201));
+        assert_eq!(hdu.algorithm_id, Some(0x80));
+        assert_eq!(hdu.key_id, Some(0x1234));
+        let link_control = frames
+            .iter()
+            .find(|frame| frame.opcode.as_deref() == Some("group voice channel user"))
+            .expect("LDU1 link control");
+        assert_eq!(link_control.destination, Some(0x1201));
+        assert_eq!(link_control.source, Some(0xABCDEF));
         assert!(
             frames.iter().any(|f| f.kind == DvFrameKind::Terminator),
             "no terminator: {frames:?}"
@@ -348,10 +761,12 @@ mod tests {
         let frames = decode(&mut channel(), &iq);
         let control = frames
             .iter()
-            .find(|f| f.kind == DvFrameKind::Control)
-            .expect("trunking block");
+            .find(|frame| frame.opcode.as_deref() == Some("group voice channel grant"))
+            .expect("decoded TSBK");
         assert_eq!(control.color_code, Some(0x4D2));
-        assert_eq!(control.opcode.as_deref(), Some("trunking block"));
+        assert_eq!(control.channel, Some(0x1234));
+        assert_eq!(control.destination, Some(0x1201));
+        assert_eq!(control.source, Some(0xABCDEF));
     }
 
     #[test]
@@ -362,6 +777,24 @@ mod tests {
         let iq = tx::transmission_with_voice(0x293, &voice, INPUT_RATE_HZ);
         let (_, audio) = decode_with_audio(&mut channel(), &iq);
         assert_tone_audio(&audio, 18);
+    }
+
+    #[test]
+    fn encrypted_calls_report_identifiers_and_are_muted() {
+        let encoded = full_rate_frames(18);
+        let voice: [[[bool; 144]; 9]; 2] =
+            std::array::from_fn(|ldu| std::array::from_fn(|frame| encoded[ldu * 9 + frame]));
+        let iq = tx::encrypted_transmission(0x293, &voice, INPUT_RATE_HZ);
+        let (frames, audio) = decode_with_audio(&mut channel(), &iq);
+        let hdu = frames
+            .iter()
+            .find(|frame| frame.opcode.as_deref() == Some("header data unit"))
+            .expect("HDU encryption metadata");
+        assert_eq!(hdu.encrypted, Some(true));
+        assert_eq!(hdu.algorithm_id, Some(0x84));
+        assert_eq!(hdu.key_id, Some(0x1234));
+        assert!(!audio.is_empty());
+        assert!(audio.iter().all(|&sample| sample == 0.0));
     }
 
     #[test]

--- a/crates/channels/src/testgen/dv/dmr.rs
+++ b/crates/channels/src/testgen/dv/dmr.rs
@@ -10,6 +10,8 @@ use super::{bits, dibits, filler};
 /// Direct-mode slot 1 sync patterns, which name their timeslot on the wire.
 const VOICE_SYNC: u64 = 0x5D57_7F77_57FF;
 const DATA_SYNC: u64 = 0xF7FD_D5DD_FD55;
+const BS_VOICE_SYNC: u64 = 0x755F_D7DF_75F7;
+const BS_DATA_SYNC: u64 = 0xDFF5_7D75_DF5D;
 
 const DT_VOICE_LC_HEADER: u8 = 0x1;
 const DT_TERMINATOR_WITH_LC: u8 = 0x2;
@@ -67,13 +69,130 @@ impl Call {
 /// slot with the rest of the 60 ms TDMA frame dead, as a direct-mode radio transmits.
 #[must_use]
 pub fn transmission(call: &Call, rate: f64) -> Vec<Complex<f32>> {
-    let voice = std::array::from_fn(|_| {
+    let voice: [[bool; 216]; 6] = std::array::from_fn(|_| {
         let mut payload = [false; 216];
         payload[..108].copy_from_slice(&filler(108, u32::from(call.color_code) + 17));
         payload[108..].copy_from_slice(&filler(108, u32::from(call.color_code) + 23));
         payload
     });
     transmission_with_voice(call, &voice, rate)
+}
+
+/// A base-station transmission with a Golay/Hamming-protected CACH naming the repeater slot.
+#[must_use]
+pub fn repeater_transmission(call: &Call, slot: u8, rate: f64) -> Vec<Complex<f32>> {
+    repeater_calls(call, None, slot, rate)
+}
+
+/// Two simultaneous repeater calls, one state machine per timeslot.
+#[must_use]
+pub fn dual_slot_transmission(slot_one: &Call, slot_two: &Call, rate: f64) -> Vec<Complex<f32>> {
+    repeater_calls(slot_one, Some(slot_two), 1, rate)
+}
+
+fn repeater_calls(
+    first: &Call,
+    second: Option<&Call>,
+    first_slot: u8,
+    rate: f64,
+) -> Vec<Complex<f32>> {
+    let first_bursts = call_bursts(first);
+    let second_bursts = second.map(call_bursts);
+    let mut symbols = Vec::new();
+    symbols.extend(dibits(&filler(800, 73)).into_iter().map(Some));
+    for (index, first_burst) in first_bursts.iter().enumerate() {
+        append_repeater_burst(&mut symbols, first_burst, first_slot);
+        if let Some(second_bursts) = &second_bursts {
+            append_repeater_burst(&mut symbols, &second_bursts[index], 2);
+        } else {
+            symbols.extend(
+                dibits(&filler(288, 91 + index as u32))
+                    .into_iter()
+                    .map(Some),
+            );
+        }
+    }
+    symbols.extend(dibits(&filler(400, 101)).into_iter().map(Some));
+    Keyed { symbols }.modulate(rate)
+}
+
+fn call_bursts(call: &Call) -> Vec<Vec<bool>> {
+    let voice: [[bool; 216]; 6] = std::array::from_fn(|_| {
+        let mut payload = [false; 216];
+        payload[..108].copy_from_slice(&filler(108, u32::from(call.color_code) + 17));
+        payload[108..].copy_from_slice(&filler(108, u32::from(call.color_code) + 23));
+        payload
+    });
+    let mut bursts = vec![data_burst(
+        call,
+        DT_VOICE_LC_HEADER,
+        &lc_with_parity(call, [0x96, 0x96, 0x96]),
+    )];
+    let embedded = Bptc128::encode(&embedded_block(call));
+    bursts.push(voice_burst(call, None, &voice[0]));
+    for (i, lcss) in [0b01u8, 0b11, 0b11, 0b10].into_iter().enumerate() {
+        bursts.push(voice_burst(
+            call,
+            Some((lcss, embedded[i * 32..(i + 1) * 32].to_vec())),
+            &voice[i + 1],
+        ));
+    }
+    bursts.push(voice_burst(call, Some((0, vec![false; 32])), &voice[5]));
+    bursts.push(data_burst(
+        call,
+        DT_TERMINATOR_WITH_LC,
+        &lc_with_parity(call, [0x99, 0x99, 0x99]),
+    ));
+    bursts
+}
+
+fn append_repeater_burst(symbols: &mut Vec<Option<u8>>, burst: &[bool], slot: u8) {
+    let mut burst = burst.to_vec();
+    let sync = if burst[108..156] == bits(VOICE_SYNC, 48) {
+        BS_VOICE_SYNC
+    } else if burst[108..156] == bits(DATA_SYNC, 48) {
+        BS_DATA_SYNC
+    } else {
+        0
+    };
+    if sync != 0 {
+        burst[108..156].copy_from_slice(&bits(sync, 48));
+    }
+    symbols.extend(dibits(&cach(slot)).into_iter().map(Some));
+    symbols.extend(dibits(&burst).into_iter().map(Some));
+}
+
+fn cach(slot: u8) -> Vec<bool> {
+    let mut tact = [true, slot == 2, false, false, false, false, false];
+    sdrmm_dsp::ParityCode::HAMMING_7_4.encode(&mut tact);
+    let payload = [false; 17];
+    [
+        tact[0],
+        payload[0],
+        payload[1],
+        payload[2],
+        tact[1],
+        payload[3],
+        payload[4],
+        payload[5],
+        tact[2],
+        payload[6],
+        payload[7],
+        payload[8],
+        tact[3],
+        payload[9],
+        tact[4],
+        payload[10],
+        payload[11],
+        payload[12],
+        tact[5],
+        payload[13],
+        payload[14],
+        payload[15],
+        tact[6],
+        payload[16],
+    ]
+    .to_vec()
 }
 
 /// The same independently-framed transmission with caller-provided, already encoded vocoder
@@ -120,10 +239,24 @@ pub fn csbk(
     source: u32,
     rate: f64,
 ) -> Vec<Complex<f32>> {
+    csbk_with_fid(color_code, 0, opcode, destination, source, rate)
+}
+
+/// A CSBK in a manufacturer feature set, used to prove that an opcode collision never enters
+/// the standardized ETSI field parser.
+#[must_use]
+pub(crate) fn csbk_with_fid(
+    color_code: u8,
+    fid: u8,
+    opcode: u8,
+    destination: u32,
+    source: u32,
+    rate: f64,
+) -> Vec<Complex<f32>> {
     let mut payload = bits(u64::from(opcode) & 0x3F, 8);
     // Feature set id, then the sixteen opcode-specific bits every CSBK carries ahead of its
     // two addresses.
-    payload.extend(bits(0, 8));
+    payload.extend(bits(u64::from(fid), 8));
     payload.extend(bits(0, 16));
     payload.extend(bits(u64::from(destination), 24));
     payload.extend(bits(u64::from(source), 24));

--- a/crates/channels/src/testgen/dv/p25.rs
+++ b/crates/channels/src/testgen/dv/p25.rs
@@ -2,7 +2,7 @@
 //! symbols a transmitter interleaves into the frame, and filler for the rest.
 
 use num_complex::Complex;
-use sdrmm_dsp::CyclicCode;
+use sdrmm_dsp::{CyclicCode, ParityCode, crc16_msb, rs64_encode};
 
 use super::{bits, c4fm, dibits, filler};
 
@@ -26,7 +26,7 @@ fn frame_bits(duid: u8) -> usize {
 /// A transmission: header, two voice frames, terminator.
 #[must_use]
 pub fn transmission(nac: u16, rate: f64) -> Vec<Complex<f32>> {
-    transmission_inner(nac, None, rate)
+    transmission_inner(nac, None, 0x80, rate)
 }
 
 /// A transmission whose two LDUs contain caller-supplied Annex-H IMBE frames.
@@ -37,12 +37,22 @@ pub(crate) fn transmission_with_voice(
     voice: &[[[bool; 144]; 9]; 2],
     rate: f64,
 ) -> Vec<Complex<f32>> {
-    transmission_inner(nac, Some(voice), rate)
+    transmission_inner(nac, Some(voice), 0x80, rate)
+}
+
+#[must_use]
+pub fn encrypted_transmission(
+    nac: u16,
+    voice: &[[[bool; 144]; 9]; 2],
+    rate: f64,
+) -> Vec<Complex<f32>> {
+    transmission_inner(nac, Some(voice), 0x84, rate)
 }
 
 fn transmission_inner(
     nac: u16,
     voice: Option<&[[[bool; 144]; 9]; 2]>,
+    algorithm: u8,
     rate: f64,
 ) -> Vec<Complex<f32>> {
     let mut symbols = dibits(&filler(400, 31));
@@ -52,7 +62,13 @@ fn transmission_inner(
             2 => voice.map(|frames| &frames[1]),
             _ => None,
         };
-        symbols.extend(frame(nac, duid, voice));
+        if duid == 0x3 {
+            // Conventional transmitters may leave a short unkeyed/idle interval before the
+            // terminator; it also prevents the reference waveform's final LDU tail from being
+            // the only acquisition lead-in the terminator test sees.
+            symbols.extend(dibits(&filler(400, 89)));
+        }
+        symbols.extend(frame(nac, duid, voice, algorithm));
     }
     symbols.extend(dibits(&filler(200, 37)));
     c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
@@ -62,14 +78,14 @@ fn transmission_inner(
 #[must_use]
 pub fn trunking(nac: u16, rate: f64) -> Vec<Complex<f32>> {
     let mut symbols = dibits(&filler(400, 41));
-    symbols.extend(frame(nac, 0x7, None));
+    symbols.extend(frame(nac, 0x7, None, 0x80));
     symbols.extend(dibits(&filler(200, 43)));
     c4fm(&symbols, rate, BAUD, DEVIATION_HZ, RRC_ALPHA)
 }
 
 /// One frame: sync, network identifier, payload — with a status di-bit inserted after every 35
 /// payload di-bits, starting at bit 70.
-fn frame(nac: u16, duid: u8, voice: Option<&[[bool; 144]; 9]>) -> Vec<u8> {
+fn frame(nac: u16, duid: u8, voice: Option<&[[bool; 144]; 9]>, algorithm: u8) -> Vec<u8> {
     const IMBE_OFFSETS: [usize; 9] = [0, 72, 164, 256, 348, 440, 532, 624, 712];
     let total = frame_bits(duid);
     let status_count = total.saturating_sub(70).div_ceil(72);
@@ -89,6 +105,13 @@ fn frame(nac: u16, duid: u8, voice: Option<&[[bool; 144]; 9]>) -> Vec<u8> {
             body[start..start + 144].copy_from_slice(frame);
         }
     }
+    match duid {
+        0x0 => insert_hdu(&mut body, algorithm),
+        0x5 => insert_signalling(&mut body, &ldu1_symbols(algorithm != 0x80)),
+        0xA => insert_signalling(&mut body, &ldu2_symbols(algorithm)),
+        0x7 => insert_tsbk(&mut body),
+        _ => {}
+    }
 
     let mut out = Vec::with_capacity(total);
     let mut read = 0;
@@ -104,4 +127,130 @@ fn frame(nac: u16, duid: u8, voice: Option<&[[bool; 144]; 9]>) -> Vec<u8> {
     }
     assert_eq!(read, body.len());
     dibits(&out)
+}
+
+fn insert_hdu(frame: &mut [bool], algorithm: u8) {
+    let mut info = Vec::new();
+    info.extend(bits(0x0123_4567_89AB_CDEF, 64));
+    info.extend(bits(0x12, 8));
+    info.extend(bits(0, 8));
+    info.extend(bits(u64::from(algorithm), 8));
+    info.extend(bits(0x1234, 16));
+    info.extend(bits(0x1201, 16));
+    let data = six_bit_symbols(&info);
+    let codeword = rs64_encode(&data, 16);
+    let mut coded = Vec::with_capacity(648);
+    for symbol in codeword {
+        coded.extend(bits(CyclicCode::GOLAY_18_6.encode(u32::from(symbol)), 18));
+    }
+    frame[112..112 + coded.len()].copy_from_slice(&coded);
+}
+
+fn ldu1_symbols(encrypted: bool) -> Vec<u8> {
+    let mut lc = bits(0, 16);
+    lc.extend(bits(u64::from(encrypted) << 6, 8));
+    lc.extend(bits(0, 8));
+    lc.extend(bits(0x1201, 16));
+    lc.extend(bits(0xABCDEF, 24));
+    rs64_encode(&six_bit_symbols(&lc), 12)
+}
+
+fn ldu2_symbols(algorithm: u8) -> Vec<u8> {
+    let mut sync = bits(0x0123_4567_89AB_CDEF, 64);
+    sync.extend(bits(0x12, 8));
+    sync.extend(bits(u64::from(algorithm), 8));
+    sync.extend(bits(0x1234, 16));
+    rs64_encode(&six_bit_symbols(&sync), 8)
+}
+
+fn insert_signalling(frame: &mut [bool], symbols: &[u8]) {
+    const OFFSETS: [usize; 9] = [0, 72, 164, 256, 348, 440, 532, 624, 712];
+    let mut coded = Vec::with_capacity(240);
+    for &symbol in symbols {
+        let mut word = [false; 10];
+        for (index, bit) in word[..6].iter_mut().enumerate() {
+            *bit = symbol >> (5 - index) & 1 != 0;
+        }
+        ParityCode::HAMMING_10_6.encode(&mut word);
+        coded.extend(word);
+    }
+    for (chunk, voice_index) in coded.as_slice().as_chunks::<40>().0.iter().zip(1usize..=6) {
+        let start = 112 + (OFFSETS[voice_index] + 72) * 2;
+        frame[start..start + 40].copy_from_slice(chunk);
+    }
+}
+
+fn insert_tsbk(frame: &mut [bool]) {
+    let mut payload = bits(2, 2);
+    payload.extend(bits(0, 6));
+    payload.extend(bits(0, 8));
+    payload.extend(bits(0, 8));
+    payload.extend(bits(0x1234, 16));
+    payload.extend(bits(0x1201, 16));
+    payload.extend(bits(0xABCDEF, 24));
+    let bytes: Vec<u8> = payload
+        .as_slice()
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|byte| {
+            byte.iter()
+                .fold(0u8, |value, &bit| value << 1 | u8::from(bit))
+        })
+        .collect();
+    let crc = crc16_msb(0x1021, 0, &bytes) ^ 0xFFFF;
+    payload.extend(bits(u64::from(crc), 16));
+    let coded = data_interleave(&trellis_encode(&payload));
+    frame[112..308].copy_from_slice(&coded);
+}
+
+fn trellis_encode(payload: &[bool]) -> Vec<bool> {
+    const OUTPUT: [[[u8; 2]; 4]; 4] = [
+        [[0, 2], [3, 0], [0, 1], [3, 3]],
+        [[3, 2], [0, 0], [3, 1], [0, 3]],
+        [[2, 1], [1, 3], [2, 2], [1, 0]],
+        [[1, 1], [2, 3], [1, 2], [2, 0]],
+    ];
+    let mut state = 0usize;
+    let mut coded = Vec::with_capacity(196);
+    for input in payload
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|pair| u8::from(pair[0]) << 1 | u8::from(pair[1]))
+        .chain(std::iter::once(0))
+    {
+        for dibit in OUTPUT[state][usize::from(input)] {
+            coded.push(dibit & 2 != 0);
+            coded.push(dibit & 1 != 0);
+        }
+        state = usize::from(input);
+    }
+    coded
+}
+
+fn data_interleave(input: &[bool]) -> Vec<bool> {
+    assert_eq!(input.len(), 196);
+    let mut output = vec![false; 196];
+    let mut source = 0;
+    for row in 0..12 {
+        for base in [0, 52, 100, 148] {
+            output[base + row * 4..base + row * 4 + 4].copy_from_slice(&input[source..source + 4]);
+            source += 4;
+        }
+    }
+    output[48..52].copy_from_slice(&input[source..]);
+    output
+}
+
+fn six_bit_symbols(data: &[bool]) -> Vec<u8> {
+    data.as_chunks::<6>()
+        .0
+        .iter()
+        .map(|symbol| {
+            symbol
+                .iter()
+                .fold(0u8, |value, &bit| value << 1 | u8::from(bit))
+        })
+        .collect()
 }

--- a/crates/dsp/src/fec/block.rs
+++ b/crates/dsp/src/fec/block.rs
@@ -28,6 +28,12 @@ pub struct ParityCode {
 }
 
 impl ParityCode {
+    /// Hamming(7,4,3) protecting the DMR CACH TACT field.
+    pub const HAMMING_7_4: Self = Self {
+        k: 4,
+        parity: &[0b0111, 0b1110, 0b1011],
+    };
+
     /// Hamming(13,9,3) — the columns of a DMR BPTC(196,96) block (ETSI TS 102 361-1 B.3.11).
     pub const HAMMING_13_9: Self = Self {
         k: 9,
@@ -177,6 +183,14 @@ impl CyclicCode {
         correctable: 3,
     };
 
+    /// Golay(18,6,8) protecting each six-bit symbol in a P25 header data unit.
+    pub const GOLAY_18_6: Self = Self {
+        k: 6,
+        parity: 11,
+        generator: 0xC75,
+        correctable: 3,
+    };
+
     /// QR(16,7,6) — the DMR embedded signalling field in a voice burst (B.3.4). Corrects two.
     pub const QR_16_7: Self = Self {
         k: 7,
@@ -284,6 +298,7 @@ mod tests {
     #[test]
     fn the_hamming_family_has_its_published_distances() {
         assert_eq!(min_distance_parity(&ParityCode::HAMMING_13_9), 3);
+        assert_eq!(min_distance_parity(&ParityCode::HAMMING_7_4), 3);
         assert_eq!(min_distance_parity(&ParityCode::HAMMING_15_11), 3);
         assert_eq!(min_distance_parity(&ParityCode::HAMMING_16_11), 4);
         assert_eq!(min_distance_parity(&ParityCode::HAMMING_10_6), 3);
@@ -293,6 +308,7 @@ mod tests {
     #[test]
     fn parity_codes_repair_any_single_bit() {
         for code in [
+            ParityCode::HAMMING_7_4,
             ParityCode::HAMMING_13_9,
             ParityCode::HAMMING_15_11,
             ParityCode::HAMMING_16_11,

--- a/crates/dsp/src/fec/mod.rs
+++ b/crates/dsp/src/fec/mod.rs
@@ -103,6 +103,173 @@ pub fn rs129_parity(msg: &[u8]) -> [u8; 3] {
     [parity[2], parity[1], parity[0]]
 }
 
+/// Systematic Reed-Solomon code over GF(64), the symbol code used by P25 HDU and LDU metadata.
+/// `parity_symbols` is 12 for RS(24,12,13), 8 for RS(24,16,9), and 16 for RS(36,20,17).
+#[must_use]
+pub fn rs64_encode(data: &[u8], parity_symbols: usize) -> Vec<u8> {
+    let mut generator = vec![1u8];
+    for root in 1..=parity_symbols {
+        let mut next = vec![0u8; generator.len() + 1];
+        for (index, &coefficient) in generator.iter().enumerate() {
+            next[index] ^= coefficient;
+            next[index + 1] ^= gf64_mul(coefficient, gf64_pow(2, root as i32));
+        }
+        generator = next;
+    }
+    let mut codeword: Vec<u8> = data.iter().map(|symbol| symbol & 0x3F).collect();
+    codeword.resize(data.len() + parity_symbols, 0);
+    for index in 0..data.len() {
+        let coefficient = codeword[index];
+        if coefficient == 0 {
+            continue;
+        }
+        for (offset, &factor) in generator.iter().enumerate() {
+            codeword[index + offset] ^= gf64_mul(factor, coefficient);
+        }
+    }
+    codeword[..data.len()].copy_from_slice(data);
+    codeword
+}
+
+/// Correct a P25 GF(64) Reed-Solomon codeword and return its systematic data symbols plus the
+/// number of repaired symbols. Invalid or over-capacity words are rejected.
+#[must_use]
+pub fn rs64_decode(codeword: &[u8], data_symbols: usize) -> Option<(Vec<u8>, u32)> {
+    let parity = codeword.len().checked_sub(data_symbols)?;
+    if parity == 0 || parity >= 32 || codeword.len() > 63 {
+        return None;
+    }
+    let mut corrected: Vec<u8> = codeword.iter().map(|symbol| symbol & 0x3F).collect();
+    let mut syndromes = rs64_syndromes(&corrected, parity);
+    if syndromes.iter().all(|&value| value == 0) {
+        return Some((corrected[..data_symbols].to_vec(), 0));
+    }
+
+    // Berlekamp-Massey, with locator coefficients in ascending polynomial order.
+    let mut locator = vec![0u8; parity + 1];
+    let mut previous = vec![0u8; parity + 1];
+    locator[0] = 1;
+    previous[0] = 1;
+    let (mut degree, mut shift, mut discrepancy_at_update) = (0usize, 1usize, 1u8);
+    for n in 0..parity {
+        let mut discrepancy = syndromes[n];
+        for i in 1..=degree {
+            discrepancy ^= gf64_mul(locator[i], syndromes[n - i]);
+        }
+        if discrepancy == 0 {
+            shift += 1;
+            continue;
+        }
+        let saved = locator.clone();
+        let scale = gf64_mul(discrepancy, gf64_inv(discrepancy_at_update)?);
+        for i in 0..=parity - shift {
+            locator[i + shift] ^= gf64_mul(scale, previous[i]);
+        }
+        if 2 * degree <= n {
+            degree = n + 1 - degree;
+            previous = saved;
+            discrepancy_at_update = discrepancy;
+            shift = 1;
+        } else {
+            shift += 1;
+        }
+    }
+    if degree == 0 || degree > parity / 2 {
+        return None;
+    }
+
+    let mut positions = Vec::with_capacity(degree);
+    let mut powers = Vec::with_capacity(degree);
+    for position in 0..corrected.len() {
+        let power = corrected.len() - 1 - position;
+        let root = gf64_pow(2, -(power as i32));
+        if gf64_eval_ascending(&locator[..=degree], root) == 0 {
+            positions.push(position);
+            powers.push(power);
+        }
+    }
+    if positions.len() != degree {
+        return None;
+    }
+
+    // Solve the first `degree` syndrome equations for the error magnitudes.
+    let mut matrix = vec![vec![0u8; degree + 1]; degree];
+    for row in 0..degree {
+        for (column, &power) in powers.iter().enumerate() {
+            matrix[row][column] = gf64_pow(2, ((row + 1) * power) as i32);
+        }
+        matrix[row][degree] = syndromes[row];
+    }
+    for column in 0..degree {
+        let pivot = (column..degree).find(|&row| matrix[row][column] != 0)?;
+        matrix.swap(column, pivot);
+        let inverse = gf64_inv(matrix[column][column])?;
+        for value in &mut matrix[column][column..=degree] {
+            *value = gf64_mul(*value, inverse);
+        }
+        let pivot_row = matrix[column][column..=degree].to_vec();
+        for (row, target_row) in matrix.iter_mut().enumerate() {
+            if row == column {
+                continue;
+            }
+            let scale = target_row[column];
+            for (value, &pivot_value) in target_row[column..=degree].iter_mut().zip(&pivot_row) {
+                *value ^= gf64_mul(scale, pivot_value);
+            }
+        }
+    }
+    for (row, &position) in positions.iter().enumerate() {
+        corrected[position] ^= matrix[row][degree];
+    }
+    syndromes = rs64_syndromes(&corrected, parity);
+    if syndromes.iter().any(|&value| value != 0) {
+        return None;
+    }
+    Some((corrected[..data_symbols].to_vec(), degree as u32))
+}
+
+fn rs64_syndromes(codeword: &[u8], count: usize) -> Vec<u8> {
+    (1..=count)
+        .map(|root| {
+            let x = gf64_pow(2, root as i32);
+            codeword
+                .iter()
+                .fold(0, |value, &symbol| gf64_mul(value, x) ^ symbol)
+        })
+        .collect()
+}
+
+fn gf64_eval_ascending(poly: &[u8], x: u8) -> u8 {
+    poly.iter()
+        .rev()
+        .fold(0, |value, &coefficient| gf64_mul(value, x) ^ coefficient)
+}
+
+fn gf64_mul(a: u8, b: u8) -> u8 {
+    let (mut a, mut b, mut product) = (a & 0x3F, b & 0x3F, 0u8);
+    while b != 0 {
+        if b & 1 != 0 {
+            product ^= a;
+        }
+        let high = a & 0x20 != 0;
+        a <<= 1;
+        if high {
+            a ^= 0x43;
+        }
+        b >>= 1;
+    }
+    product & 0x3F
+}
+
+fn gf64_pow(base: u8, exponent: i32) -> u8 {
+    let exponent = exponent.rem_euclid(63);
+    (0..exponent).fold(1, |value, _| gf64_mul(value, base))
+}
+
+fn gf64_inv(value: u8) -> Option<u8> {
+    (value != 0).then(|| gf64_pow(value, 62))
+}
+
 /// GF(256) multiply modulo `x⁸ + x⁴ + x³ + x² + 1`.
 fn gf256_mul(a: u8, b: u8) -> u8 {
     let (mut a, mut b, mut product) = (a, b, 0u8);
@@ -446,6 +613,25 @@ pub fn rds_encode_block(data: u16, offset: RdsOffset) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn p25_reed_solomon_corrects_to_each_codes_capacity() {
+        for (data_symbols, parity_symbols) in [(12, 12), (16, 8), (20, 16)] {
+            let data: Vec<u8> = (0..data_symbols)
+                .map(|index| (index * 7 + 3) as u8 & 0x3F)
+                .collect();
+            let clean = rs64_encode(&data, parity_symbols);
+            assert_eq!(rs64_decode(&clean, data_symbols), Some((data.clone(), 0)));
+            let mut damaged = clean;
+            for index in 0..parity_symbols / 2 {
+                damaged[index * 2] ^= (index as u8 + 1) & 0x3F;
+            }
+            assert_eq!(
+                rs64_decode(&damaged, data_symbols),
+                Some((data, (parity_symbols / 2) as u32))
+            );
+        }
+    }
 
     const RDS_OFFSETS: [RdsOffset; 5] = [
         RdsOffset::A,

--- a/crates/dsp/src/lib.rs
+++ b/crates/dsp/src/lib.rs
@@ -37,7 +37,7 @@ pub use fec::{
     crc16_ccitt, crc16_msb, crc16_msb_bits, crc16_x25, golay23_encode, golay23_ok, hdlc_fcs_ok,
     mode_s_append_overlaid_parity, mode_s_append_parity, mode_s_fix_single_bit, mode_s_overlay,
     mode_s_syndrome, pocsag_bch_decode, pocsag_bch_encode, rds_check_block, rds_encode_block,
-    rds_syndrome, rs129_parity,
+    rds_syndrome, rs64_decode, rs64_encode, rs129_parity,
 };
 pub use fir::{design_bandpass, design_gaussian, design_lowpass, design_rrc};
 pub use firc::FirC;

--- a/crates/wire/src/decode.rs
+++ b/crates/wire/src/decode.rs
@@ -398,6 +398,53 @@ pub enum DvFrameKind {
     Data,
 }
 
+/// Manufacturer feature set carried by DMR FID and P25 MFID fields.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Vendor {
+    Standard,
+    Etsi,
+    Motorola,
+    Hytera,
+    Harris,
+    Tait,
+    JvcKenwood,
+    Emc,
+    RadioActivity,
+    FlydeMicro,
+    ProdEl,
+    Unknown,
+}
+
+impl Vendor {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Etsi => "ETSI",
+            Self::Motorola => "Motorola",
+            Self::Hytera => "Hytera",
+            Self::Harris => "Harris",
+            Self::Tait => "Tait",
+            Self::JvcKenwood => "JVCKENWOOD",
+            Self::Emc => "EMC",
+            Self::RadioActivity => "Radio Activity",
+            Self::FlydeMicro => "Flyde Micro",
+            Self::ProdEl => "PROD-EL",
+            Self::Unknown => "unknown vendor",
+        }
+    }
+}
+
+/// Activity advertised for one DMR timeslot by a Short LC activity update.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DvSlotActivity {
+    pub slot: u8,
+    pub activity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_hash: Option<u8>,
+}
+
 /// One decoded digital-voice frame — the metadata of a call. Audio travels through the channel's
 /// PCM output rather than inside this event.
 ///
@@ -417,6 +464,12 @@ pub struct DvFrame {
     /// NXDN/dPMR RAN or colour code, P25 NAC, YSF has none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color_code: Option<u16>,
+    /// Vendor selected by a DMR feature-set ID or P25 manufacturer ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<Vendor>,
+    /// Raw DMR FID or P25 MFID. One manufacturer may own several feature sets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manufacturer_id: Option<u8>,
     /// True for a talkgroup call, false for a call addressed to one radio.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group_call: Option<bool>,
@@ -438,6 +491,41 @@ pub struct DvFrame {
     /// that it is in the clear; `None` means the frame did not say.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub algorithm_id: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<u16>,
+    /// P25 encryption message indicator as the 72-bit hexadecimal value on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_indicator: Option<String>,
+    /// DMR talker alias assembled from its header and continuation LCs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub talker_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lat: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lon: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position_error_m: Option<u32>,
+    /// Logical or absolute channel number named by trunking signalling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<u16>,
+    /// Capacity Plus logical slot number carrying the rest channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rest_channel: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_id: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_id: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub site_id: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emergency: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slot_activity: Vec<DvSlotActivity>,
+    /// Decoded packet text, or hexadecimal when its application format is not understood.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
     /// Name of the signalling opcode for a control frame — "group voice channel grant",
     /// "preamble", … — as its specification names it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -654,6 +742,12 @@ impl DecoderEvent {
                 if let Some(parties) = f.parties() {
                     parts.push(parties);
                 }
+                if let Some(alias) = &f.talker_alias {
+                    parts.push(alias.clone());
+                }
+                if let Some(vendor) = f.vendor {
+                    parts.push(vendor.label().to_owned());
+                }
                 if let Some(via) = &f.via {
                     parts.push(format!("via {via}"));
                 }
@@ -661,7 +755,12 @@ impl DecoderEvent {
                     parts.push(opcode.clone());
                 }
                 if f.encrypted == Some(true) {
-                    parts.push("encrypted".to_owned());
+                    parts.push(match (f.algorithm_id, f.key_id) {
+                        (Some(algorithm), Some(key)) => {
+                            format!("encrypted ALG {algorithm:02X} KID {key:04X}")
+                        }
+                        _ => "encrypted".to_owned(),
+                    });
                 }
                 if let Some(text) = &f.text {
                     parts.push(text.clone());
@@ -679,6 +778,7 @@ impl DecoderEvent {
             Self::Adsb(a) => (a.lat, a.lon),
             Self::Ais(m) => (m.lat, m.lon),
             Self::Aprs(p) => (p.lat, p.lon),
+            Self::Dv(f) => (f.lat, f.lon),
             _ => (None, None),
         };
         lat.zip(lon)

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -33,8 +33,8 @@ pub use channel::{
 };
 pub use decode::{
     AcarsMessage, AdsbMessage, AisMessage, AprsPacket, DecodedRecord, DecoderEvent, DvFrame,
-    DvFrameKind, DvMode, MorseText, NavtexMessage, PocsagMessage, PocsagPayload, RdsUpdate,
-    RttyText, SubghzEncoding, SubghzFrame, ToneSquelchStatus,
+    DvFrameKind, DvMode, DvSlotActivity, MorseText, NavtexMessage, PocsagMessage, PocsagPayload,
+    RdsUpdate, RttyText, SubghzEncoding, SubghzFrame, ToneSquelchStatus, Vendor,
 };
 pub use device::{
     Capabilities, DeviceInfo, DeviceSettings, Direction, Duplex, ExtraSetting, ExtraValue,

--- a/openapi.json
+++ b/openapi.json
@@ -4544,6 +4544,23 @@
           "errors_corrected"
         ],
         "properties": {
+          "algorithm_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "channel": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Logical or absolute channel number named by trunking signalling.",
+            "minimum": 0
+          },
           "color_code": {
             "type": [
               "integer",
@@ -4552,6 +4569,13 @@
             "format": "int32",
             "description": "The mode's network discriminator, under whichever name it publishes: DMR colour code,\nNXDN/dPMR RAN or colour code, P25 NAC, YSF has none.",
             "minimum": 0
+          },
+          "data": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Decoded packet text, or hexadecimal when its application format is not understood."
           },
           "destination": {
             "type": [
@@ -4565,6 +4589,12 @@
           "destination_call": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "emergency": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -4588,11 +4618,57 @@
             ],
             "description": "True for a talkgroup call, false for a call addressed to one radio."
           },
+          "key_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
           "kind": {
             "$ref": "#/components/schemas/DvFrameKind"
           },
+          "lat": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "lon": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "manufacturer_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Raw DMR FID or P25 MFID. One manufacturer may own several feature sets.",
+            "minimum": 0
+          },
+          "message_indicator": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "P25 encryption message indicator as the 72-bit hexadecimal value on the wire."
+          },
           "mode": {
             "$ref": "#/components/schemas/DvMode"
+          },
+          "network_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
           },
           "opcode": {
             "type": [
@@ -4600,6 +4676,31 @@
               "null"
             ],
             "description": "Name of the signalling opcode for a control frame — \"group voice channel grant\",\n\"preamble\", … — as its specification names it."
+          },
+          "position_error_m": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "rest_channel": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Capacity Plus logical slot number carrying the rest channel.",
+            "minimum": 0
+          },
+          "site_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
           },
           "slot": {
             "type": [
@@ -4609,6 +4710,12 @@
             "format": "int32",
             "description": "TDMA timeslot, 1 or 2 — DMR only; every other mode here is single-slot.",
             "minimum": 0
+          },
+          "slot_activity": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DvSlotActivity"
+            }
           },
           "source": {
             "type": [
@@ -4626,12 +4733,38 @@
             ],
             "description": "Source callsign — the modes that address by callsign rather than by number."
           },
+          "system_id": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "talker_alias": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "DMR talker alias assembled from its header and continuation LCs."
+          },
           "text": {
             "type": [
               "string",
               "null"
             ],
             "description": "Free text the frame carried: a D-Star slow-data message, a YSF radio ID, an M17 meta\nfield."
+          },
+          "vendor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Vendor",
+                "description": "Vendor selected by a DMR feature-set ID or P25 manufacturer ID."
+              }
+            ]
           },
           "via": {
             "type": [
@@ -4665,6 +4798,32 @@
           "dpmr",
           "m17"
         ]
+      },
+      "DvSlotActivity": {
+        "type": "object",
+        "description": "Activity advertised for one DMR timeslot by a Short LC activity update.",
+        "required": [
+          "slot",
+          "activity"
+        ],
+        "properties": {
+          "activity": {
+            "type": "string"
+          },
+          "destination_hash": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "slot": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
       },
       "ExportFormat": {
         "type": "string",
@@ -7158,6 +7317,24 @@
             ]
           }
         }
+      },
+      "Vendor": {
+        "type": "string",
+        "description": "Manufacturer feature set carried by DMR FID and P25 MFID fields.",
+        "enum": [
+          "standard",
+          "etsi",
+          "motorola",
+          "hytera",
+          "harris",
+          "tait",
+          "jvc_kenwood",
+          "emc",
+          "radio_activity",
+          "flyde_micro",
+          "prod_el",
+          "unknown"
+        ]
       },
       "WfmParams": {
         "type": "object",

--- a/web/src/components/decoderDetail.test.ts
+++ b/web/src/components/decoderDetail.test.ts
@@ -218,6 +218,44 @@ describe("eventDetail", () => {
     expect(silent).not.toHaveProperty("Encrypted");
   });
 
+  it("exposes DMR and P25 metadata and keeps packet data readable", () => {
+    const detail = eventDetail({
+      kind: "dv",
+      data: {
+        mode: "dmr",
+        kind: "control",
+        errors_corrected: 2,
+        vendor: "hytera",
+        manufacturer_id: 8,
+        talker_alias: "Dispatcher",
+        lat: 52.52,
+        lon: 13.405,
+        position_error_m: 20,
+        channel: 407,
+        emergency: true,
+        algorithm_id: 5,
+        key_id: 42,
+        message_indicator: "001122334455667788",
+        slot_activity: [{ slot: 2, activity: "group voice", destination_hash: 0xab }],
+        data: "A1B2C3",
+      },
+    });
+    expect(Object.fromEntries(detail.fields)).toMatchObject({
+      Vendor: "Hytera (0x08)",
+      "Talker alias": "Dispatcher",
+      Position: "52.52000, 13.40500",
+      "Position error": "≤ 20 m",
+      Channel: "407",
+      Emergency: "yes",
+      "Slot activity": "TS2 group voice (hash 0xAB)",
+      Algorithm: "0x05",
+      "Key ID": "0x002A",
+      "Message indicator": "001122334455667788",
+      Repaired: "2 bits",
+    });
+    expect(detail.body).toBe("A1B2C3");
+  });
+
   it("reads an RDS picture as its fields, with the radiotext as the body", () => {
     const detail = eventDetail({
       kind: "rds",

--- a/web/src/components/decoderDetail.ts
+++ b/web/src/components/decoderDetail.ts
@@ -173,18 +173,68 @@ const DETAIL: {
       ["Mode", dvMode(f)],
       ["Frame", dvKind(f)],
       ["Network", dvNetwork(f)],
+      ["Vendor", dvVendor(f)],
       ["Parties", dvParties(f)],
+      ["Talker alias", f.talker_alias],
       ["Call", f.group_call == null ? undefined : f.group_call ? "talkgroup" : "private"],
       ["Via", f.via],
       ["Signalling", f.opcode],
+      ["Position", position(f.lat, f.lon)],
+      ["Position error", f.position_error_m == null ? undefined : `≤ ${f.position_error_m} m`],
+      ["Channel", f.channel == null ? undefined : String(f.channel)],
+      ["Rest channel", f.rest_channel == null ? undefined : String(f.rest_channel)],
+      ["Network ID", f.network_id == null ? undefined : String(f.network_id)],
+      ["System ID", f.system_id == null ? undefined : String(f.system_id)],
+      ["Site ID", f.site_id == null ? undefined : String(f.site_id)],
+      ["Emergency", flag(f.emergency)],
+      ["Slot activity", slotActivity(f)],
       // `Some(false)` is a positive statement that the payload is in the clear; absent means the
       // frame did not say, which is not the same thing.
       ["Encrypted", flag(f.encrypted)],
+      ["Algorithm", f.algorithm_id == null ? undefined : hex(f.algorithm_id, 2)],
+      ["Key ID", f.key_id == null ? undefined : hex(f.key_id, 4)],
+      ["Message indicator", f.message_indicator],
       ["Repaired", f.errors_corrected > 0 ? `${f.errors_corrected} bits` : undefined],
     ]),
-    body: f.text ?? null,
+    body: f.text ?? f.data ?? null,
   }),
 };
+
+function dvVendor(frame: DvFrame): string | undefined {
+  if (frame.vendor == null) return undefined;
+  const names: Record<NonNullable<DvFrame["vendor"]>, string> = {
+    standard: "standard",
+    etsi: "ETSI",
+    motorola: "Motorola",
+    hytera: "Hytera",
+    harris: "Harris",
+    tait: "Tait",
+    jvc_kenwood: "JVCKENWOOD",
+    emc: "EMC",
+    radio_activity: "Radio Activity",
+    flyde_micro: "Flyde Micro",
+    prod_el: "PROD-EL",
+    unknown: "unknown vendor",
+  };
+  const mfid = frame.manufacturer_id == null ? "" : ` (${hex(frame.manufacturer_id, 2)})`;
+  return `${names[frame.vendor]}${mfid}`;
+}
+
+function slotActivity(frame: DvFrame): string | undefined {
+  if (frame.slot_activity == null || frame.slot_activity.length === 0) return undefined;
+  return frame.slot_activity
+    .map(
+      (item) =>
+        `TS${item.slot} ${item.activity}${
+          item.destination_hash == null ? "" : ` (hash ${hex(item.destination_hash, 2)})`
+        }`,
+    )
+    .join(", ");
+}
+
+function hex(value: number, width: number): string {
+  return `0x${value.toString(16).toUpperCase().padStart(width, "0")}`;
+}
 
 /** What the frame was: the words a scanner shows rather than the specification's field names. */
 function dvKind(frame: Pick<DvFrame, "kind">): string {

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -1673,18 +1673,28 @@ export interface components {
          *     talkgroup, a DMR voice header the reverse.
          */
         DvFrame: {
+            /** Format: int32 */
+            algorithm_id?: number | null;
+            /**
+             * Format: int32
+             * @description Logical or absolute channel number named by trunking signalling.
+             */
+            channel?: number | null;
             /**
              * Format: int32
              * @description The mode's network discriminator, under whichever name it publishes: DMR colour code,
              *     NXDN/dPMR RAN or colour code, P25 NAC, YSF has none.
              */
             color_code?: number | null;
+            /** @description Decoded packet text, or hexadecimal when its application format is not understood. */
+            data?: string | null;
             /**
              * Format: int32
              * @description Numeric destination: talkgroup for a group call, radio ID for a private one.
              */
             destination?: number | null;
             destination_call?: string | null;
+            emergency?: boolean | null;
             /**
              * @description Set when the frame says its payload is encrypted. `Some(false)` is a positive statement
              *     that it is in the clear; `None` means the frame did not say.
@@ -1698,18 +1708,43 @@ export interface components {
             errors_corrected: number;
             /** @description True for a talkgroup call, false for a call addressed to one radio. */
             group_call?: boolean | null;
+            /** Format: int32 */
+            key_id?: number | null;
             kind: components["schemas"]["DvFrameKind"];
+            /** Format: double */
+            lat?: number | null;
+            /** Format: double */
+            lon?: number | null;
+            /**
+             * Format: int32
+             * @description Raw DMR FID or P25 MFID. One manufacturer may own several feature sets.
+             */
+            manufacturer_id?: number | null;
+            /** @description P25 encryption message indicator as the 72-bit hexadecimal value on the wire. */
+            message_indicator?: string | null;
             mode: components["schemas"]["DvMode"];
+            /** Format: int32 */
+            network_id?: number | null;
             /**
              * @description Name of the signalling opcode for a control frame — "group voice channel grant",
              *     "preamble", … — as its specification names it.
              */
             opcode?: string | null;
+            /** Format: int32 */
+            position_error_m?: number | null;
+            /**
+             * Format: int32
+             * @description Capacity Plus logical slot number carrying the rest channel.
+             */
+            rest_channel?: number | null;
+            /** Format: int32 */
+            site_id?: number | null;
             /**
              * Format: int32
              * @description TDMA timeslot, 1 or 2 — DMR only; every other mode here is single-slot.
              */
             slot?: number | null;
+            slot_activity?: components["schemas"]["DvSlotActivity"][];
             /**
              * Format: int32
              * @description Numeric source address — DMR/NXDN/dPMR radio ID, P25 source unit.
@@ -1717,11 +1752,16 @@ export interface components {
             source?: number | null;
             /** @description Source callsign — the modes that address by callsign rather than by number. */
             source_call?: string | null;
+            /** Format: int32 */
+            system_id?: number | null;
+            /** @description DMR talker alias assembled from its header and continuation LCs. */
+            talker_alias?: string | null;
             /**
              * @description Free text the frame carried: a D-Star slow-data message, a YSF radio ID, an M17 meta
              *     field.
              */
             text?: string | null;
+            vendor?: null | components["schemas"]["Vendor"];
             /** @description The repeater or reflector the call is routed through: D-Star RPT1/RPT2. */
             via?: string | null;
         };
@@ -1739,6 +1779,14 @@ export interface components {
          * @enum {string}
          */
         DvMode: "dmr" | "dstar" | "ysf" | "nxdn" | "p25" | "dpmr" | "m17";
+        /** @description Activity advertised for one DMR timeslot by a Short LC activity update. */
+        DvSlotActivity: {
+            activity: string;
+            /** Format: int32 */
+            destination_hash?: number | null;
+            /** Format: int32 */
+            slot: number;
+        };
         /**
          * @description Export format for `GET /api/decoderlog/export/{format}` (PLAN §11: CSV/JSON). It is a
          *     path segment, not a query field: `serde_urlencoded` cannot flatten a struct, so sharing
@@ -2931,6 +2979,11 @@ export interface components {
             revision: number;
             snapshot?: null | components["schemas"]["WorkspaceSnapshot"];
         };
+        /**
+         * @description Manufacturer feature set carried by DMR FID and P25 MFID fields.
+         * @enum {string}
+         */
+        Vendor: "standard" | "etsi" | "motorola" | "hytera" | "harris" | "tait" | "jvc_kenwood" | "emc" | "radio_activity" | "flyde_micro" | "prod_el" | "unknown";
         WfmParams: {
             /**
              * Format: float


### PR DESCRIPTION
## Summary

- gate DMR CSBK address extraction on FID and add shared vendor-aware wire dispatch
- decode DMR talker aliases, GPS, PI metadata, data headers/blocks, CACH slot TACT, Short LC, per-slot state, Tier III grants, and selected Capacity Plus, Connect Plus, and Hytera XPT fields
- decode P25 HDU/LDU1/LDU2 protected metadata, encryption identifiers and muting, MFID-gated link control, interleaved trellis/CRC TSBKs, and retain PDU payload data
- expose all new metadata through DvFrame, OpenAPI/generated TypeScript, decoder details, summaries, and map coordinates

Unknown or undocumented proprietary payloads remain explicitly marked unparsed and are retained as raw hexadecimal data instead of applying standard field offsets.

## Validation

- cargo test -p sdrmm-dsp -p sdrmm-wire -p sdrmm-channels (633 passed; 6 long measurement probes ignored)
- cargo clippy -p sdrmm-dsp -p sdrmm-wire -p sdrmm-channels --all-targets --all-features -- -D warnings
- pnpm --dir web run test (413 passed)
- pnpm --dir web run typecheck
- pnpm --dir web run lint
- cargo xtask codegen
- cargo fmt --all -- --check