### PR TITLE
Keep queued workspace edits across refetches

### DIFF
--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -7,7 +7,15 @@
 // workspace it leaves, which the single worker and the throwaway database below make sound.
 import { expect, type Locator, type Page, test } from "@playwright/test";
 // The state shape is generated from the server's OpenAPI, like everywhere else (CLAUDE.md #1).
-import type { StateSnapshot } from "../src/lib/types";
+import type { StateSnapshot, WorkspaceDetail } from "../src/lib/types";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 /** Draw a wire between two ports the way a pointer does. */
 async function dragWire(page: Page, from: Locator, to: Locator): Promise<void> {
@@ -189,37 +197,47 @@ test.describe("the workspace", () => {
     // something to preserve.
     await expect(node("scope").getByText(/waiting for the first frame/i)).toHaveCount(0);
 
-    // Hold the first pin's response after the server has accepted it. Its StateChanged refetch can
-    // then return the one-pin snapshot while the second optimistic pin is already on screen — the
-    // exact ordering that used to erase the second edit before its queued write began.
-    let heldFirstPin = false;
+    // Hold the one-pin refetch after the server has answered it. The second optimistic pin lands
+    // while that stale response is in flight, deterministically reproducing the ordering that used
+    // to erase the second edit before its queued write began.
+    const staleGet = deferred();
+    const releaseStaleGet = deferred();
+    const staleGetFulfilled = deferred();
+    let heldStaleGet = false;
     await page.route(/\/api\/workspaces\/\d+$/, async (route) => {
       const request = route.request();
-      const rackSlots =
-        request.method() === "PUT" ? request.postDataJSON()?.snapshot?.rack?.slots : null;
-      if (
-        !heldFirstPin &&
-        request.method() === "PUT" &&
-        Array.isArray(rackSlots) &&
-        rackSlots.length === 1 &&
-        rackSlots[0]?.node === "scope"
-      ) {
-        heldFirstPin = true;
-        const response = await route.fetch();
-        await new Promise((resolve) => setTimeout(resolve, 150));
+      if (heldStaleGet || request.method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const detail = (await response.json()) as WorkspaceDetail;
+      const rackNodes = detail.snapshot.rack?.slots?.map((slot) => slot.node) ?? [];
+      if (rackNodes.length !== 1 || rackNodes[0] !== "scope") {
         await route.fulfill({ response });
         return;
       }
-      await route.continue();
+      heldStaleGet = true;
+      staleGet.resolve();
+      await releaseStaleGet.promise;
+      await route.fulfill({ response });
+      staleGetFulfilled.resolve();
     });
 
     // Pinning adds the face to the rack and leaves the canvas node where it was (CANVAS §5).
-    for (const id of ["scope", "speaker"]) {
-      await node(id)
-        .getByRole("button", { name: /pin to the rack/i })
-        .click();
-      await expect(node(id).getByRole("button", { name: /unpin from the rack/i })).toBeVisible();
-    }
+    await node("scope")
+      .getByRole("button", { name: /pin to the rack/i })
+      .click();
+    await expect(node("scope").getByRole("button", { name: /unpin from the rack/i })).toBeVisible();
+    await staleGet.promise;
+    await node("speaker")
+      .getByRole("button", { name: /pin to the rack/i })
+      .click();
+    await expect(
+      node("speaker").getByRole("button", { name: /unpin from the rack/i }),
+    ).toBeVisible();
+    releaseStaleGet.resolve();
+    await staleGetFulfilled.promise;
     await expect
       .poll(async () => (await slots(page)).map((slot) => slot.node))
       .toEqual(["scope", "speaker"]);

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -89,6 +89,10 @@ async function dragBy(page: Page, grip: Locator, cells: number): Promise<void> {
 }
 
 test.describe("the workspace", () => {
+  // These legs deliberately share the throwaway server state built by the first one. If that
+  // setup fails, later assertions describe consequences rather than independent failures.
+  test.describe.configure({ mode: "serial" });
+
   test("binds a radio, adds a channel and pins a face", async ({ page }) => {
     // The tile CDN is cut off, not awaited: CI must not lean on a third party, and the offline
     // fallback the map leg below lands in is itself behaviour the map owes a field workspace.
@@ -185,6 +189,30 @@ test.describe("the workspace", () => {
     // something to preserve.
     await expect(node("scope").getByText(/waiting for the first frame/i)).toHaveCount(0);
 
+    // Hold the first pin's response after the server has accepted it. Its StateChanged refetch can
+    // then return the one-pin snapshot while the second optimistic pin is already on screen — the
+    // exact ordering that used to erase the second edit before its queued write began.
+    let heldFirstPin = false;
+    await page.route(/\/api\/workspaces\/\d+$/, async (route) => {
+      const request = route.request();
+      const rackSlots =
+        request.method() === "PUT" ? request.postDataJSON()?.snapshot?.rack?.slots : null;
+      if (
+        !heldFirstPin &&
+        request.method() === "PUT" &&
+        Array.isArray(rackSlots) &&
+        rackSlots.length === 1 &&
+        rackSlots[0]?.node === "scope"
+      ) {
+        heldFirstPin = true;
+        const response = await route.fetch();
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        await route.fulfill({ response });
+        return;
+      }
+      await route.continue();
+    });
+
     // Pinning adds the face to the rack and leaves the canvas node where it was (CANVAS §5).
     for (const id of ["scope", "speaker"]) {
       await node(id)
@@ -192,6 +220,9 @@ test.describe("the workspace", () => {
         .click();
       await expect(node(id).getByRole("button", { name: /unpin from the rack/i })).toBeVisible();
     }
+    await expect
+      .poll(async () => (await slots(page)).map((slot) => slot.node))
+      .toEqual(["scope", "speaker"]);
     await expect(node("scope").getByText(/pinned to the rack/i)).toHaveCount(0);
 
     const rack = page.getByRole("group", { name: "View" }).getByRole("button", { name: "Rack" });

--- a/web/src/canvas/useWorkspace.ts
+++ b/web/src/canvas/useWorkspace.ts
@@ -48,6 +48,16 @@ export function useWorkspace(): WorkspaceStore {
   const activeId = list.data?.active ?? null;
   const detail = useQuery(workspaceQuery(activeId));
 
+  // A refetch is allowed to replace the query cache while writes are queued (the server emits a
+  // workspace invalidation for every accepted write). Keep the composed local draft outside that
+  // cache until the last queued write settles, or a refetch containing only an earlier edit can
+  // erase a later one before it has been sent.
+  const pending = useRef<{ id: number; snapshot: WorkspaceSnapshot } | null>(null);
+  // The query cache can likewise receive an older in-flight response after a write. The queue
+  // advances revisions from each mutation response instead of trusting that cache between writes.
+  const revisions = useRef(new Map<number, number>());
+  const generation = useRef(0);
+
   const update = useMutation({
     mutationFn: (variables: { id: number; revision: number; snapshot: WorkspaceSnapshot }) =>
       updateWorkspace(variables.id, {
@@ -55,15 +65,23 @@ export function useWorkspace(): WorkspaceStore {
         snapshot: variables.snapshot,
       }),
     // The write's own answer carries the new revision, and the next queued write reads it from
-    // here: without folding it in, that write would still send the revision this one consumed
-    // and the server would refuse it as stale.
-    onSuccess: (info, variables) =>
+    // here. Preserve the latest local draft at the same time: the server's answer describes this
+    // write, which may not be the last edit already waiting behind it.
+    onSuccess: (info, variables) => {
+      revisions.current.set(variables.id, info.revision);
       queryClient.setQueryData<WorkspaceDetail>([...WORKSPACES_KEY, variables.id], (previous) =>
-        previous ? { ...previous, ...info } : previous,
-      ),
-    // A 409 means another client wrote first. The fix is always the same — take their patch —
-    // so refetching is the whole recovery, and the canvas re-applies what came back.
-    onSettled: () => queryClient.invalidateQueries({ queryKey: WORKSPACES_KEY }),
+        previous
+          ? {
+              ...previous,
+              ...info,
+              snapshot:
+                pending.current?.id === variables.id
+                  ? pending.current.snapshot
+                  : variables.snapshot,
+            }
+          : previous,
+      );
+    },
   });
   const activateMut = useMutation({
     mutationFn: activateWorkspace,
@@ -81,7 +99,13 @@ export function useWorkspace(): WorkspaceStore {
   const applyMut = useMutation({ mutationFn: applyWorkspace });
   const applyAsync = applyMut.mutateAsync;
 
-  const active = detail.data ?? null;
+  const queried = detail.data ?? null;
+  // Refetches still update the authoritative metadata and revision in the query. While a local
+  // draft is pending, its snapshot is what the operator is editing and therefore what we render.
+  const active =
+    queried !== null && pending.current?.id === queried.id
+      ? { ...queried, snapshot: pending.current.snapshot }
+      : queried;
   const activeIdRef = useRef<number | null>(null);
   activeIdRef.current = active?.id ?? null;
   // Writes are serialized: each one reads the revision the previous one produced. Issuing them
@@ -100,6 +124,16 @@ export function useWorkspace(): WorkspaceStore {
       if (current === undefined) {
         return;
       }
+      // Compose against the pending draft, not necessarily the query cache. A StateChanged
+      // refetch may have replaced the cache with the last snapshot the server accepted while a
+      // newer local edit is still queued.
+      const base = pending.current?.id === id ? pending.current.snapshot : current.snapshot;
+      const snapshot = fitRack(edit(base));
+      pending.current = { id, snapshot };
+      if (!revisions.current.has(id)) {
+        revisions.current.set(id, current.revision);
+      }
+      const write = ++generation.current;
       // Applied to the cache *synchronously*, in the same task as the gesture that ended: a
       // drag's own preview is dropped on pointer-up, and anything that renders the stored
       // arrangement between the two — one microtask, or one whole round trip when a previous
@@ -108,25 +142,32 @@ export function useWorkspace(): WorkspaceStore {
       // within one round trip composing: the second sees the first.
       queryClient.setQueryData<WorkspaceDetail>(key, {
         ...current,
-        // Every write leaves a rack the server will accept: it validates the whole snapshot, so
-        // one slot left over from an older grid would refuse every later write — including a
-        // node drag on the canvas that has nothing to do with the rack.
-        snapshot: fitRack(edit(current.snapshot)),
+        snapshot,
       });
-      // The write itself is still serialized, and still reads the revision the previous one
-      // produced — issuing them concurrently would send the same revision twice, and the server,
-      // correctly, refuses the second as stale.
+      // Capture this edit's composed snapshot now. Only the revision is read when its turn comes:
+      // the cache may legitimately refetch before then, but that must not change what this write
+      // means.
       queue.current = queue.current
         .catch(() => undefined)
-        .then(() => {
-          const latest = queryClient.getQueryData<WorkspaceDetail>(key);
-          return latest === undefined
-            ? undefined
-            : update.mutateAsync({
+        .then(async () => {
+          try {
+            const latest = queryClient.getQueryData<WorkspaceDetail>(key);
+            if (latest !== undefined) {
+              await update.mutateAsync({
                 id,
-                revision: latest.revision,
-                snapshot: latest.snapshot,
+                revision: revisions.current.get(id) ?? latest.revision,
+                snapshot,
               });
+            }
+          } finally {
+            // One authoritative refetch after the last queued write is enough. Earlier writes
+            // leave the draft in place for the edits behind them.
+            if (generation.current === write && pending.current?.id === id) {
+              pending.current = null;
+              revisions.current.delete(id);
+              await queryClient.invalidateQueries({ queryKey: WORKSPACES_KEY });
+            }
+          }
         })
         // The failure is already on screen through `update.error`; this only keeps the last one
         // in a chain from surfacing as an unhandled rejection.

--- a/web/src/canvas/useWorkspace.ts
+++ b/web/src/canvas/useWorkspace.ts
@@ -20,6 +20,7 @@ import type {
   WorkspaceSnapshot,
 } from "../lib/types";
 import { pruneRack } from "./graph";
+import { WorkspaceDrafts } from "./workspaceDrafts";
 
 export interface WorkspaceStore {
   workspaces: WorkspaceInfo[];
@@ -52,11 +53,9 @@ export function useWorkspace(): WorkspaceStore {
   // workspace invalidation for every accepted write). Keep the composed local draft outside that
   // cache until the last queued write settles, or a refetch containing only an earlier edit can
   // erase a later one before it has been sent.
-  const pending = useRef<{ id: number; snapshot: WorkspaceSnapshot } | null>(null);
-  // The query cache can likewise receive an older in-flight response after a write. The queue
-  // advances revisions from each mutation response instead of trusting that cache between writes.
-  const revisions = useRef(new Map<number, number>());
-  const generation = useRef(0);
+  // Keyed by workspace because a switch can put A, B and then A back into the same global write
+  // queue. Settling one workspace must neither discard another's draft nor retain A's old revision.
+  const drafts = useRef(new WorkspaceDrafts());
 
   const update = useMutation({
     mutationFn: (variables: { id: number; revision: number; snapshot: WorkspaceSnapshot }) =>
@@ -68,16 +67,13 @@ export function useWorkspace(): WorkspaceStore {
     // here. Preserve the latest local draft at the same time: the server's answer describes this
     // write, which may not be the last edit already waiting behind it.
     onSuccess: (info, variables) => {
-      revisions.current.set(variables.id, info.revision);
+      const snapshot = drafts.current.accepted(variables.id, info.revision) ?? variables.snapshot;
       queryClient.setQueryData<WorkspaceDetail>([...WORKSPACES_KEY, variables.id], (previous) =>
         previous
           ? {
               ...previous,
               ...info,
-              snapshot:
-                pending.current?.id === variables.id
-                  ? pending.current.snapshot
-                  : variables.snapshot,
+              snapshot,
             }
           : previous,
       );
@@ -102,10 +98,9 @@ export function useWorkspace(): WorkspaceStore {
   const queried = detail.data ?? null;
   // Refetches still update the authoritative metadata and revision in the query. While a local
   // draft is pending, its snapshot is what the operator is editing and therefore what we render.
+  const draft = queried === null ? undefined : drafts.current.get(queried.id);
   const active =
-    queried !== null && pending.current?.id === queried.id
-      ? { ...queried, snapshot: pending.current.snapshot }
-      : queried;
+    queried !== null && draft !== undefined ? { ...queried, snapshot: draft.snapshot } : queried;
   const activeIdRef = useRef<number | null>(null);
   activeIdRef.current = active?.id ?? null;
   // Writes are serialized: each one reads the revision the previous one produced. Issuing them
@@ -127,13 +122,9 @@ export function useWorkspace(): WorkspaceStore {
       // Compose against the pending draft, not necessarily the query cache. A StateChanged
       // refetch may have replaced the cache with the last snapshot the server accepted while a
       // newer local edit is still queued.
-      const base = pending.current?.id === id ? pending.current.snapshot : current.snapshot;
+      const base = drafts.current.get(id)?.snapshot ?? current.snapshot;
       const snapshot = fitRack(edit(base));
-      pending.current = { id, snapshot };
-      if (!revisions.current.has(id)) {
-        revisions.current.set(id, current.revision);
-      }
-      const write = ++generation.current;
+      const write = drafts.current.stage(id, snapshot, current.revision);
       // Applied to the cache *synchronously*, in the same task as the gesture that ended: a
       // drag's own preview is dropped on pointer-up, and anything that renders the stored
       // arrangement between the two — one microtask, or one whole round trip when a previous
@@ -155,16 +146,14 @@ export function useWorkspace(): WorkspaceStore {
             if (latest !== undefined) {
               await update.mutateAsync({
                 id,
-                revision: revisions.current.get(id) ?? latest.revision,
+                revision: drafts.current.get(id)?.revision ?? latest.revision,
                 snapshot,
               });
             }
           } finally {
-            // One authoritative refetch after the last queued write is enough. Earlier writes
-            // leave the draft in place for the edits behind them.
-            if (generation.current === write && pending.current?.id === id) {
-              pending.current = null;
-              revisions.current.delete(id);
+            // One authoritative refetch after this workspace's last queued write is enough.
+            // Earlier generations leave its newer draft in place; other workspaces are separate.
+            if (drafts.current.finish(id, write.generation)) {
               await queryClient.invalidateQueries({ queryKey: WORKSPACES_KEY });
             }
           }

--- a/web/src/canvas/useWorkspace.ts
+++ b/web/src/canvas/useWorkspace.ts
@@ -107,6 +107,23 @@ export function useWorkspace(): WorkspaceStore {
   // concurrently would send the same revision twice, and the server — correctly — refuses the
   // second as stale, which would silently drop whichever change lost the race.
   const queue = useRef<Promise<unknown>>(Promise.resolve());
+  const refreshOwed = useRef(false);
+  const finishQueue = useCallback(
+    (task: Promise<unknown>) => {
+      queue.current = task;
+      // Only the actual tail pays for the authoritative refetch. `apply` uses this same finalizer,
+      // so a save followed by its apply cannot strand the refresh merely because the apply is last.
+      void task
+        .then(() => {
+          if (queue.current === task && refreshOwed.current) {
+            refreshOwed.current = false;
+            return queryClient.invalidateQueries({ queryKey: WORKSPACES_KEY });
+          }
+        })
+        .catch(() => undefined);
+    },
+    [queryClient],
+  );
 
   const save = useCallback(
     (edit: (snapshot: WorkspaceSnapshot) => WorkspaceSnapshot) => {
@@ -138,7 +155,7 @@ export function useWorkspace(): WorkspaceStore {
       // Capture this edit's composed snapshot now. Only the revision is read when its turn comes:
       // the cache may legitimately refetch before then, but that must not change what this write
       // means.
-      queue.current = queue.current
+      const task = queue.current
         .catch(() => undefined)
         .then(async () => {
           try {
@@ -150,19 +167,20 @@ export function useWorkspace(): WorkspaceStore {
                 snapshot,
               });
             }
+          } catch {
+            // `update.error` owns the visible failure; the queue must still clean up and refetch.
           } finally {
-            // One authoritative refetch after this workspace's last queued write is enough.
-            // Earlier generations leave its newer draft in place; other workspaces are separate.
-            if (drafts.current.finish(id, write.generation)) {
-              await queryClient.invalidateQueries({ queryKey: WORKSPACES_KEY });
-            }
+            // Earlier generations leave this workspace's newer draft in place. The global queue
+            // tail below turns the last completed generation into one authoritative refetch.
+            const finished = drafts.current.finish(id, write.generation);
+            refreshOwed.current = refreshOwed.current || finished;
           }
         })
-        // The failure is already on screen through `update.error`; this only keeps the last one
-        // in a chain from surfacing as an unhandled rejection.
+        // Defensive for cache/draft errors outside the mutation itself.
         .catch(() => undefined);
+      finishQueue(task);
     },
-    [queryClient, update],
+    [finishQueue, queryClient, update],
   );
 
   // Apply goes through the same queue as a write, and that ordering is load-bearing: the gesture
@@ -174,11 +192,12 @@ export function useWorkspace(): WorkspaceStore {
     if (id === null) {
       return;
     }
-    queue.current = queue.current
+    const task = queue.current
       .catch(() => undefined)
       .then(() => applyAsync(id))
       .catch(() => undefined);
-  }, [applyAsync]);
+    finishQueue(task);
+  }, [applyAsync, finishQueue]);
 
   // Applying is idempotent, so it runs once per workspace that becomes active: opening the app on
   // a workspace whose radios are attached should give you the workspace, not an empty canvas waiting

--- a/web/src/canvas/workspaceDrafts.test.ts
+++ b/web/src/canvas/workspaceDrafts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceSnapshot } from "../lib/types";
+import { WorkspaceDrafts } from "./workspaceDrafts";
+
+function snapshot(label: string): WorkspaceSnapshot {
+  return {
+    version: 2,
+    graph: { nodes: [], edges: [] },
+    rack: {},
+    settings: { band_region: label },
+  };
+}
+
+describe("workspace drafts", () => {
+  it("finishes each workspace independently before a later save", () => {
+    const drafts = new WorkspaceDrafts();
+    const firstA = drafts.stage(1, snapshot("a1"), 1);
+    const firstB = drafts.stage(2, snapshot("b1"), 4);
+
+    drafts.accepted(1, 2);
+    expect(drafts.finish(1, firstA.generation)).toBe(true);
+    expect(drafts.get(2)).toEqual(firstB);
+
+    // A refetched after its queue drained. Its next save must start from that current revision,
+    // not from revision 2 retained merely because B was also pending.
+    const secondA = drafts.stage(1, snapshot("a2"), 9);
+    expect(secondA.revision).toBe(9);
+    expect(drafts.finish(2, firstB.generation)).toBe(true);
+    expect(drafts.get(1)).toEqual(secondA);
+  });
+
+  it("keeps a newer generation when an earlier write finishes", () => {
+    const drafts = new WorkspaceDrafts();
+    const first = drafts.stage(1, snapshot("a1"), 1);
+    drafts.accepted(1, 2);
+    const second = drafts.stage(1, snapshot("a2"), 2);
+
+    expect(drafts.finish(1, first.generation)).toBe(false);
+    expect(drafts.get(1)).toEqual(second);
+    expect(drafts.finish(1, second.generation)).toBe(true);
+  });
+});

--- a/web/src/canvas/workspaceDrafts.ts
+++ b/web/src/canvas/workspaceDrafts.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceSnapshot } from "../lib/types";
+
+export interface WorkspaceDraft {
+  snapshot: WorkspaceSnapshot;
+  revision: number;
+  generation: number;
+}
+
+/** Local workspace state that must outlive query-cache refetches while writes are queued. */
+export class WorkspaceDrafts {
+  readonly #drafts = new Map<number, WorkspaceDraft>();
+
+  get(id: number): WorkspaceDraft | undefined {
+    return this.#drafts.get(id);
+  }
+
+  stage(id: number, snapshot: WorkspaceSnapshot, revision: number): WorkspaceDraft {
+    const previous = this.#drafts.get(id);
+    const draft = {
+      snapshot,
+      revision: previous?.revision ?? revision,
+      generation: (previous?.generation ?? 0) + 1,
+    };
+    this.#drafts.set(id, draft);
+    return draft;
+  }
+
+  accepted(id: number, revision: number): WorkspaceSnapshot | undefined {
+    const draft = this.#drafts.get(id);
+    if (draft === undefined) {
+      return undefined;
+    }
+    this.#drafts.set(id, { ...draft, revision });
+    return draft.snapshot;
+  }
+
+  /** Drop only the last write for this workspace; a newer generation remains the local draft. */
+  finish(id: number, generation: number): boolean {
+    if (this.#drafts.get(id)?.generation !== generation) {
+      return false;
+    }
+    this.#drafts.delete(id);
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

- retain the composed workspace draft and mutation revision outside the refetchable query cache
- serialize captured snapshots and perform one authoritative refetch after the write queue drains
- force the former two-pin race in the smoke test and mark its state-sharing tests serial to avoid cascade failures

## Verification

- cargo xtask check
- cargo xtask smoke
- pnpm --dir web test
- pnpm --dir web lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace editing reliability when multiple changes are saved quickly.
  * Prevented refreshes from overwriting edits that are still being saved.
  * Ensured queued workspace updates are applied in the correct order.
  * Improved pinning behavior so overlapping pin actions preserve both selections.

* **Tests**
  * Added coverage for concurrent pin updates and sequential workspace state handling.
  * Added coverage for preserving newer workspace changes while earlier saves complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->