### PR TITLE
Add SDRplay support through SoapySDRPlay3

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,7 +9,8 @@
   capabilities, explicit multi-channel streams, generic module settings, reconnect supervision,
   and pinned private runtimes in desktop installers and containers
 - **[shipped]** Base packages include RTL-SDR, HackRF, Airspy/AirspyHF, bladeRF, LimeSDR,
-  PlutoSDR/libiio, and SoapyRemote modules; UHD and SDRplay are documented optional packs
+  PlutoSDR/libiio, and SoapyRemote modules; SDRplay RSP devices are supported through a
+  user-installed SDRplay API and SoapySDRPlay3 module, while UHD remains an optional pack
 - **[planned]** KiwiSDR client device
 - **[planned]** Remote source/sink between sdr-- instances; local routing between device sets
 - **[planned]** Audio-input device (`cpal`) — soundcard as a receiver

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ private SoapySDR 0.8.1 runtime, SoapyRTLSDR, SoapyHackRF, and the curated module
 [`packaging/soapy/environment.yml`](packaging/soapy/environment.yml); do not install SoapySDR
 separately for those artifacts. Portable `sdrmm` headless archives compile the same backend but
 use the host runtime: install SoapySDR 0.8.1 (module ABI 0.8) plus the matching module first;
-the release baseline is SoapyRTLSDR 0.3.3 and SoapyHackRF 0.3.4.
+the release baseline is SoapyRTLSDR 0.3.3 and SoapyHackRF 0.3.4. SDRplay RSP receivers are
+supported through SoapySDRPlay3 0.5.2 after installing SDRplay API 3.15 or newer; the proprietary
+API and its module are not bundled. See the [hardware guide](docs/src/hardware.md#sdrplay).
 
 To build from source you need the pinned nightly Rust toolchain (`rust-toolchain.toml` —
 `rustup` installs it on the first build), Node 26, pnpm 11, and SoapySDR 0.8 development files:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,5 +12,6 @@ Their package metadata and license texts are shipped under `soapy/licenses` in d
 - Airspy, AirspyHF, bladeRF, LimeSuite, libiio/PlutoSDR, and SoapyRemote: see the bundled package
   metadata and license files for the exact versions in each platform package.
 
-UHD and SDRplay are not part of the base package. Their modules may be installed as optional
-packs when their size and redistribution terms are acceptable.
+SoapySDRPlay3 is MIT licensed. It and SDRplay API are not part of the base package: SDRplay API
+is commercial software licensed for use with genuine SDRplay hardware, so operators install the
+vendor API and the SoapySDRPlay3 module themselves. UHD is likewise not part of the base package.

--- a/crates/device-soapy/src/lib.rs
+++ b/crates/device-soapy/src/lib.rs
@@ -79,8 +79,17 @@ fn map_err(error: soapysdr::Error) -> DeviceError {
 }
 
 fn args_key(args: &soapysdr::Args) -> String {
-    args.get("serial")
-        .map_or_else(|| args.to_string(), str::to_string)
+    args.get("serial").map_or_else(
+        || args.to_string(),
+        |serial| match args.get("mode") {
+            // SoapySDRPlay3 enumerates each RSPduo operating mode as a separate device with the
+            // same serial. The mode is part of the address upstream too (`serial@mode` in its
+            // claimed-device cache), so keep it in our probe key or every choice opens the first
+            // mode returned by the module.
+            Some(mode) => format!("{serial}@{mode}"),
+            None => serial.to_string(),
+        },
+    )
 }
 
 fn device_info(args: &soapysdr::Args) -> DeviceInfo {
@@ -111,9 +120,12 @@ struct ProbeIdentity {
 
 impl ProbeIdentity {
     fn from_args(args: &soapysdr::Args) -> Self {
-        let filter = match (args.get("driver"), args.get("serial")) {
-            (Some(driver), Some(serial)) => format!("driver={driver},serial={serial}"),
-            (Some(driver), None) => format!("driver={driver}"),
+        let filter = match (args.get("driver"), args.get("serial"), args.get("mode")) {
+            (Some(driver), Some(serial), Some(mode)) => {
+                format!("driver={driver},serial={serial},mode={mode}")
+            }
+            (Some(driver), Some(serial), None) => format!("driver={driver},serial={serial}"),
+            (Some(driver), None, _) => format!("driver={driver}"),
             _ => args.to_string(),
         };
         Self {
@@ -408,6 +420,34 @@ pub struct SoapyDevice {
     duplex: Arc<Mutex<DuplexState>>,
 }
 
+/// Most Soapy modules accept one stream containing every requested channel. SoapySDRPlay3 is
+/// deliberately different for the RSPduo: it exposes two channels but requires one stream handle
+/// per channel. Keep the combined path where it exists and fall back to split handles when the
+/// module refuses it.
+enum RxStreams {
+    Combined(soapysdr::RxStream<Sample>),
+    Split(Vec<soapysdr::RxStream<Sample>>),
+}
+
+impl RxStreams {
+    fn activate(&mut self) -> Result<(), soapysdr::Error> {
+        match self {
+            Self::Combined(stream) => stream.activate(None),
+            Self::Split(streams) => {
+                for index in 0..streams.len() {
+                    if let Err(error) = streams[index].activate(None) {
+                        for active in &mut streams[..index] {
+                            let _ = active.deactivate(None);
+                        }
+                        return Err(error);
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 impl SoapyDevice {
     fn from_device(device: soapysdr::Device, identity: ProbeIdentity) -> Result<Self, DeviceError> {
         let capabilities = query_capabilities(&device)?;
@@ -622,21 +662,42 @@ impl SdrDevice for SoapyDevice {
             )));
         }
         lock(&self.duplex).claim(WireDirection::Rx)?;
-        let mut stream = match self.device.rx_stream::<Sample>(&channels) {
-            Ok(stream) => stream,
+        let mut streams = match self.device.rx_stream::<Sample>(&channels) {
+            Ok(stream) => RxStreams::Combined(stream),
+            Err(combined) if channels.len() > 1 => {
+                match channels
+                    .iter()
+                    .map(|channel| self.device.rx_stream::<Sample>(&[*channel]))
+                    .collect::<Result<Vec<_>, _>>()
+                {
+                    Ok(streams) => RxStreams::Split(streams),
+                    Err(split) => {
+                        lock(&self.duplex).release(WireDirection::Rx);
+                        return Err(DeviceError::Io(format!(
+                            "soapy multi-channel stream setup failed: combined: {combined}; \
+                             split: {split}"
+                        )));
+                    }
+                }
+            }
             Err(error) => {
                 lock(&self.duplex).release(WireDirection::Rx);
                 return Err(map_err(error));
             }
         };
-        if let Err(error) = stream.activate(None) {
+        if let Err(error) = streams.activate() {
             lock(&self.duplex).release(WireDirection::Rx);
             return Err(map_err(error));
         }
         let identity = self.identity.clone();
         let duplex = self.duplex.clone();
         if let Err(error) = self.worker.start("sdrmm-soapy-rx", move |running| {
-            capture_loop(stream, &identity, running, sinks);
+            match streams {
+                RxStreams::Combined(stream) => capture_loop(stream, &identity, running, sinks),
+                RxStreams::Split(streams) => {
+                    capture_split_loop(streams, &identity, running, sinks);
+                }
+            }
             lock(&duplex).release(WireDirection::Rx);
         }) {
             lock(&self.duplex).release(WireDirection::Rx);
@@ -762,6 +823,89 @@ fn capture_loop(
     }
     if let Err(error) = stream.deactivate(None) {
         tracing::debug!("soapy stream deactivate failed: {error}");
+    }
+}
+
+fn capture_split_loop(
+    mut streams: Vec<soapysdr::RxStream<Sample>>,
+    identity: &ProbeIdentity,
+    running: &AtomicBool,
+    mut sinks: Vec<RxSink>,
+) {
+    let mut buffers: Vec<Vec<Sample>> = streams
+        .iter()
+        .map(|stream| vec![Sample::new(0.0, 0.0); stream.mtu().unwrap_or(MIN_BLOCK).max(MIN_BLOCK)])
+        .collect();
+    let mut timeouts = vec![0u32; streams.len()];
+    let mut probe_failures = 0u32;
+    let mut last_probe: Option<Instant> = None;
+    let mut overflows = vec![0u64; streams.len()];
+    'capture: while running.load(Ordering::Acquire) {
+        for channel in 0..streams.len() {
+            let result = streams[channel].read(&mut [&mut buffers[channel]], READ_TIMEOUT_US);
+            match result {
+                Ok(count) => {
+                    timeouts[channel] = 0;
+                    probe_failures = 0;
+                    if count > 0 {
+                        sinks[channel].push(&buffers[channel][..count]);
+                    }
+                }
+                Err(error) if error.code == ErrorCode::Timeout => {
+                    timeouts[channel] += 1;
+                    if timeouts[channel] < UNPLUG_TIMEOUT_READS
+                        || last_probe.is_some_and(|at| at.elapsed() < PROBE_MIN_INTERVAL)
+                    {
+                        continue;
+                    }
+                    last_probe = Some(Instant::now());
+                    match identity.is_present() {
+                        Ok(true) => {
+                            timeouts[channel] = 0;
+                            probe_failures = 0;
+                        }
+                        Ok(false) => {
+                            fail_all(&mut sinks, "device lost: no longer enumerates");
+                            break 'capture;
+                        }
+                        Err(probe) => {
+                            probe_failures += 1;
+                            if probe_failures >= UNPLUG_PROBE_FAILURES {
+                                fail_all(
+                                    &mut sinks,
+                                    &format!("device lost: enumerate failed: {probe}"),
+                                );
+                                break 'capture;
+                            }
+                        }
+                    }
+                }
+                Err(error) if error.code == ErrorCode::Overflow => {
+                    overflows[channel] += 1;
+                    if overflows[channel] == 1
+                        || overflows[channel].is_multiple_of(OVERFLOW_LOG_EVERY)
+                    {
+                        tracing::warn!(
+                            channel,
+                            overflows = overflows[channel],
+                            "soapy rx overflow"
+                        );
+                    }
+                }
+                Err(error) => {
+                    fail_all(
+                        &mut sinks,
+                        &format!("stream {channel} read failed: {error}"),
+                    );
+                    break 'capture;
+                }
+            }
+        }
+    }
+    for (channel, stream) in streams.iter_mut().enumerate() {
+        if let Err(error) = stream.deactivate(None) {
+            tracing::debug!(channel, "soapy stream deactivate failed: {error}");
+        }
     }
 }
 
@@ -985,6 +1129,22 @@ mod tests {
         assert_eq!(info.driver, "soapy");
         assert_eq!(info.key, "00000001");
         assert_eq!(info.label, "Generic RTL2832U");
+    }
+
+    #[test]
+    fn sdrplay_duo_modes_have_distinct_keys_and_probe_filters() {
+        let single = soapysdr::Args::from(
+            "driver=sdrplay, serial=123456, mode=ST, label=RSPduo Single Tuner",
+        );
+        let dual =
+            soapysdr::Args::from("driver=sdrplay, serial=123456, mode=DT, label=RSPduo Dual Tuner");
+
+        assert_eq!(device_info(&single).key, "123456@ST");
+        assert_eq!(device_info(&dual).key, "123456@DT");
+        assert_eq!(
+            ProbeIdentity::from_args(&dual).filter,
+            "driver=sdrplay,serial=123456,mode=DT"
+        );
     }
 
     #[test]

--- a/crates/device/src/registry.rs
+++ b/crates/device/src/registry.rs
@@ -1,6 +1,8 @@
 //! Driver registry (PLAN §6): probes every registered backend and merges results, collapsing
-//! duplicates by serial with native drivers winning over Soapy. At M0 only `device-virtual`
-//! registers, but the merge policy is here from the start.
+//! cross-backend duplicates by serial with native drivers winning over Soapy. One backend may
+//! intentionally expose several addresses for a serial (the RSPduo's Soapy operating modes), so
+//! those remain separate. At M0 only `device-virtual` registers, but the merge policy is here
+//! from the start.
 
 use std::collections::HashMap;
 
@@ -35,10 +37,11 @@ impl DeviceRegistry {
         self.drivers.iter().map(|(p, d)| (*p, d.id())).collect()
     }
 
-    /// Probe all drivers and merge, collapsing serial duplicates by priority (PLAN §6).
+    /// Probe all drivers and merge, collapsing cross-driver serial duplicates by priority while
+    /// retaining distinct keys a single driver exposes for one serial (PLAN §6).
     #[must_use]
     pub fn probe_all(&self) -> Vec<DeviceInfo> {
-        let mut by_serial: HashMap<String, (u8, DeviceInfo)> = HashMap::new();
+        let mut by_serial: HashMap<String, (u8, &'static str, Vec<DeviceInfo>)> = HashMap::new();
         let mut serialless: Vec<DeviceInfo> = Vec::new();
 
         for (priority, driver) in &self.drivers {
@@ -48,12 +51,21 @@ impl DeviceRegistry {
                         let entry = by_serial.entry(serial.clone());
                         match entry {
                             std::collections::hash_map::Entry::Occupied(mut e) => {
-                                if *priority > e.get().0 {
-                                    e.insert((*priority, info));
+                                let (winning_priority, winning_driver, variants) = e.get_mut();
+                                if *priority > *winning_priority {
+                                    *winning_priority = *priority;
+                                    *winning_driver = driver.id();
+                                    variants.clear();
+                                    variants.push(info);
+                                } else if *priority == *winning_priority
+                                    && driver.id() == *winning_driver
+                                    && !variants.iter().any(|known| known.key == info.key)
+                                {
+                                    variants.push(info);
                                 }
                             }
                             std::collections::hash_map::Entry::Vacant(e) => {
-                                e.insert((*priority, info));
+                                e.insert((*priority, driver.id(), vec![info]));
                             }
                         }
                     }
@@ -62,7 +74,10 @@ impl DeviceRegistry {
             }
         }
 
-        let mut out: Vec<DeviceInfo> = by_serial.into_values().map(|(_, info)| info).collect();
+        let mut out: Vec<DeviceInfo> = by_serial
+            .into_values()
+            .flat_map(|(_, _, variants)| variants)
+            .collect();
         out.extend(serialless);
         out.sort_by_key(DeviceInfo::id);
         out
@@ -240,6 +255,13 @@ mod tests {
         registry
     }
 
+    fn serial_info(driver: &str, key: &str, serial: &str) -> DeviceInfo {
+        DeviceInfo {
+            serial: Some(serial.to_string()),
+            ..info(driver, key)
+        }
+    }
+
     #[test]
     fn open_finds_a_probed_device() {
         let registry = registry([Fake::new("mock", &["one", "two"])]);
@@ -294,5 +316,56 @@ mod tests {
         let registry = registry([Fake::adopting("mock"), Fake::new("mock", &["real"])]);
         let (info, _) = registry.open("mock:real").expect("the probed one");
         assert_eq!(info.label, "mock real");
+    }
+
+    #[test]
+    fn one_driver_can_expose_multiple_addresses_for_a_serial() {
+        let variants = Fake {
+            id: "soapy",
+            probed: Mutex::new(vec![
+                serial_info("soapy", "123456@ST", "123456"),
+                serial_info("soapy", "123456@DT", "123456"),
+            ]),
+            adopts: false,
+        };
+        let registry = registry([variants]);
+
+        assert_eq!(
+            registry
+                .probe_all()
+                .iter()
+                .map(DeviceInfo::id)
+                .collect::<Vec<_>>(),
+            vec!["soapy:123456@DT", "soapy:123456@ST"]
+        );
+    }
+
+    #[test]
+    fn a_higher_priority_backend_still_wins_a_shared_serial() {
+        let soapy = Fake {
+            id: "soapy",
+            probed: Mutex::new(vec![
+                serial_info("soapy", "123456@ST", "123456"),
+                serial_info("soapy", "123456@DT", "123456"),
+            ]),
+            adopts: false,
+        };
+        let native = Fake {
+            id: "native",
+            probed: Mutex::new(vec![serial_info("native", "123456", "123456")]),
+            adopts: false,
+        };
+        let mut registry = DeviceRegistry::new();
+        registry.register(10, Box::new(soapy));
+        registry.register(20, Box::new(native));
+
+        assert_eq!(
+            registry
+                .probe_all()
+                .iter()
+                .map(DeviceInfo::id)
+                .collect::<Vec<_>>(),
+            vec!["native:123456"]
+        );
     }
 }

--- a/crates/wire/src/patch.rs
+++ b/crates/wire/src/patch.rs
@@ -304,18 +304,19 @@ pub enum NodeCategory {
 /// allocated per run and reused, so a stored engine id would silently bind a node to whichever
 /// radio opened first — the kind of failure that looks like a working panel.
 ///
-/// `key` is the tie-break CANVAS §3 does not name, added because a backend can have several
-/// devices and no serials: the virtual backend's key is `siggen` or the stem of a recording, both
-/// durable, and without it a patch could not say *which* capture it plays. It is consulted only
-/// when there is no serial, which is what keeps it away from the case it would be wrong for — an
-/// RTL-SDR clone whose key is a bus index.
+/// `key` is the tie-break CANVAS §3 does not name. It normally matters only when there is no
+/// serial: the virtual backend's key is `siggen` or the stem of a recording, both durable, and
+/// without it a patch could not say *which* capture it plays. It is also retained when a backend
+/// deliberately exposes several durable addresses for one serial, such as the RSPduo's SDRplay
+/// operating modes. Variant keys use the `serial@variant` form; every other key is omitted when
+/// there is a serial, which keeps a transient USB index from overriding it on ordinary radios.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct DeviceRef {
     /// Driver id, matching [`DeviceInfo::driver`]: `"rtlsdr"`, `"hackrf"`, `"soapy"`, `"virtual"`.
     pub backend: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub serial: Option<String>,
-    /// Per-driver key, used only when the driver exposes no serial.
+    /// Per-driver key, used without a serial or to distinguish variants sharing one serial.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 }
@@ -324,23 +325,30 @@ impl DeviceRef {
     /// The reference that names this discovered device.
     #[must_use]
     pub fn from_info(info: &DeviceInfo) -> Self {
+        let variant = info.serial.as_ref().is_some_and(|serial| {
+            info.key
+                .strip_prefix(serial)
+                .is_some_and(|suffix| suffix.starts_with('@'))
+        });
         Self {
             backend: info.driver.clone(),
             serial: info.serial.clone(),
-            key: info.serial.is_none().then(|| info.key.clone()),
+            key: (info.serial.is_none() || variant).then(|| info.key.clone()),
         }
     }
 
-    /// Whether `info` is the device this reference names. Serial wins when the driver exposes
-    /// one; otherwise the key does; a backend with a single serial-less device matches on the
-    /// backend alone, which is what makes `{backend, serial: none}` unambiguous for a singleton.
+    /// Whether `info` is the device this reference names. Serial identifies the physical radio;
+    /// an accompanying key narrows that to a variant. Without a serial the key identifies the
+    /// device; a backend with a single serial-less device can match on the backend alone.
     #[must_use]
     pub fn matches(&self, info: &DeviceInfo) -> bool {
         if self.backend != info.driver {
             return false;
         }
         match (&self.serial, &info.serial) {
-            (Some(want), Some(have)) => want == have,
+            (Some(want), Some(have)) => {
+                want == have && self.key.as_ref().is_none_or(|key| *key == info.key)
+            }
             (Some(_), None) => false,
             (None, _) => match &self.key {
                 Some(key) => *key == info.key,
@@ -1462,6 +1470,21 @@ mod tests {
         assert!(by_serial.matches(&DeviceInfo {
             key: "3".to_owned(),
             ..hardware.clone()
+        }));
+
+        let duo = DeviceInfo {
+            driver: "soapy".to_owned(),
+            key: "123456@DT".to_owned(),
+            label: "RSPduo Dual Tuner".to_owned(),
+            serial: Some("123456".to_owned()),
+            profile: None,
+        };
+        let by_variant = DeviceRef::from_info(&duo);
+        assert_eq!(by_variant.key.as_deref(), Some("123456@DT"));
+        assert!(by_variant.matches(&duo));
+        assert!(!by_variant.matches(&DeviceInfo {
+            key: "123456@ST".to_owned(),
+            ..duo
         }));
 
         let by_key = DeviceRef::from_info(&file);

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -52,7 +52,9 @@ so every gate that can fail in CI can be run locally first.
 and license/notices files. These portable headless archives compile the Soapy backend but do not
 copy a runtime: the target machine must provide SoapySDR 0.8.1 (module ABI 0.8) and its hardware
 module. Release baselines are SoapyRTLSDR 0.3.3 and SoapyHackRF 0.3.4; the other curated versions
-are declared in `packaging/soapy/environment.yml`. Release and Docker builds install the
+are declared in `packaging/soapy/environment.yml`. SDRplay uses the separately installed
+SoapySDRPlay3 0.5.2 module and SDRplay API 3.15 or newer described in the
+[hardware guide](hardware.md#sdrplay). Release and Docker builds install the
 matching immutable `packaging/soapy/conda-<platform>.lock`, which pins every transitive package
 URL and checksum. Confirm the installation with `sdrmm --doctor`;
 its report includes the compiled backend, core version, module search paths, and discovered

--- a/docs/src/hardware.md
+++ b/docs/src/hardware.md
@@ -10,9 +10,43 @@ writes, timeouts, status/underflow events, orderly deactivation, and half-duplex
 The desktop app and container carry SoapySDR 0.8.1 and these base modules: RTL-SDR, HackRF,
 Airspy, AirspyHF, bladeRF, LimeSDR, PlutoSDR/libiio, and SoapyRemote. Their transitive libraries
 and package license metadata are bundled too. UHD is kept out of the base package because of its
-size. SDRplay remains an optional pack because its runtime has separate redistribution terms.
-Install an optional module into the private `soapy/lib/SoapySDR/modules0.8` directory and keep
-its core ABI at 0.8; `sdrmm --doctor` shows exactly which module path and modules are in use.
+size. SDRplay is supported but not bundled because its runtime has separate redistribution terms.
+Install an optional module into the private `soapy/lib/SoapySDR/modules0.8` directory and keep its
+core ABI at 0.8; `sdrmm --doctor` shows exactly which module path and modules are in use.
+
+## SDRplay
+
+RSP1, RSP1A/B, RSP2, RSPduo, and RSPdx/R2 receivers work through
+[SoapySDRPlay3](https://github.com/pothosware/SoapySDRPlay3). The tested baseline is module 0.5.2,
+which requires SDRplay API 3.15 or newer. Install the API for your platform from
+[SDRplay](https://www.sdrplay.com/api/) first; its service, library, and hardware driver are
+commercial software restricted to genuine SDRplay hardware and are intentionally absent from
+sdr-- artifacts.
+
+For a source build or portable headless archive using the host's SoapySDR 0.8 runtime, build the
+matching module into that runtime:
+
+```sh
+git clone --branch soapy-sdrplay3-0.5.2 --depth 1 \
+  https://github.com/pothosware/SoapySDRPlay3.git
+cmake -S SoapySDRPlay3 -B SoapySDRPlay3/build -DCMAKE_BUILD_TYPE=Release
+cmake --build SoapySDRPlay3/build --parallel
+sudo cmake --install SoapySDRPlay3/build
+SoapySDRUtil --find="driver=sdrplay"
+```
+
+Desktop installers and the container use their private Soapy tree rather than the host module
+directory. To extend one, place the module built against its SoapySDR 0.8 ABI in
+`soapy/lib/SoapySDR/modules0.8` (the container path is
+`/opt/conda/lib/SoapySDR/modules0.8`) and make the vendor API library and service available in
+the same environment. This is necessarily a local extension: accepting and redistributing the
+SDRplay API license cannot be automated by the release pipeline.
+
+The RSPduo's Single Tuner, Dual Tuner, Master, 8 MHz Master, and Slave entries share a hardware
+serial but are distinct choices. sdr-- retains the module's mode in the device key, so opening or
+saving one mode does not silently select another. Dual Tuner mode exposes both receive streams;
+sdr-- uses the separate stream handle SoapySDRPlay3 requires for each tuner instead of assuming
+the module accepts one combined two-channel handle.
 
 ## RTL-SDR settings
 
@@ -34,6 +68,8 @@ SoapySDRUtil --find="driver=rtlsdr"
 SoapySDRUtil --probe="driver=rtlsdr"
 SoapySDRUtil --find="driver=hackrf"
 SoapySDRUtil --probe="driver=hackrf"
+SoapySDRUtil --find="driver=sdrplay"
+SoapySDRUtil --probe="driver=sdrplay"
 ```
 
 For RTL-SDR, stream for at least 30 minutes, unplug/replug once, and verify tuning, manual and
@@ -41,6 +77,9 @@ digital AGC, gain, bias tee (when advertised), I/Q swap orientation, and both di
 branches including an HF frequency. For HackRF, repeat sustained RX and reconnect checks, then
 transmit into a shielded attenuated load or legal bench loopback and verify TX frequency, gain
 stages, amplifier, bias power, bandwidth, partial-buffer progress, stop, and RX/TX arbitration.
+For SDRplay, repeat sustained RX and reconnect checks, verify AGC/manual gain, bandwidth,
+antenna selection and every model-specific setting the module advertises; on an RSPduo, open each
+offered mode and verify both streams independently in Dual Tuner mode.
 Record the radio revisions, module versions shown by `--doctor`, test duration, overflow or
 underflow counts, and result in the release checklist.
 

--- a/openapi.json
+++ b/openapi.json
@@ -4449,7 +4449,7 @@
       },
       "DeviceRef": {
         "type": "object",
-        "description": "A device named by durable identity (CANVAS §3), never by an engine or probe id: those are\nallocated per run and reused, so a stored engine id would silently bind a node to whichever\nradio opened first — the kind of failure that looks like a working panel.\n\n`key` is the tie-break CANVAS §3 does not name, added because a backend can have several\ndevices and no serials: the virtual backend's key is `siggen` or the stem of a recording, both\ndurable, and without it a patch could not say *which* capture it plays. It is consulted only\nwhen there is no serial, which is what keeps it away from the case it would be wrong for — an\nRTL-SDR clone whose key is a bus index.",
+        "description": "A device named by durable identity (CANVAS §3), never by an engine or probe id: those are\nallocated per run and reused, so a stored engine id would silently bind a node to whichever\nradio opened first — the kind of failure that looks like a working panel.\n\n`key` is the tie-break CANVAS §3 does not name. It normally matters only when there is no\nserial: the virtual backend's key is `siggen` or the stem of a recording, both durable, and\nwithout it a patch could not say *which* capture it plays. It is also retained when a backend\ndeliberately exposes several durable addresses for one serial, such as the RSPduo's SDRplay\noperating modes. Variant keys use the `serial@variant` form; every other key is omitted when\nthere is a serial, which keeps a transient USB index from overriding it on ordinary radios.",
         "required": [
           "backend"
         ],
@@ -4463,7 +4463,7 @@
               "string",
               "null"
             ],
-            "description": "Per-driver key, used only when the driver exposes no serial."
+            "description": "Per-driver key, used without a serial or to distinguish variants sharing one serial."
           },
           "serial": {
             "type": [

--- a/web/src/canvas/binding.test.ts
+++ b/web/src/canvas/binding.test.ts
@@ -56,6 +56,17 @@ describe("device references", () => {
     expect(refMatches(bySerial, info({ key: "3", serial: "00000001" }))).toBe(true);
     expect(refMatches(bySerial, info({ serial: "00000002" }))).toBe(false);
 
+    const duo = info({
+      driver: "soapy",
+      key: "123456@DT",
+      label: "RSPduo Dual Tuner",
+      serial: "123456",
+    });
+    const byVariant = deviceRefOf(duo);
+    expect(byVariant).toEqual({ backend: "soapy", serial: "123456", key: "123456@DT" });
+    expect(refMatches(byVariant, duo)).toBe(true);
+    expect(refMatches(byVariant, { ...duo, key: "123456@ST" })).toBe(false);
+
     const file = info({ driver: "virtual", key: "file:/rec/capture", serial: undefined });
     const byKey = deviceRefOf(file);
     expect(byKey).toEqual({ backend: "virtual", key: "file:/rec/capture" });

--- a/web/src/canvas/binding.ts
+++ b/web/src/canvas/binding.ts
@@ -20,12 +20,13 @@ import { portStream } from "./graph";
 export function deviceRefOf(info: DeviceInfo): DeviceRef {
   return {
     backend: info.driver,
-    ...(info.serial == null ? { key: info.key } : { serial: info.serial }),
+    ...(info.serial == null ? {} : { serial: info.serial }),
+    ...(info.serial == null || info.key.startsWith(`${info.serial}@`) ? { key: info.key } : {}),
   };
 }
 
-/** Whether `info` is the device this reference names (mirrors `DeviceRef::matches`): serial when
- * the driver exposes one, else the key, else a backend with a single serial-less device. */
+/** Whether `info` is the device this reference names (mirrors `DeviceRef::matches`): a serial
+ * plus an optional variant key, else the key, else a backend with one serial-less device. */
 /** The durable reference that names the device a `driver:key` handle addresses.
  *
  * Split on the *first* colon only, exactly as `DeviceRegistry::open` does: a playback device's
@@ -45,7 +46,9 @@ export function refMatches(reference: DeviceRef, info: DeviceInfo): boolean {
     return false;
   }
   if (reference.serial != null) {
-    return reference.serial === info.serial;
+    return (
+      reference.serial === info.serial && (reference.key == null || reference.key === info.key)
+    );
   }
   return reference.key == null || reference.key === info.key;
 }

--- a/web/src/canvas/nodes/DeviceFace.test.ts
+++ b/web/src/canvas/nodes/DeviceFace.test.ts
@@ -42,6 +42,9 @@ describe("refLabel", () => {
   it("names the radio by whichever identity the reference carries", () => {
     expect(refLabel({ backend: "rtlsdr", serial: "00000001" })).toBe("rtlsdr · 00000001");
     expect(refLabel({ backend: "virtual", key: "siggen" })).toBe("virtual · siggen");
+    expect(refLabel({ backend: "soapy", serial: "123456", key: "123456@DT" })).toBe(
+      "soapy · 123456@DT",
+    );
   });
 
   // A serial-less singleton is a legal reference (CANVAS §3), and it must still read as a radio

--- a/web/src/canvas/nodes/DeviceFace.tsx
+++ b/web/src/canvas/nodes/DeviceFace.tsx
@@ -77,10 +77,10 @@ export function tuneDelta(capabilities: Capabilities, stream: number, hz: number
     : { center_hz: hz };
 }
 
-/** The radio a reference names, in the terms the operator would use to go and find it. A ref
- * carries a serial or a key, never both (CANVAS §3). */
+/** The radio a reference names, in the terms the operator would use to go and find it. A variant
+ * key is shown when it narrows a serial to one operating mode. */
 export function refLabel(reference: DeviceRef): string {
-  const identity = reference.serial ?? reference.key;
+  const identity = reference.key ?? reference.serial;
   return identity == null ? reference.backend : `${reference.backend} · ${identity}`;
 }
 

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -1596,16 +1596,17 @@ export interface components {
          *     allocated per run and reused, so a stored engine id would silently bind a node to whichever
          *     radio opened first — the kind of failure that looks like a working panel.
          *
-         *     `key` is the tie-break CANVAS §3 does not name, added because a backend can have several
-         *     devices and no serials: the virtual backend's key is `siggen` or the stem of a recording, both
-         *     durable, and without it a patch could not say *which* capture it plays. It is consulted only
-         *     when there is no serial, which is what keeps it away from the case it would be wrong for — an
-         *     RTL-SDR clone whose key is a bus index.
+         *     `key` is the tie-break CANVAS §3 does not name. It normally matters only when there is no
+         *     serial: the virtual backend's key is `siggen` or the stem of a recording, both durable, and
+         *     without it a patch could not say *which* capture it plays. It is also retained when a backend
+         *     deliberately exposes several durable addresses for one serial, such as the RSPduo's SDRplay
+         *     operating modes. Variant keys use the `serial@variant` form; every other key is omitted when
+         *     there is a serial, which keeps a transient USB index from overriding it on ordinary radios.
          */
         DeviceRef: {
             /** @description Driver id, matching [`DeviceInfo::driver`]: `"rtlsdr"`, `"hackrf"`, `"soapy"`, `"virtual"`. */
             backend: string;
-            /** @description Per-driver key, used only when the driver exposes no serial. */
+            /** @description Per-driver key, used without a serial or to distinguish variants sharing one serial. */
             key?: string | null;
             serial?: string | null;
         };


### PR DESCRIPTION
## Summary

- support SDRplay RSP receivers through the existing Soapy backend and SoapySDRPlay3 0.5.2
- preserve distinct RSPduo operating-mode identities across discovery, opening, hotplug checks, and saved workspaces
- fall back to one RX stream handle per tuner for RSPduo Dual Tuner mode, matching SoapySDRPlay3's stream API
- document installation, validation, and the reason the proprietary SDRplay API is not bundled

## Validation

- `cargo xtask check`
- `cargo xtask test`
- `coderabbit review` — no findings

Hardware validation still requires genuine SDRplay hardware plus SDRplay API 3.15 or newer; neither is available in CI and the vendor API's license prevents bundling it in release artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDRplay RSP support, including RSPduo operating modes and split-channel streaming.
  * Device references and labels now distinguish variants that share a serial number.
* **Bug Fixes**
  * Improved SDRplay stream startup, recovery, timeout handling, overflow tracking, unplug detection, and cleanup.
  * Improved device discovery when multiple driver variants expose the same hardware.
* **Documentation**
  * Added setup, compatibility, licensing, validation, and troubleshooting guidance for SDRplay.
  * Clarified that SDRplay API and SoapySDRPlay3 must be installed separately; UHD is not included in the base package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->