### PR TITLE
Place new canvas nodes in the visible viewport

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,8 @@ The dial and the plot were built so this could hang off them without rework, and
   third-party component it distributes, with each license text readable in the app. The list is
   harvested from the workspace lockfiles by `cargo xtask licenses`, compiled into the binary, and
   gated against drift by `cargo xtask check`
+- **[shipped]** New canvas nodes land deterministically inside the current viewport and take the
+  nearest clear space when one is available
 - **[planned]** Node kinds whose backends do not exist yet: GPS source, UDP sink, WAV sink, and the `iq-tap`/`position` port types that go with them
 - **[planned]** A scope on a channel tap — a scope only takes a device today
 - **[planned]** Theme/skin system and a layout marketplace

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -65,9 +65,7 @@ async function slots(page: Page): Promise<{ node: string; x: number; w: number }
   return detail.snapshot.rack.slots;
 }
 
-/** Bring every node into view. New nodes drop to the right of everything already drawn, which
- * after a few adds is outside the framed viewport — and a wire cannot be dragged to a handle
- * the pointer cannot reach. */
+/** Bring every node into view before wiring faces from opposite sides of a large patch. */
 async function fitPatch(page: Page): Promise<void> {
   const pane = page.locator(".react-flow__pane");
   const box = await pane.boundingBox();
@@ -131,7 +129,38 @@ test.describe("the workspace", () => {
     // A channel is added as a node, and the server's apply creates the engine channel behind it.
     await page.getByRole("button", { name: "+ Node" }).click();
     await page.getByRole("button", { name: "NFM", exact: true }).click();
-    await expect(page.locator('.react-flow__node[data-id^="channel:"]')).toBeVisible();
+    const channel = page.locator('.react-flow__node[data-id^="channel:"]');
+    await expect(channel).toBeVisible();
+
+    // A palette add belongs to the camera the operator is looking through, not to the graph's
+    // rightmost coordinate. Its rendered face is wholly reachable and, while this starter patch
+    // has room, does not cover any face already there.
+    const canvasBounds = await page.locator(".react-flow").boundingBox();
+    const channelBounds = await channel.boundingBox();
+    if (canvasBounds === null || channelBounds === null) {
+      throw new Error("a visible canvas and newly added channel");
+    }
+    expect(channelBounds.x).toBeGreaterThanOrEqual(canvasBounds.x);
+    expect(channelBounds.y).toBeGreaterThanOrEqual(canvasBounds.y);
+    expect(channelBounds.x + channelBounds.width).toBeLessThanOrEqual(
+      canvasBounds.x + canvasBounds.width,
+    );
+    expect(channelBounds.y + channelBounds.height).toBeLessThanOrEqual(
+      canvasBounds.y + canvasBounds.height,
+    );
+    for (const id of ["device", "scope", "speaker"]) {
+      const existing = await node(id).boundingBox();
+      if (existing === null) {
+        throw new Error(`a visible ${id} node`);
+      }
+      const overlapWidth =
+        Math.min(channelBounds.x + channelBounds.width, existing.x + existing.width) -
+        Math.max(channelBounds.x, existing.x);
+      const overlapHeight =
+        Math.min(channelBounds.y + channelBounds.height, existing.y + existing.height) -
+        Math.max(channelBounds.y, existing.y);
+      expect(overlapWidth > 0 && overlapHeight > 0).toBe(false);
+    }
 
     // Wiring the receiver to it is what makes it a channel on that radio, and apply creates it.
     // The drag needs intermediate moves: React Flow starts a connection on pointer *movement*
@@ -155,7 +184,6 @@ test.describe("the workspace", () => {
     // Cycling the mode has to move the node and its engine channel together: the node names the
     // type (CANVAS §4), so a patch left naming the old one unbinds the face and the next apply
     // adds a second channel for it.
-    const channel = page.locator('.react-flow__node[data-id^="channel:"]');
     await channel.getByText("NFM", { exact: true }).first().click();
     await page.keyboard.press("m");
     await expect

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -309,24 +309,20 @@ export function App() {
               apply: workspace.apply,
             }}
           >
-            <WorkspaceBar
-              view={view}
-              onView={setView}
-              workspaces={workspace.workspaces}
-              activeWorkspace={workspace.active?.id ?? null}
-              onActivate={workspace.activate}
-              onCreate={workspace.create}
-              onRemove={workspace.remove}
-              onShowShortcuts={() => setShowShortcuts(true)}
-              onShowAbout={() => setShowAbout(true)}
-            />
-            {view === "patch" ? (
-              <ReactFlowProvider>
-                <Canvas />
-              </ReactFlowProvider>
-            ) : (
-              <Rack />
-            )}
+            <ReactFlowProvider>
+              <WorkspaceBar
+                view={view}
+                onView={setView}
+                workspaces={workspace.workspaces}
+                activeWorkspace={workspace.active?.id ?? null}
+                onActivate={workspace.activate}
+                onCreate={workspace.create}
+                onRemove={workspace.remove}
+                onShowShortcuts={() => setShowShortcuts(true)}
+                onShowAbout={() => setShowAbout(true)}
+              />
+              {view === "patch" ? <Canvas /> : <Rack />}
+            </ReactFlowProvider>
           </WorkspaceProvider>
         )}
 

--- a/web/src/canvas/Library.tsx
+++ b/web/src/canvas/Library.tsx
@@ -17,7 +17,8 @@ import { pushToast } from "../lib/toasts";
 import type { RecordingInfo } from "../lib/types";
 import { refFromDeviceId } from "./binding";
 import { useWorkspaceContext } from "./context";
-import { addNode, dropPosition, MAX_NAME_LEN, newNodeId } from "./graph";
+import { addNode, MAX_NAME_LEN, newNodeId } from "./graph";
+import { useNodePlacement } from "./placement";
 
 const TABS = [
   { id: "templates", label: "Templates" },
@@ -31,6 +32,7 @@ type Tab = (typeof TABS)[number]["id"];
 
 export function Library() {
   const workspace = useWorkspaceContext();
+  const placeNode = useNodePlacement();
   const [tab, setTab] = useState<Tab>("templates");
   // The radio a section that acts on *one* of them means: the selected device node, falling back
   // to the only one drawn. Applying a template to the wrong radio is not recoverable by undo, so
@@ -63,7 +65,7 @@ export function Library() {
         id,
         kind: "device",
         data: { device },
-        position: dropPosition(snapshot.graph),
+        position: placeNode(snapshot.graph, "device"),
         // Bounded like every other node label: the server validates the whole snapshot on every
         // write, so one over-long label would refuse the next node drag too.
         label: recording.file.slice(0, MAX_NAME_LEN),

--- a/web/src/canvas/WorkspaceBar.tsx
+++ b/web/src/canvas/WorkspaceBar.tsx
@@ -10,9 +10,10 @@ import { Popover } from "../components/Popover";
 import { ThemeControl } from "../components/ThemeControl";
 import type { NodeKind, PatchNode, WorkspaceInfo } from "../lib/types";
 import { useWorkspaceContext } from "./context";
-import { addNode, dropPosition, newNodeId } from "./graph";
+import { addNode, newNodeId } from "./graph";
 import { Library } from "./Library";
 import { NodePalette } from "./NodePalette";
+import { useNodePlacement } from "./placement";
 import { WorkspaceMenu } from "./WorkspaceMenu";
 
 export type View = "patch" | "rack";
@@ -44,6 +45,7 @@ export function WorkspaceBar({
   onShowAbout: () => void;
 }) {
   const workspace = useWorkspaceContext();
+  const placeNode = useNodePlacement();
   const active = workspaces.find((entry) => entry.id === activeWorkspace) ?? null;
   const pinned = workspace.rack.slots?.length ?? 0;
 
@@ -52,7 +54,7 @@ export function WorkspaceBar({
     workspace.edit((snapshot) => {
       const node = {
         id,
-        position: dropPosition(snapshot.graph),
+        position: placeNode(snapshot.graph, kind),
         ...(kind === "channel"
           ? { kind: "channel" as const, data: { channel_type: channelType ?? "nfm" } }
           : kind === "device"

--- a/web/src/canvas/graph.test.ts
+++ b/web/src/canvas/graph.test.ts
@@ -11,9 +11,7 @@ import type {
 } from "../lib/types";
 import {
   addEdge,
-  addNode,
   connectionRefusal,
-  dropPosition,
   edgeKey,
   edgeWarning,
   type GraphContext,
@@ -592,20 +590,5 @@ describe("the rack", () => {
     // rather than left to make every later write fail validation.
     const stale = { slots: [{ node: "nfm", x: 12, y: 12, w: 12, h: 8 }] };
     expect(pruneRack(stale, workspace()).slots).toEqual([{ node: "nfm", x: 0, y: 0, w: 6, h: 4 }]);
-  });
-});
-
-// One placement rule, shared by the palette and the recordings drawer: a drop lands clear of
-// everything already drawn, and a run of them staggers instead of stacking.
-describe("dropPosition", () => {
-  it("lands right of everything drawn and staggers down as the patch fills", () => {
-    const g = workspace();
-    const first = dropPosition(g);
-    const rightmost = g.nodes.reduce((max, drawn) => Math.max(max, drawn.position.x), 0);
-    expect(first.x).toBeGreaterThan(rightmost);
-    expect(dropPosition({ nodes: [], edges: [] })).toEqual({ x: 360, y: 0 });
-
-    const fuller = addNode(g, node("extra", { kind: "scope" }));
-    expect(dropPosition(fuller).y).toBeGreaterThan(first.y);
   });
 });

--- a/web/src/canvas/graph.ts
+++ b/web/src/canvas/graph.ts
@@ -20,7 +20,6 @@ import type {
   PatchNode,
   PortRef,
   PortSpec,
-  Position,
   RackLayout,
   WorkspaceSnapshot,
 } from "../lib/types";
@@ -370,20 +369,6 @@ export function nodeMinSize(kind: NodeKind, ports: readonly PortSpec[]): { w: nu
 }
 
 /** Add a node. The caller supplies the id so the same call can be replayed optimistically. */
-/** Vertical stagger between nodes dropped in one session, so a run of them does not stack. */
-const DROP_STEP = 40;
-
-/** Where a node dropped from a palette or a library panel lands: to the right of everything
- * already drawn, so it is on screen and on top of nothing. CANVAS §9 left auto-placement to
- * feel; this is the feel, and it lives here so every drop site shares it. */
-export function dropPosition(graph: PatchGraph): Position {
-  const drawn = graph.nodes;
-  return {
-    x: drawn.reduce((max, node) => Math.max(max, node.position.x), 0) + 360,
-    y: drawn.length * DROP_STEP,
-  };
-}
-
 export function addNode(graph: PatchGraph, node: PatchNode): PatchGraph {
   return { ...graph, nodes: [...graph.nodes, node] };
 }

--- a/web/src/canvas/placement.test.ts
+++ b/web/src/canvas/placement.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { dropPosition, type PlacementRect } from "./placement";
+
+const viewport = { x: 1_800, y: -600, w: 1_200, h: 800 };
+const size = { w: 300, h: 200 };
+
+function overlaps(position: { x: number; y: number }, occupied: PlacementRect): boolean {
+  return (
+    position.x < occupied.x + occupied.w &&
+    position.x + size.w > occupied.x &&
+    position.y < occupied.y + occupied.h &&
+    position.y + size.h > occupied.y
+  );
+}
+
+describe("dropPosition", () => {
+  it("centres the first node in the visible flow coordinates", () => {
+    expect(dropPosition(viewport, size, [], 20)).toEqual({ x: 2_250, y: -300 });
+  });
+
+  it("chooses the nearest clear visible position deterministically", () => {
+    const occupied = [
+      { x: 2_200, y: -350, w: 400, h: 300 },
+      { x: 1_820, y: -580, w: 300, h: 200 },
+    ];
+    const first = dropPosition(viewport, size, occupied, 20);
+    const second = dropPosition(viewport, size, occupied, 20);
+
+    expect(second).toEqual(first);
+    expect(first.x).toBeGreaterThanOrEqual(viewport.x);
+    expect(first.y).toBeGreaterThanOrEqual(viewport.y);
+    expect(first.x + size.w).toBeLessThanOrEqual(viewport.x + viewport.w);
+    expect(first.y + size.h).toBeLessThanOrEqual(viewport.y + viewport.h);
+    expect(occupied.every((rect) => !overlaps(first, rect))).toBe(true);
+  });
+
+  it("uses an edge of an existing node to find a narrow clear lane", () => {
+    const occupied = [
+      { x: 1_800, y: -600, w: 1_200, h: 250 },
+      { x: 1_800, y: -100, w: 1_200, h: 300 },
+    ];
+    const position = dropPosition(viewport, size, occupied, 20);
+
+    expect(position.y).toBe(-320);
+    expect(occupied.every((rect) => !overlaps(position, rect))).toBe(true);
+  });
+
+  it("keeps a node visible even when every candidate overlaps", () => {
+    const position = dropPosition(
+      viewport,
+      size,
+      [{ x: viewport.x, y: viewport.y, w: viewport.w, h: viewport.h }],
+      20,
+    );
+
+    expect(position.x).toBeGreaterThanOrEqual(viewport.x);
+    expect(position.y).toBeGreaterThanOrEqual(viewport.y);
+    expect(position.x + size.w).toBeLessThanOrEqual(viewport.x + viewport.w);
+    expect(position.y + size.h).toBeLessThanOrEqual(viewport.y + viewport.h);
+  });
+});

--- a/web/src/canvas/placement.ts
+++ b/web/src/canvas/placement.ts
@@ -1,0 +1,172 @@
+import { type Node, useReactFlow, useStoreApi } from "@xyflow/react";
+import { useCallback } from "react";
+import type { NodeKind, PatchGraph, Position } from "../lib/types";
+import { NODE_MIN_SIZE, NODE_SIZE } from "./graph";
+
+export interface PlacementRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const SCREEN_GAP = 24;
+
+/** Place new nodes against the camera the operator is looking through, using React Flow's last
+ * measured face sizes when they are available. The provider outlives the patch/rack switch, so
+ * the last patch viewport remains the target when a recording is opened from the rack. */
+export function useNodePlacement(): (graph: PatchGraph, kind: NodeKind) => Position {
+  const flow = useReactFlow();
+  const store = useStoreApi();
+
+  return useCallback(
+    (graph, kind) => {
+      const { width, height } = store.getState();
+      const { x, y, zoom } = flow.getViewport();
+      const gap = SCREEN_GAP / zoom;
+      const viewport = {
+        x: -x / zoom,
+        y: -y / zoom,
+        w: width / zoom,
+        h: height / zoom,
+      };
+      const rendered = new Map(flow.getNodes().map((node) => [node.id, node]));
+      const occupied = graph.nodes.map((node) => nodeRect(node, rendered.get(node.id)));
+      const peers = graph.nodes
+        .filter((node) => node.kind === kind && node.size == null)
+        .map((node) => measuredSize(rendered.get(node.id))?.h)
+        .filter((value): value is number => value !== undefined);
+      const natural = NODE_SIZE[kind];
+      const size = {
+        w: natural.w,
+        h: natural.h ?? Math.max(NODE_MIN_SIZE[kind].h, ...peers),
+      };
+
+      // Width is zero only before React Flow has mounted for the first time. The top bar cannot
+      // be clicked in that interval, but keeping a deterministic fallback makes the helper safe
+      // in tests and during a future server-rendered shell.
+      if (width <= 0 || height <= 0 || zoom <= 0) {
+        return dropPosition({ x: 0, y: 0, w: 1200, h: 800 }, size, occupied, SCREEN_GAP);
+      }
+      return dropPosition(viewport, size, occupied, gap);
+    },
+    [flow, store],
+  );
+}
+
+/** Find the clear visible position nearest the centre. When a crowded viewport has no clear
+ * footprint, keep the node visible and choose the candidate with the least overlap. */
+export function dropPosition(
+  viewport: PlacementRect,
+  size: { w: number; h: number },
+  occupied: readonly PlacementRect[],
+  gap = SCREEN_GAP,
+): Position {
+  const nearby = occupied.filter(
+    (rect) =>
+      rect.x < viewport.x + viewport.w + gap &&
+      rect.x + rect.w + gap > viewport.x &&
+      rect.y < viewport.y + viewport.h + gap &&
+      rect.y + rect.h + gap > viewport.y,
+  );
+  const xs = axisCandidates(viewport.x, viewport.w, size.w, nearby, "x", "w", gap);
+  const ys = axisCandidates(viewport.y, viewport.h, size.h, nearby, "y", "h", gap);
+  const centre = { x: viewport.x + viewport.w / 2, y: viewport.y + viewport.h / 2 };
+  const candidates = xs
+    .flatMap((x) => ys.map((y) => ({ x, y })))
+    .toSorted(
+      (a, b) => distance(a, size, centre) - distance(b, size, centre) || a.y - b.y || a.x - b.x,
+    );
+  const clear = candidates.find((candidate) =>
+    nearby.every((rect) => !intersects(candidate, size, rect, gap)),
+  );
+  if (clear !== undefined) {
+    return clear;
+  }
+  return (
+    candidates.toSorted(
+      (a, b) =>
+        overlap(a, size, nearby) - overlap(b, size, nearby) ||
+        distance(a, size, centre) - distance(b, size, centre) ||
+        a.y - b.y ||
+        a.x - b.x,
+    )[0] ?? { x: viewport.x, y: viewport.y }
+  );
+}
+
+function nodeRect(node: PatchGraph["nodes"][number], rendered: Node | undefined): PlacementRect {
+  const measured = measuredSize(rendered);
+  const natural = NODE_SIZE[node.kind];
+  const stored = node.size;
+  return {
+    x: rendered?.position.x ?? node.position.x,
+    y: rendered?.position.y ?? node.position.y,
+    w: measured?.w ?? stored?.w ?? natural.w,
+    h: measured?.h ?? stored?.h ?? natural.h ?? NODE_MIN_SIZE[node.kind].h,
+  };
+}
+
+function measuredSize(node: Node | undefined): { w: number; h: number } | undefined {
+  const w = node?.measured?.width ?? node?.width;
+  const h = node?.measured?.height ?? node?.height;
+  return w == null || h == null ? undefined : { w, h };
+}
+
+function axisCandidates(
+  start: number,
+  span: number,
+  size: number,
+  occupied: readonly PlacementRect[],
+  position: "x" | "y",
+  extent: "w" | "h",
+  gap: number,
+): number[] {
+  const inset = Math.min(gap, Math.max(0, (span - size) / 2));
+  const min = start + inset;
+  const end = start + span - size - inset;
+  const max = Math.max(min, end);
+  const clamp = (value: number) => Math.min(Math.max(value, min), max);
+  const values = [start + (span - size) / 2, min, max];
+  for (const rect of occupied) {
+    values.push(rect[position], rect[position] - size - gap, rect[position] + rect[extent] + gap);
+  }
+  return [...new Set(values.map(clamp))];
+}
+
+function intersects(
+  position: Position,
+  size: { w: number; h: number },
+  rect: PlacementRect,
+  gap: number,
+): boolean {
+  return (
+    position.x < rect.x + rect.w + gap &&
+    position.x + size.w + gap > rect.x &&
+    position.y < rect.y + rect.h + gap &&
+    position.y + size.h + gap > rect.y
+  );
+}
+
+function overlap(
+  position: Position,
+  size: { w: number; h: number },
+  occupied: readonly PlacementRect[],
+): number {
+  return occupied.reduce((area, rect) => {
+    const w = Math.max(
+      0,
+      Math.min(position.x + size.w, rect.x + rect.w) - Math.max(position.x, rect.x),
+    );
+    const h = Math.max(
+      0,
+      Math.min(position.y + size.h, rect.y + rect.h) - Math.max(position.y, rect.y),
+    );
+    return area + w * h;
+  }, 0);
+}
+
+function distance(position: Position, size: { w: number; h: number }, centre: Position): number {
+  const dx = position.x + size.w / 2 - centre.x;
+  const dy = position.y + size.h / 2 - centre.y;
+  return dx * dx + dy * dy;
+}


### PR DESCRIPTION
## Summary

- derive new-node placement from the live React Flow viewport instead of the graph's rightmost coordinate
- deterministically choose the nearest clear visible position using measured node sizes, with a least-overlap fallback for full views
- apply the same placement to palette nodes and recordings opened from the library, including across patch/rack switches
- cover panned viewports, collision avoidance, crowded views, and rendered browser geometry

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec playwright test --grep "binds a radio"`
