### PR TITLE
Add Hytera XPT support to the DMR trunk system

### DIFF
--- a/crates/channels/src/dv/dmr.rs
+++ b/crates/channels/src/dv/dmr.rs
@@ -727,6 +727,7 @@ impl Decoder {
                 frame.rest_channel = Some(bits_to_u32(lc, 52, 4) as u16);
             }
             (0x68, 0 | 3 | 9) => {
+                frame.trunk_protocol = Some(DvTrunkProtocol::HyteraXpt);
                 frame.opcode = Some(
                     if flco == 9 {
                         "Hytera XPT call alert"
@@ -920,6 +921,7 @@ fn decode_short_lc(bits: &[bool]) -> DvFrame {
         }
         8 => {
             frame.opcode = Some("Hytera XPT Short LC".to_owned());
+            frame.trunk_protocol = Some(DvTrunkProtocol::HyteraXpt);
             frame.vendor = Some(Vendor::Hytera);
             frame.manufacturer_id = Some(0x68);
             frame.channel = Some(bits_to_u32(bits, 12, 4) as u16);
@@ -1025,6 +1027,8 @@ fn set_dmr_vendor(frame: &mut DvFrame, fid: u8) {
 fn decode_vendor_csbk(frame: &mut DvFrame, fid: u8, opcode: u8, payload: &[bool]) {
     if fid == 0x10 && matches!(opcode, 0x3A | 0x3B | 0x3E) {
         frame.trunk_protocol = Some(DvTrunkProtocol::CapacityPlus);
+    } else if fid == 0x68 && matches!(opcode, 0x0A | 0x0B) {
+        frame.trunk_protocol = Some(DvTrunkProtocol::HyteraXpt);
     }
     match (fid, opcode) {
         (0x10, 0x3A | 0x3E) => {
@@ -1940,6 +1944,18 @@ mod tests {
         assert_eq!(csbk.opcode.as_deref(), Some("Hytera CSBK, unparsed"));
         assert_eq!(csbk.destination, None);
         assert_eq!(csbk.source, None);
+    }
+
+    #[test]
+    fn a_hytera_xpt_csbk_names_its_protocol() {
+        let iq = tx::csbk_with_fid(3, 0x68, 0x0A, 505, 2_621_001, INPUT_RATE_HZ);
+        let frames = decode(&mut channel(DmrSlots::Both), &iq);
+        let csbk = frames
+            .iter()
+            .find(|frame| frame.kind == DvFrameKind::Control)
+            .expect("Hytera XPT CSBK");
+        assert_eq!(csbk.trunk_protocol, Some(DvTrunkProtocol::HyteraXpt));
+        assert_eq!(csbk.crc_verified, Some(true));
     }
 
     #[test]

--- a/crates/engine/src/trunking.rs
+++ b/crates/engine/src/trunking.rs
@@ -55,8 +55,7 @@ struct Carrier {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum FollowerKey {
-    /// Capacity Plus grants no frequency: every carrier is itself a traffic channel.
-    CapacityPlus {
+    KnownCarrier {
         system_node: String,
         device_set: u32,
         carrier: u32,
@@ -72,7 +71,7 @@ enum FollowerKey {
 impl FollowerKey {
     fn system_node(&self) -> &str {
         match self {
-            Self::CapacityPlus { system_node, .. } | Self::TierThree { system_node, .. } => {
+            Self::KnownCarrier { system_node, .. } | Self::TierThree { system_node, .. } => {
                 system_node
             }
         }
@@ -80,13 +79,13 @@ impl FollowerKey {
 
     fn slot(&self) -> u8 {
         match self {
-            Self::CapacityPlus { slot, .. } | Self::TierThree { slot, .. } => *slot,
+            Self::KnownCarrier { slot, .. } | Self::TierThree { slot, .. } => *slot,
         }
     }
 
     fn logical_channel(&self) -> Option<u16> {
         match self {
-            Self::CapacityPlus { .. } => None,
+            Self::KnownCarrier { .. } => None,
             Self::TierThree {
                 logical_channel, ..
             } => Some(*logical_channel),
@@ -220,6 +219,7 @@ impl Follower {
     ) -> Option<DvTrunkProtocol> {
         match configured {
             DmrTrunkProtocol::CapacityPlus => Some(DvTrunkProtocol::CapacityPlus),
+            DmrTrunkProtocol::HyteraXpt => Some(DvTrunkProtocol::HyteraXpt),
             DmrTrunkProtocol::TierThree => Some(DvTrunkProtocol::TierThree),
             DmrTrunkProtocol::Auto => self.detected.get(system_node).copied(),
         }
@@ -250,8 +250,9 @@ impl Follower {
             }
             match self.protocol_of(&carrier.system_node, carrier.protocol) {
                 Some(DvTrunkProtocol::CapacityPlus) => {
-                    self.provision_capacity_plus(&engine, carrier)
+                    self.provision_known_carrier(&engine, carrier)
                 }
+                Some(DvTrunkProtocol::HyteraXpt) => self.provision_known_carrier(&engine, carrier),
                 Some(DvTrunkProtocol::TierThree) => {
                     self.observe_tier_three(&engine, carrier, frame)
                 }
@@ -302,14 +303,12 @@ impl Follower {
         );
     }
 
-    /// Capacity Plus carriers are themselves traffic channels, so both slots of every carrier
-    /// get a follower without any grant.
-    fn provision_capacity_plus(&mut self, engine: &Engine, carrier: &Carrier) {
+    fn provision_known_carrier(&mut self, engine: &Engine, carrier: &Carrier) {
         for slot in [1, 2] {
             self.ensure_follower(
                 engine,
                 carrier,
-                FollowerKey::CapacityPlus {
+                FollowerKey::KnownCarrier {
                     system_node: carrier.system_node.clone(),
                     device_set: carrier.device_set,
                     carrier: carrier.channel,
@@ -496,10 +495,11 @@ impl Follower {
         self.problems
             .retain(|key, _| nodes.contains(&key.system_node()));
         for carrier in &live {
-            if self.protocol_of(&carrier.system_node, carrier.protocol)
-                == Some(DvTrunkProtocol::CapacityPlus)
-            {
-                self.provision_capacity_plus(&engine, carrier);
+            if matches!(
+                self.protocol_of(&carrier.system_node, carrier.protocol),
+                Some(DvTrunkProtocol::CapacityPlus | DvTrunkProtocol::HyteraXpt)
+            ) {
+                self.provision_known_carrier(&engine, carrier);
             }
         }
         self.publish();
@@ -507,7 +507,7 @@ impl Follower {
 
     fn system_holds(&self, live: &[Carrier], key: &FollowerKey) -> bool {
         match key {
-            FollowerKey::CapacityPlus {
+            FollowerKey::KnownCarrier {
                 system_node,
                 device_set,
                 carrier,
@@ -516,8 +516,10 @@ impl Follower {
                 source.system_node == *system_node
                     && source.device_set == *device_set
                     && source.channel == *carrier
-                    && self.protocol_of(system_node, source.protocol)
-                        == Some(DvTrunkProtocol::CapacityPlus)
+                    && matches!(
+                        self.protocol_of(system_node, source.protocol),
+                        Some(DvTrunkProtocol::CapacityPlus | DvTrunkProtocol::HyteraXpt)
+                    )
             }),
             FollowerKey::TierThree { system_node, .. } => live.iter().any(|source| {
                 source.system_node == *system_node
@@ -775,6 +777,53 @@ mod tests {
         assert_eq!(set.channels.len(), 3, "both slots were not provisioned");
         let status = status(&follower);
         assert_eq!(status.detected, Some(DvTrunkProtocol::CapacityPlus));
+        assert_eq!(status.followers.len(), 2);
+        assert_eq!(status.followers[0].slot, 1);
+        assert_eq!(status.followers[1].slot, 2);
+    }
+
+    #[test]
+    fn auto_follows_hytera_xpt_once_its_signalling_identifies_it() {
+        let engine = engine();
+        let (device_set, channel, _) = control_channel(&engine);
+        let carrier = (device_set, channel);
+        let mut follower = follower(&engine, DmrTrunkProtocol::Auto, carrier);
+        assert!(
+            follower.followers.is_empty(),
+            "auto followed before it knew"
+        );
+
+        follower.observe(&record(
+            carrier,
+            DvFrame {
+                trunk_protocol: Some(DvTrunkProtocol::HyteraXpt),
+                crc_verified: Some(true),
+                ..DvFrame::new(DvMode::Dmr, DvFrameKind::Control)
+            },
+        ));
+
+        let set = engine.snapshot().device_sets.remove(0);
+        assert_eq!(set.channels.len(), 3, "both slots were not provisioned");
+        assert!(set.channels.iter().any(|channel| {
+            matches!(
+                channel.settings.params,
+                ChannelParams::Dmr(DmrParams {
+                    slots: DmrSlots::One,
+                    ..
+                })
+            )
+        }));
+        assert!(set.channels.iter().any(|channel| {
+            matches!(
+                channel.settings.params,
+                ChannelParams::Dmr(DmrParams {
+                    slots: DmrSlots::Two,
+                    ..
+                })
+            )
+        }));
+        let status = status(&follower);
+        assert_eq!(status.detected, Some(DvTrunkProtocol::HyteraXpt));
         assert_eq!(status.followers.len(), 2);
         assert_eq!(status.followers[0].slot, 1);
         assert_eq!(status.followers[1].slot, 2);

--- a/crates/wire/src/decode.rs
+++ b/crates/wire/src/decode.rs
@@ -446,6 +446,7 @@ pub struct DvChannelDefinition {
 #[serde(rename_all = "snake_case")]
 pub enum DvTrunkProtocol {
     CapacityPlus,
+    HyteraXpt,
     TierThree,
 }
 

--- a/crates/wire/src/patch.rs
+++ b/crates/wire/src/patch.rs
@@ -341,6 +341,7 @@ pub enum DmrTrunkProtocol {
     #[default]
     Auto,
     CapacityPlus,
+    HyteraXpt,
     TierThree,
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -5010,6 +5010,7 @@
         "enum": [
           "auto",
           "capacity_plus",
+          "hytera_xpt",
           "tier_three"
         ]
       },
@@ -5449,6 +5450,7 @@
         "description": "What the signalling turned out to be. An observation, so it has no \"auto\" —\n[`crate::DmrTrunkProtocol`] is what an operator asks the node for.",
         "enum": [
           "capacity_plus",
+          "hytera_xpt",
           "tier_three"
         ]
       },

--- a/web/src/canvas/nodes/DmrTrunkFace.test.ts
+++ b/web/src/canvas/nodes/DmrTrunkFace.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { DMR_TRUNK_PROTOCOLS, dmrTrunkGuidance } from "./DmrTrunkFace";
+
+describe("DMR trunk protocols", () => {
+  it("offers Hytera XPT alongside the Motorola and Tier III systems", () => {
+    expect(DMR_TRUNK_PROTOCOLS).toEqual([
+      { value: "auto", label: "Auto-detect" },
+      { value: "capacity_plus", label: "Capacity Plus" },
+      { value: "hytera_xpt", label: "Hytera XPT" },
+      { value: "tier_three", label: "Tier III / Capacity Max" },
+    ]);
+  });
+
+  it("explains that every XPT repeater output must be connected", () => {
+    expect(dmrTrunkGuidance("hytera_xpt")).toContain("every Hytera XPT repeater output frequency");
+    expect(dmrTrunkGuidance("auto")).toContain("Hytera XPT");
+    expect(dmrTrunkGuidance("auto", "hytera_xpt")).toContain("Detected Hytera XPT signalling");
+  });
+});

--- a/web/src/canvas/nodes/DmrTrunkFace.tsx
+++ b/web/src/canvas/nodes/DmrTrunkFace.tsx
@@ -8,9 +8,10 @@ import { patchNode } from "../graph";
 import { FaceBody, FaceEmpty, NodeShell } from "./NodeShell";
 import { CallRow } from "./SinkFaces";
 
-const PROTOCOLS: readonly { value: DmrTrunkProtocol; label: string }[] = [
+export const DMR_TRUNK_PROTOCOLS: readonly { value: DmrTrunkProtocol; label: string }[] = [
   { value: "auto", label: "Auto-detect" },
   { value: "capacity_plus", label: "Capacity Plus" },
+  { value: "hytera_xpt", label: "Hytera XPT" },
   { value: "tier_three", label: "Tier III / Capacity Max" },
 ];
 
@@ -63,7 +64,7 @@ export function DmrTrunkFace({ node }: { node: PatchNode }) {
               label="Protocol"
               className="w-48"
               value={protocol}
-              options={PROTOCOLS}
+              options={DMR_TRUNK_PROTOCOLS}
               onChange={(next) => edit({ protocol: next })}
             />
           </label>
@@ -83,8 +84,8 @@ export function DmrTrunkFace({ node }: { node: PatchNode }) {
         ) : (
           <>
             <p className="border-b border-line p-2 text-xs text-ink-dim">
-              {guidance(protocol, status?.detected ?? null)} Runs on the server while this page is
-              closed.
+              {dmrTrunkGuidance(protocol, status?.detected ?? null)} Runs on the server while this
+              page is closed.
             </p>
             {status !== undefined && status.followers.length > 0 && (
               <ul className="flex flex-wrap gap-1 border-b border-line p-2">
@@ -122,18 +123,28 @@ export function DmrTrunkFace({ node }: { node: PatchNode }) {
   );
 }
 
-function guidance(protocol: DmrTrunkProtocol, detected: DvTrunkProtocol | null): string {
+export function dmrTrunkGuidance(
+  protocol: DmrTrunkProtocol,
+  detected: DvTrunkProtocol | null = null,
+): string {
   if (protocol === "auto" && detected !== null) {
-    return detected === "capacity_plus"
-      ? "Detected Capacity Plus signalling; both timeslots of every wired carrier are being followed."
-      : "Detected Tier III signalling; voice grants create traffic receivers automatically.";
+    switch (detected) {
+      case "capacity_plus":
+        return "Detected Capacity Plus signalling; both timeslots of every wired carrier are being followed.";
+      case "hytera_xpt":
+        return "Detected Hytera XPT signalling; both timeslots of every wired carrier are being followed.";
+      case "tier_three":
+        return "Detected Tier III signalling; voice grants create traffic receivers automatically.";
+    }
   }
   switch (protocol) {
     case "capacity_plus":
       return "Add one DMR decoder for every known repeater output frequency. Both timeslots are isolated automatically.";
+    case "hytera_xpt":
+      return "Add one DMR decoder for every Hytera XPT repeater output frequency. Both timeslots are isolated automatically.";
     case "tier_three":
       return "Add the DMR control-channel decoder. Standard channel definitions and voice grants create traffic receivers automatically.";
     case "auto":
-      return "The system detects Capacity Plus or Tier III signalling from the connected DMR carriers.";
+      return "The system detects Capacity Plus, Hytera XPT, or Tier III signalling from the connected DMR carriers.";
   }
 }

--- a/web/src/generated/schema.d.ts
+++ b/web/src/generated/schema.d.ts
@@ -1761,7 +1761,7 @@ export interface components {
             retention_seconds?: number;
         };
         /** @enum {string} */
-        DmrTrunkProtocol: "auto" | "capacity_plus" | "tier_three";
+        DmrTrunkProtocol: "auto" | "capacity_plus" | "hytera_xpt" | "tier_three";
         /** @description One diagnostic line. */
         DoctorCheck: {
             /** @description What was actually found. */
@@ -1931,7 +1931,7 @@ export interface components {
          *     [`crate::DmrTrunkProtocol`] is what an operator asks the node for.
          * @enum {string}
          */
-        DvTrunkProtocol: "capacity_plus" | "tier_three";
+        DvTrunkProtocol: "capacity_plus" | "hytera_xpt" | "tier_three";
         EventAudio: {
             media_type: string;
             url: string;


### PR DESCRIPTION
## Summary

- add Hytera XPT as a DMR trunk-system protocol in the wire model and node selector
- provision isolated timeslot followers across every configured XPT repeater output
- auto-detect decoded Hytera XPT site signalling and activate the same follower path
- regenerate the OpenAPI and TypeScript wire schemas
- cover XPT provisioning, auto-detection, protocol options, and operator guidance

## Design

Hytera documents XPT as a system without a dedicated control channel where all available repeater channels are used for communications: https://www.hytera.com/eu/system.page/products_system_dmr-system_xpt

That maps to the existing known-carrier slot-pool strategy used by Capacity Plus. Tier III / Capacity Max stays grant-driven. The shared follower key also preserves followers when switching between explicitly configured known-carrier protocols while removing them when switching to Tier III.

## Verification

- `cargo test -p sdrmm-server trunking::tests`
- `pnpm --dir web test src/canvas/nodes/DmrTrunkFace.test.ts`
- `cargo xtask check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Hytera XPT trunking.
  - Hytera XPT protocols are now available in configuration and API options.
  - Added automatic detection and provisioning for Hytera XPT systems, including both slots.
  - Added protocol-specific setup guidance and improved auto-detection messaging.
  - Hytera XPT traffic is now correctly identified and validated.

- **Tests**
  - Added coverage for Hytera XPT protocol options, guidance, detection, and provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->