### PR TITLE
Point the Nix package at the web dependencies the lockfile now names

### DIFF
--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit pnpm;
     sourceRoot = "${finalAttrs.src.name}/web";
     fetcherVersion = 4;
-    hash = "sha256-mVLsNgc71tUhDzfxrfAVBvqRiAZ4dSYEmhINfg2V/AM=";
+    hash = "sha256-ec4kCf7nxWNQ7rY1BzaEXSmZPEgrLhnCFzysGdlMIoc=";
   };
   pnpmRoot = "web";
 


### PR DESCRIPTION
## What changes

The `Nix desktop package` jobs build again. `web/pnpm-lock.yaml` gained the Babel and Rolldown plugin entries in 305ada9 without the matching `pnpmDeps` hash, so every run since has stopped at the fixed-output derivation:

```
error: hash mismatch in fixed-output derivation 'sdrmm-desktop-pnpm-deps.drv':
         specified: sha256-mVLsNgc71tUhDzfxrfAVBvqRiAZ4dSYEmhINfg2V/AM=
            got:    sha256-ec4kCf7nxWNQ7rY1BzaEXSmZPEgrLhnCFzysGdlMIoc=
```

## Why this layer

The hash pins the offline pnpm store to one lockfile; a lockfile change is meant to move it. Nothing else in the fetcher block is touched, because the new hash is only valid for the current `fetcherVersion`, the pinned pnpm 11.15.1, and the pinned nixpkgs.

## How it was verified

- Both arches reported the same `got` hash independently, and `web/pnpm-lock.yaml` is unchanged since the run that observed it.
- `cargo check -p sdrmm-desktop --no-default-features --features soapy,net-client` is clean. That is the feature set `buildRustPackage` compiles, and it had not been exercised since the job went red eight commits ago.
- The remaining steps — the Nix cargo build and the `xvfb` smoke test — run for the first time in this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency metadata to ensure reliable Nix-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->